### PR TITLE
Api комментариев и сообщений

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ curl -X POST "https://tg-mcp.redevest.ru/mtproto-api/messages.SendMessage" \
 | Tool | Purpose | Key Features |
 |------|---------|--------------|
 | `search_messages_globally` | Search across all chats | Multi-term queries, date filtering, chat type filtering |
-| `search_messages_in_chat` | Search within specific chat | Supports "me" for Saved Messages, optional query for latest messages |
+| `get_messages` | Unified message retrieval | Search/browse chat, read by IDs, post comments, 5 modes in one tool |
 | `send_message` | Send new message | File attachments (URLs/local), formatting (markdown/html), unified `reply_to` (message or forum topic root id) |
 | `edit_message` | Edit existing message | Text formatting, preserves message structure |
-| `read_messages` | Read specific messages by ID | Batch reading, full message content, voice transcription for Premium accounts |
 | `find_chats` | Find users/groups/channels | Multi-term search, contact discovery, username/phone lookup |
 | `get_chat_info` | Get detailed profile info | Member counts, bio/about, online status, forum topics, enriched data |
 | `send_message_to_phone` | Message phone numbers | Auto-contact management, optional cleanup, file support |

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ curl -X POST "https://tg-mcp.redevest.ru/mtproto-api/messages.SendMessage" \
 |---------|-------------|
 | 🔐 **Multi-User Authentication** | Production-ready Bearer token auth with session isolation and LRU cache management |
 | 🌐 **HTTP-MTProto Bridge** | Direct curl access to any Telegram API method with entity resolution and safety guardrails |
-| 🔍 **Unified Message API** | Single `get_messages` tool for search, browse, read by IDs, and post comments - 5 modes in one |
-| 💬 **Post Comments Support** | Access channel post discussion threads with full search and metadata |
+| 🔍 **Unified Message API** | Single `get_messages` tool for search, browse, read by IDs, and replies - 5 modes in one |
+| 💬 **Universal Replies** | Get replies from channel posts, forum topics, or any message with one parameter |
 | 🔎 **Intelligent Search** | Global & per-chat message search with multi-query support and intelligent deduplication |
 | 🏗️ **Dual Transport** | Seamless development (stdio) and production (HTTP) deployment support |
 | 📁 **Secure File Handling** | Rich media sharing with SSRF protection, size limits, and album support |
@@ -55,7 +55,7 @@ curl -X POST "https://tg-mcp.redevest.ru/mtproto-api/messages.SendMessage" \
 | Tool | Purpose | Key Features |
 |------|---------|--------------|
 | `search_messages_globally` | Search across all chats | Multi-term queries, date filtering, chat type filtering |
-| `get_messages` | Unified message retrieval | Search/browse chat, read by IDs, post comments, 5 modes in one tool |
+| `get_messages` | Unified message retrieval | Search/browse, read by IDs, get replies (posts/topics/messages), 5 modes |
 | `send_message` | Send new message | File attachments (URLs/local), formatting (markdown/html), unified `reply_to` (message or forum topic root id) |
 | `edit_message` | Edit existing message | Text formatting, preserves message structure |
 | `find_chats` | Find users/groups/channels | Multi-term search, contact discovery, username/phone lookup |
@@ -125,8 +125,8 @@ fast-mcp-telegram-setup --api-id="your_api_id" --api-hash="your_api_hash" --phon
 // Read specific messages by ID
 {"tool": "get_messages", "params": {"chat_id": "me", "message_ids": [123, 124]}}
 
-// Get channel post comments (discussion thread)
-{"tool": "get_messages", "params": {"chat_id": "-1001234567890", "post_id": 42}}
+// Get replies (channel posts, forum topics, or message replies)
+{"tool": "get_messages", "params": {"chat_id": "-1001234567890", "reply_to_id": 42}}
 
 // Send a message
 {"tool": "send_message", "params": {"chat_id": "me", "message": "Hello from AI!"}}

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ curl -X POST "https://tg-mcp.redevest.ru/mtproto-api/messages.SendMessage" \
 |---------|-------------|
 | 🔐 **Multi-User Authentication** | Production-ready Bearer token auth with session isolation and LRU cache management |
 | 🌐 **HTTP-MTProto Bridge** | Direct curl access to any Telegram API method with entity resolution and safety guardrails |
-| 🔍 **Intelligent Search** | Global & per-chat message search with multi-query support and intelligent deduplication |
+| 🔍 **Unified Message API** | Single `get_messages` tool for search, browse, read by IDs, and post comments - 5 modes in one |
+| 💬 **Post Comments Support** | Access channel post discussion threads with full search and metadata |
+| 🔎 **Intelligent Search** | Global & per-chat message search with multi-query support and intelligent deduplication |
 | 🏗️ **Dual Transport** | Seamless development (stdio) and production (HTTP) deployment support |
 | 📁 **Secure File Handling** | Rich media sharing with SSRF protection, size limits, and album support |
-| 💬 **Advanced Messaging** | Send, edit, reply, post to forum topics,formatting, file attachments, and phone number messaging |
+| ✉️ **Advanced Messaging** | Send, edit, reply, post to forum topics, formatting, file attachments, and phone number messaging |
 | 🎤 **Voice Transcription** | Automatic speech-to-text for Premium accounts with parallel processing and polling |
 | 📊 **Unified Session Management** | Single configuration system for setup and server, with multi-account support |
 | 👥 **Smart Contact Discovery** | Search users, groups, channels with uniform entity schemas, forum detection, profile enrichment |
@@ -111,7 +113,22 @@ fast-mcp-telegram-setup --api-id="your_api_id" --api-hash="your_api_hash" --phon
 
 ### 4. Start Using!
 ```json
+// Global search across all chats
 {"tool": "search_messages_globally", "params": {"query": "hello", "limit": 5}}
+
+// Get latest messages from a chat
+{"tool": "get_messages", "params": {"chat_id": "me", "limit": 10}}
+
+// Search within a specific chat
+{"tool": "get_messages", "params": {"chat_id": "@username", "query": "project"}}
+
+// Read specific messages by ID
+{"tool": "get_messages", "params": {"chat_id": "me", "message_ids": [123, 124]}}
+
+// Get channel post comments (discussion thread)
+{"tool": "get_messages", "params": {"chat_id": "-1001234567890", "post_id": 42}}
+
+// Send a message
 {"tool": "send_message", "params": {"chat_id": "me", "message": "Hello from AI!"}}
 ```
 

--- a/docs/Search-Guidelines.md
+++ b/docs/Search-Guidelines.md
@@ -54,16 +54,16 @@ Telegram search has specific limitations that AI models should understand to pro
 
 ```json
 // ✅ Good: Search in specific chat
-{"tool": "search_messages_in_chat", "params": {"chat_id": "-1001234567890", "query": "launch"}}
+{"tool": "get_messages", "params": {"chat_id": "-1001234567890", "query": "launch"}}
 
 // ✅ Good: Get latest messages (no query)
-{"tool": "search_messages_in_chat", "params": {"chat_id": "me", "limit": 10}}
+{"tool": "get_messages", "params": {"chat_id": "me", "limit": 10}}
 
 // ✅ Good: Multi-term search in chat
-{"tool": "search_messages_in_chat", "params": {"chat_id": "telegram", "query": "update, news"}}
+{"tool": "get_messages", "params": {"chat_id": "telegram", "query": "update, news"}}
 
 // ✅ Good: Partial word search
-{"tool": "search_messages_in_chat", "params": {"chat_id": "me", "query": "proj"}}
+{"tool": "get_messages", "params": {"chat_id": "me", "query": "proj"}}
 ```
 
 ### Filtered Search Examples
@@ -110,7 +110,7 @@ Telegram search has specific limitations that AI models should understand to pro
 ### 2. Use Chat-Specific Search When Possible
 ```json
 // If user mentions a specific person/channel, search there first
-{"tool": "search_messages_in_chat", "params": {"chat_id": "@username", "query": "project"}}
+{"tool": "get_messages", "params": {"chat_id": "@username", "query": "project"}}
 
 // Then try global search if needed
 {"tool": "search_messages_globally", "params": {"query": "project", "limit": 20}}
@@ -150,7 +150,7 @@ Telegram search has specific limitations that AI models should understand to pro
 ### Finding Messages by Context
 ```json
 // Recent messages from a specific person
-{"tool": "search_messages_in_chat", "params": {"chat_id": "@username", "limit": 10}}
+{"tool": "get_messages", "params": {"chat_id": "@username", "limit": 10}}
 
 // Messages in a specific time period
 {"tool": "search_messages_globally", "params": {

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -235,9 +235,11 @@ get_messages(
   query?: str,                   // Search terms (optional)
   message_ids?: number[],        // Specific message IDs to retrieve
   post_id?: number,              // Channel post ID for discussion comments
-  limit?: number = 50,          // Max results
-  min_date?: string,            // ISO date filter
-  max_date?: string             // ISO date filter
+  limit?: number = 50,           // Max results
+  min_date?: string,             // ISO date filter
+  max_date?: string,             // ISO date filter
+  auto_expand_batches?: number = 2,  // Extra batches for filtered searches
+  include_total_count?: boolean = false  // Include total count (chat search only)
 )
 ```
 
@@ -292,15 +294,17 @@ get_messages(
 }}
 ```
 
-**Response:**
-- For `message_ids` mode: Returns list of message dicts
-- For other modes: Returns dict with:
-  - `messages`: List of message dicts
-  - `has_more`: Boolean indicating more results available
-  - `total_count`: Total messages (if `include_total_count=True`)
-  - `discussion_chat_id`: Discussion group ID (if `post_id` used)
-  - `discussion_total_count`: Total comments (if `post_id` used)
-  - `linked_post_id`: Original post ID (if `post_id` used)
+**Response (unified format for all modes):**
+```json
+{
+  "messages": [...],           // List of message dicts
+  "has_more": false,           // Boolean (always false for message_ids mode)
+  "total_count": 123,          // Optional: only if include_total_count=true
+  "discussion_chat_id": "...", // Optional: only for post_id mode
+  "discussion_total_count": 45, // Optional: only for post_id mode
+  "linked_post_id": 123        // Optional: only for post_id mode
+}
+```
 
 **Features:**
 - **Rich Media Parsing**: Automatically parses Todo lists, polls, photos, documents

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -314,23 +314,6 @@ get_messages(
 - **Partial words**: Use shorter forms (e.g., "proj" finds "project", "projects")
 - **Post comments**: Requires discussion to be enabled on the channel post
 
----
-
-### 📍 search_messages_in_chat [DEPRECATED]
-**Use `get_messages(chat_id, query)` instead**
-
-This is a backward-compatible alias. New code should use `get_messages`.
-
-```typescript
-search_messages_in_chat(
-  chat_id: str,
-  query?: str,
-  limit?: number = 50,
-  min_date?: string,
-  max_date?: string
-)
-```
-
 ### 💬 send_message
 **Send new messages with formatting and optional files**
 
@@ -434,33 +417,6 @@ edit_message(
   "parse_mode": "html"
 }}
 
-```
-
-### 📖 read_messages [DEPRECATED]
-**Use `get_messages(chat_id, message_ids)` instead**
-
-This is a backward-compatible alias. New code should use `get_messages`.
-
-```typescript
-read_messages(
-  chat_id: str,
-  message_ids: number[]
-)
-```
-
-**Migration example:**
-```json
-// Old way:
-{"tool": "read_messages", "params": {
-  "chat_id": "me",
-  "message_ids": [680204, 680205]
-}}
-
-// New way (equivalent):
-{"tool": "get_messages", "params": {
-  "chat_id": "me",
-  "message_ids": [680204, 680205]
-}}
 ```
 
 ### 👥 find_chats

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -227,14 +227,14 @@ search_messages_globally(
 ```
 
 ### 📬 get_messages
-**Unified message retrieval - search, browse, read by IDs, or get post comments**
+**Unified message retrieval - search, browse, read by IDs, or get replies**
 
 ```typescript
 get_messages(
   chat_id: str,                  // Target chat ID (required)
   query?: str,                   // Search terms (optional)
   message_ids?: number[],        // Specific message IDs to retrieve
-  post_id?: number,              // Channel post ID for discussion comments
+  reply_to_id?: number,          // Get replies (post comments, forum topics, message replies)
   limit?: number = 50,           // Max results
   min_date?: string,             // ISO date filter
   max_date?: string,             // ISO date filter
@@ -247,11 +247,16 @@ get_messages(
 1. **Search in chat**: `chat_id` + `query` - Search messages in a specific chat
 2. **Browse chat**: `chat_id` only - Get latest messages
 3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages
-4. **Post comments**: `chat_id` + `post_id` - Get discussion thread comments
-5. **Search comments**: `chat_id` + `post_id` + `query` - Search within comments
+4. **Get replies**: `chat_id` + `reply_to_id` - Get replies to a message (universal)
+5. **Search replies**: `chat_id` + `reply_to_id` + `query` - Search within replies
+
+**reply_to_id automatically handles:**
+- 📢 **Channel post comments** - Detects discussion group and fetches comments
+- 📋 **Forum topic messages** - Fetches messages from forum topic
+- 💬 **Message replies** - Fetches direct replies to any message
 
 **Parameter Conflicts (will error):**
-- `message_ids` + `post_id`: Cannot combine
+- `message_ids` + `reply_to_id`: Cannot combine
 - `message_ids` + `query`: Cannot combine (specific IDs don't need search)
 
 **Examples:**
@@ -274,16 +279,28 @@ get_messages(
   "message_ids": [680204, 680205]
 }}
 
-// 4. Get channel post comments (discussion thread)
+// 4. Get channel post comments (auto-detects discussion)
 {"tool": "get_messages", "params": {
   "chat_id": "-1001234567890",
-  "post_id": 123
+  "reply_to_id": 123
 }}
 
-// 5. Search within post comments
+// 5. Get forum topic messages (same parameter!)
 {"tool": "get_messages", "params": {
   "chat_id": "-1001234567890",
-  "post_id": 123,
+  "reply_to_id": 52
+}}
+
+// 6. Get replies to any message
+{"tool": "get_messages", "params": {
+  "chat_id": "me",
+  "reply_to_id": 100
+}}
+
+// 7. Search within replies
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "reply_to_id": 123,
   "query": "bug"
 }}
 
@@ -300,23 +317,25 @@ get_messages(
   "messages": [...],           // List of message dicts
   "has_more": false,           // Boolean (always false for message_ids mode)
   "total_count": 123,          // Optional: only if include_total_count=true
-  "discussion_chat_id": "...", // Optional: only for post_id mode
-  "discussion_total_count": 45, // Optional: only for post_id mode
-  "linked_post_id": 123        // Optional: only for post_id mode
+  "reply_to_id": 100,          // Optional: only for reply_to_id mode
+  "discussion_chat_id": "...", // Optional: only for channel posts with discussion
+  "discussion_total_count": 45 // Optional: only for channel posts with discussion
 }
 ```
 
 **Features:**
 - **Rich Media Parsing**: Automatically parses Todo lists, polls, photos, documents
 - **Voice Transcription**: Automatic for Premium accounts with parallel processing
-- **Post Comments**: Access channel post discussion threads
+- **Universal Replies**: Single parameter for post comments, forum topics, and message replies
+- **Auto-Detection**: Automatically detects channel posts and uses discussion group
 - **Structured Data**: LLM-friendly JSON structures
 
 **💡 Tips:**
 - **No query**: Returns latest messages from chat
 - **Multi-term**: Use comma-separated words for broader results
 - **Partial words**: Use shorter forms (e.g., "proj" finds "project", "projects")
-- **Post comments**: Requires discussion to be enabled on the channel post
+- **reply_to_id**: Works for channel posts, forum topics, and regular message replies
+- **Forum topics**: Use topic root message ID as reply_to_id (get from get_chat_info)
 
 ### 💬 send_message
 **Send new messages with formatting and optional files**

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -244,7 +244,7 @@ get_messages(
 ```
 
 **5 Modes (parameter combinations):**
-1. **Search in chat**: `chat_id` + `query` - Search messages in specific chat
+1. **Search in chat**: `chat_id` + `query` - Search messages in a specific chat
 2. **Browse chat**: `chat_id` only - Get latest messages
 3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages
 4. **Post comments**: `chat_id` + `post_id` - Get discussion thread comments

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -226,39 +226,110 @@ search_messages_globally(
 }}
 ```
 
-### 📍 search_messages_in_chat
-**Search messages within a specific Telegram chat**
+### 📬 get_messages
+**Unified message retrieval - search, browse, read by IDs, or get post comments**
 
 ```typescript
-search_messages_in_chat(
-  chat_id: str,                  // Target chat ID (see Supported Chat ID Formats above)
-  query?: str,                   // Search terms (optional, returns latest if omitted)
+get_messages(
+  chat_id: str,                  // Target chat ID (required)
+  query?: str,                   // Search terms (optional)
+  message_ids?: number[],        // Specific message IDs to retrieve
+  post_id?: number,              // Channel post ID for discussion comments
   limit?: number = 50,          // Max results
-  min_date?: string,            // ISO date format
-  max_date?: string             // ISO date format
+  min_date?: string,            // ISO date filter
+  max_date?: string             // ISO date filter
 )
 ```
 
+**5 Modes (parameter combinations):**
+1. **Search in chat**: `chat_id` + `query` - Search messages in specific chat
+2. **Browse chat**: `chat_id` only - Get latest messages
+3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages
+4. **Post comments**: `chat_id` + `post_id` - Get discussion thread comments
+5. **Search comments**: `chat_id` + `post_id` + `query` - Search within comments
+
+**Parameter Conflicts (will error):**
+- `message_ids` + `post_id`: Cannot combine
+- `message_ids` + `query`: Cannot combine (specific IDs don't need search)
+
 **Examples:**
 ```json
-// Search in specific chat
-{"tool": "search_messages_in_chat", "params": {"chat_id": "-1001234567890", "query": "launch"}}
+// 1. Search in chat
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "launch"
+}}
 
-// Get latest messages from Saved Messages (no query = latest messages)
-{"tool": "search_messages_in_chat", "params": {"chat_id": "me", "limit": 10}}
+// 2. Browse latest messages (no query)
+{"tool": "get_messages", "params": {
+  "chat_id": "me",
+  "limit": 10
+}}
 
-// Multi-term search in chat (comma-separated)
-{"tool": "search_messages_in_chat", "params": {"chat_id": "telegram", "query": "update, news"}}
+// 3. Read specific messages by ID
+{"tool": "get_messages", "params": {
+  "chat_id": "me",
+  "message_ids": [680204, 680205]
+}}
 
-// Partial word search in chat
-{"tool": "search_messages_in_chat", "params": {"chat_id": "me", "query": "proj"}}
+// 4. Get channel post comments (discussion thread)
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "post_id": 123
+}}
+
+// 5. Search within post comments
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "post_id": 123,
+  "query": "bug"
+}}
+
+// Multi-term search
+{"tool": "get_messages", "params": {
+  "chat_id": "telegram",
+  "query": "update, news"
+}}
 ```
 
-**💡 Search Tips:**
-- **No query**: Returns latest messages from the chat (includes voice transcription for Premium accounts)
-- **Simple terms**: Use common words that appear in messages
-- **Multiple terms**: Use comma-separated words for broader results
-- **Partial words**: Use shorter forms to catch variations (e.g., "proj" finds "project", "projects")
+**Response:**
+- For `message_ids` mode: Returns list of message dicts
+- For other modes: Returns dict with:
+  - `messages`: List of message dicts
+  - `has_more`: Boolean indicating more results available
+  - `total_count`: Total messages (if `include_total_count=True`)
+  - `discussion_chat_id`: Discussion group ID (if `post_id` used)
+  - `discussion_total_count`: Total comments (if `post_id` used)
+  - `linked_post_id`: Original post ID (if `post_id` used)
+
+**Features:**
+- **Rich Media Parsing**: Automatically parses Todo lists, polls, photos, documents
+- **Voice Transcription**: Automatic for Premium accounts with parallel processing
+- **Post Comments**: Access channel post discussion threads
+- **Structured Data**: LLM-friendly JSON structures
+
+**💡 Tips:**
+- **No query**: Returns latest messages from chat
+- **Multi-term**: Use comma-separated words for broader results
+- **Partial words**: Use shorter forms (e.g., "proj" finds "project", "projects")
+- **Post comments**: Requires discussion to be enabled on the channel post
+
+---
+
+### 📍 search_messages_in_chat [DEPRECATED]
+**Use `get_messages(chat_id, query)` instead**
+
+This is a backward-compatible alias. New code should use `get_messages`.
+
+```typescript
+search_messages_in_chat(
+  chat_id: str,
+  query?: str,
+  limit?: number = 50,
+  min_date?: string,
+  max_date?: string
+)
+```
 
 ### 💬 send_message
 **Send new messages with formatting and optional files**
@@ -365,35 +436,30 @@ edit_message(
 
 ```
 
-### 📖 read_messages
-**Read specific messages by ID with rich media parsing**
+### 📖 read_messages [DEPRECATED]
+**Use `get_messages(chat_id, message_ids)` instead**
+
+This is a backward-compatible alias. New code should use `get_messages`.
 
 ```typescript
 read_messages(
-  chat_id: str,                  // Chat identifier (see Supported Chat ID Formats above)
-  message_ids: number[]          // Array of message IDs to retrieve
+  chat_id: str,
+  message_ids: number[]
 )
 ```
 
-**Features:**
-- **Rich Media Parsing**: Automatically parses Todo lists, polls, photos, documents, and other media types
-- **Structured Data**: Returns LLM-friendly JSON structures instead of raw Telegram objects
-- **Voice Transcription**: Automatic transcription for Premium accounts with parallel processing
-- **Todo Lists**: Extracts titles, items, completion status, and timestamps
-- **Polls**: Includes questions, options, vote counts, and poll metadata
-
-**Examples:**
+**Migration example:**
 ```json
-// Read multiple messages from Saved Messages
+// Old way:
 {"tool": "read_messages", "params": {
   "chat_id": "me",
-  "message_ids": [680204, 680205, 680206]
+  "message_ids": [680204, 680205]
 }}
 
-// Read from a channel
-{"tool": "read_messages", "params": {
-  "chat_id": "-1001234567890",
-  "message_ids": [123, 124, 125]
+// New way (equivalent):
+{"tool": "get_messages", "params": {
+  "chat_id": "me",
+  "message_ids": [680204, 680205]
 }}
 ```
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,7 +6,7 @@
 2. **Monitor Usage**: Track adoption of reply_to_id for different use cases
 3. **Documentation**: Consider adding workflow examples for forum topics
 
-**Current Status**: Successfully consolidated message tools into unified get_messages API with reply_to_id parameter that automatically handles channel post comments, forum topics, and message replies.
+**Current Status**: Successfully consolidated message tools into a unified get_messages API with reply_to_id parameter that automatically handles channel post comments, forum topics, and message replies.
 
 
 - **Connection Storm Resolved**: Eliminated 1,300+ reconnections per minute that was consuming 44.70% CPU and 95.31% memory

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,12 +1,12 @@
 ## Current Work Focus
-**Completed**: PR #960 - Unified get_messages API with post comments support (2026-02-28)
+**Completed**: PR #960 - Unified get_messages API with universal replies support (2026-02-28)
 
 **Next Steps**:
 1. **Production Testing**: Deploy and test new get_messages API in production
-2. **Monitor Usage**: Track adoption of new unified API vs deprecated aliases
-3. **Documentation**: Consider adding more examples for post comments use case
+2. **Monitor Usage**: Track adoption of reply_to_id for different use cases
+3. **Documentation**: Consider adding workflow examples for forum topics
 
-**Current Status**: Successfully consolidated message tools into unified get_messages API with support for 5 modes including channel post comments/discussion threads.
+**Current Status**: Successfully consolidated message tools into unified get_messages API with reply_to_id parameter that automatically handles channel post comments, forum topics, and message replies.
 
 
 - **Connection Storm Resolved**: Eliminated 1,300+ reconnections per minute that was consuming 44.70% CPU and 95.31% memory

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,11 +1,12 @@
 ## Current Work Focus
-**Completed**: Issue 11 - Hash sanitization and error normalization (2026-02-19)
+**Completed**: PR #960 - Unified get_messages API with post comments support (2026-02-28)
 
 **Next Steps**:
-1. **Monitor Performance**: Track container performance improvements from reduced logging overhead
-2. **Review Log Levels**: Consider optimal balance between visibility and noise reduction
+1. **Production Testing**: Deploy and test new get_messages API in production
+2. **Monitor Usage**: Track adoption of new unified API vs deprecated aliases
+3. **Documentation**: Consider adding more examples for post comments use case
 
-**Current Status**: Successfully eliminated 90%+ of log noise from FastMCP Redis operations while maintaining operational visibility.
+**Current Status**: Successfully consolidated message tools into unified get_messages API with support for 5 modes including channel post comments/discussion threads.
 
 
 - **Connection Storm Resolved**: Eliminated 1,300+ reconnections per minute that was consuming 44.70% CPU and 95.31% memory

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,5 @@
 ### 2026-02-28
-- **Unified get_messages API (PR #960)**: Consolidated search_messages_in_chat and read_messages into single get_messages tool
+- **Unified get_messages API (PR #960)**: Consolidated search_messages_in_chat and read_messages into a single get_messages tool
 - **Post Comments Support**: Added post_id parameter to fetch channel post discussion threads using messages.getDiscussionMessage
 - **5 Operating Modes**: Search in chat, browse chat, read by IDs, post comments, search in comments
 - **Parameter Conflict Validation**: Automatic rejection of invalid parameter combinations (message_ids+post_id, message_ids+query)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,12 +1,14 @@
 ### 2026-02-28
 - **Unified get_messages API (PR #960)**: Consolidated search_messages_in_chat and read_messages into a single get_messages tool
-- **Post Comments Support**: Added post_id parameter to fetch channel post discussion threads using messages.getDiscussionMessage
-- **5 Operating Modes**: Search in chat, browse chat, read by IDs, post comments, search in comments
-- **Parameter Conflict Validation**: Automatic rejection of invalid parameter combinations (message_ids+post_id, message_ids+query)
-- **Discussion Metadata**: Returns discussion_chat_id, discussion_total_count, and linked_post_id for post comments
+- **Universal Replies Support**: Added reply_to_id parameter for unified handling of channel post comments, forum topic messages, and message replies
+- **Auto-Detection**: Automatically detects channel posts with discussion groups and uses appropriate chat
+- **5 Operating Modes**: Search in chat, browse chat, read by IDs, get replies, search in replies
+- **Parameter Conflict Validation**: Automatic rejection of invalid parameter combinations (message_ids+reply_to_id, message_ids+query)
+- **Discussion Metadata**: Returns discussion_chat_id and discussion_total_count for channel posts with discussions
 - **Code Cleanup**: Removed deprecated tool aliases and unused internal functions
-- **Comprehensive Testing**: Added 14 new tests covering all modes and parameter interactions (216 total tests pass)
-- **Documentation**: Updated all docs to use new get_messages API
+- **Mode Resolution**: Extracted clean orchestration with MessageRetrievalMode enum and dedicated handlers
+- **Comprehensive Testing**: 215 tests pass with full coverage of all modes
+- **Documentation**: Updated all docs to use new get_messages API with reply_to_id
 
 ### 2026-02-19
 - **invoke_mtproto Hash Sanitization Fix (Issue 11)**: Type-preserving hash handling - strings kept for messages.ImportChatInvite, integers for state methods; invalid types removed instead of coercing to 0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,3 +1,13 @@
+### 2026-02-28
+- **Unified get_messages API (PR #960)**: Consolidated search_messages_in_chat and read_messages into single get_messages tool
+- **Post Comments Support**: Added post_id parameter to fetch channel post discussion threads using messages.getDiscussionMessage
+- **5 Operating Modes**: Search in chat, browse chat, read by IDs, post comments, search in comments
+- **Parameter Conflict Validation**: Automatic rejection of invalid parameter combinations (message_ids+post_id, message_ids+query)
+- **Backward Compatibility**: Kept read_messages and search_messages_in_chat as deprecated aliases
+- **Discussion Metadata**: Returns discussion_chat_id, discussion_total_count, and linked_post_id for post comments
+- **Comprehensive Testing**: Added 14 new tests covering all modes and parameter interactions (216 total tests pass)
+- **Documentation**: Updated Tools-Reference.md with new get_messages API and deprecated tool notices
+
 ### 2026-02-19
 - **invoke_mtproto Hash Sanitization Fix (Issue 11)**: Type-preserving hash handling - strings kept for messages.ImportChatInvite, integers for state methods; invalid types removed instead of coercing to 0
 - **RPC Error Normalization (Issue 11)**: Machine-readable error_code in invoke_mtproto responses using Telethon rpc_errors_dict/rpc_errors_re reverse mapping; supports USER_ALREADY_PARTICIPANT, INVITE_HASH_EXPIRED, etc.
@@ -65,7 +75,9 @@
 ### Core Functionality ✅
 - **MCP Server**: FastMCP-based server with full Telegram integration
 - **Configuration System**: Modernized pydantic-settings based configuration with three clear server modes
-- **Message Search**: Split into `search_messages_globally` and `search_messages_in_chat` for deterministic behavior
+- **Unified Message API**: `get_messages` consolidates search, browse, read by IDs, and post comments into single tool
+- **Post Comments Support**: Fetch and search channel post discussion threads with discussion metadata
+- **Message Search**: Split into `search_messages_globally` and `search_messages_in_chat` (deprecated alias) for deterministic behavior
 - **Message Operations**: Split into `send_message` and `edit_message` for clear intent separation
 - **File Sending**: Send single or multiple files via URLs (all modes) or local paths (stdio mode only)
 - **Contact Management**: Search and get contact details

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -3,10 +3,10 @@
 - **Post Comments Support**: Added post_id parameter to fetch channel post discussion threads using messages.getDiscussionMessage
 - **5 Operating Modes**: Search in chat, browse chat, read by IDs, post comments, search in comments
 - **Parameter Conflict Validation**: Automatic rejection of invalid parameter combinations (message_ids+post_id, message_ids+query)
-- **Backward Compatibility**: Kept read_messages and search_messages_in_chat as deprecated aliases
 - **Discussion Metadata**: Returns discussion_chat_id, discussion_total_count, and linked_post_id for post comments
+- **Code Cleanup**: Removed deprecated tool aliases and unused internal functions
 - **Comprehensive Testing**: Added 14 new tests covering all modes and parameter interactions (216 total tests pass)
-- **Documentation**: Updated Tools-Reference.md with new get_messages API and deprecated tool notices
+- **Documentation**: Updated all docs to use new get_messages API
 
 ### 2026-02-19
 - **invoke_mtproto Hash Sanitization Fix (Issue 11)**: Type-preserving hash handling - strings kept for messages.ImportChatInvite, integers for state methods; invalid types removed instead of coercing to 0
@@ -77,7 +77,7 @@
 - **Configuration System**: Modernized pydantic-settings based configuration with three clear server modes
 - **Unified Message API**: `get_messages` consolidates search, browse, read by IDs, and post comments into single tool
 - **Post Comments Support**: Fetch and search channel post discussion threads with discussion metadata
-- **Message Search**: Split into `search_messages_globally` and `search_messages_in_chat` (deprecated alias) for deterministic behavior
+- **Message Search**: `search_messages_globally` for global search, `get_messages` for per-chat operations
 - **Message Operations**: Split into `send_message` and `edit_message` for clear intent separation
 - **File Sending**: Send single or multiple files via URLs (all modes) or local paths (stdio mode only)
 - **Contact Management**: Search and get contact details

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -289,7 +289,7 @@ def register_tools(mcp: FastMCP) -> None:
         WORKFLOW:
         1. Find chat: find_chats("John Doe")
         2. Get chat_id from results
-        3. Search messages: search_messages_in_chat(chat_id=chat_id, query="topic")
+        3. Search messages: get_messages(chat_id=chat_id, query="topic")
 
         EXAMPLES:
         find_chats("@telegram")      # Find user by username

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -102,42 +102,66 @@ def register_tools(mcp: FastMCP) -> None:
             readOnlyHint=True, idempotentHint=True, openWorldHint=True
         )
     )
-    @mcp_tool_with_restrictions("search_messages_in_chat")
-    async def search_messages_in_chat(
+    @mcp_tool_with_restrictions("get_messages")
+    async def get_messages(
         chat_id: str,
         query: str | None = None,
+        message_ids: list[int] | None = None,
+        post_id: int | None = None,
         limit: int = 50,
         min_date: str | None = None,
         max_date: str | None = None,
         auto_expand_batches: int = 2,
         include_total_count: bool = False,
-    ) -> dict:
+    ) -> dict | list[dict]:
         """
-        Search messages within a specific Telegram chat.
+        Get messages from a Telegram chat - supports search, specific IDs, and post comments.
+
+        MODES (mutually exclusive):
+        1. SEARCH: chat_id + query - Search messages in chat
+        2. BROWSE: chat_id only - Get latest messages
+        3. READ BY IDs: chat_id + message_ids - Get specific messages
+        4. POST COMMENTS: chat_id + post_id - Get discussion thread comments
+        5. SEARCH COMMENTS: chat_id + post_id + query - Search within comments
+
+        CONFLICTS (will error):
+        - message_ids + post_id: Cannot combine
+        - message_ids + query: Cannot combine
 
         FEATURES:
-        - Multiple queries: "term1, term2, term3"
+        - Multiple search queries: "term1, term2, term3"
         - Date filtering: ISO format (min_date="2024-01-01")
-        - Total count support for per-chat searches
-        - No query = returns latest messages from the chat
+        - Total count support for chat searches
+        - Post discussion threads for channels
 
         EXAMPLES:
-        search_messages_in_chat(chat_id="me", limit=10)      # Saved Messages
-        search_messages_in_chat(chat_id="-1001234567890", query="launch")  # Specific chat
-        search_messages_in_chat(chat_id="telegram", query="update, news")  # Multi-term search
+        get_messages(chat_id="me", limit=10)  # Latest messages from Saved Messages
+        get_messages(chat_id="-1001234567890", query="launch")  # Search in chat
+        get_messages(chat_id="telegram", query="update, news")  # Multi-term search
+        get_messages(chat_id="me", message_ids=[680204, 680205])  # Specific messages
+        get_messages(chat_id="-1001234567890", post_id=123)  # Comments on post
+        get_messages(chat_id="-1001234567890", post_id=123, query="bug")  # Search in comments
 
         Args:
-            chat_id: Target chat ID ('me' for Saved Messages) or specific chat
-            query: Optional search terms (comma-separated). If omitted, returns latest messages.
+            chat_id: Target chat ID ('me' for Saved Messages, numeric ID, or username)
+            query: Search terms (comma-separated). Optional unless global search.
+            message_ids: List of specific message IDs to retrieve. Conflicts with query/post_id.
+            post_id: Channel post ID to get discussion comments. Conflicts with message_ids.
             limit: Max results (recommended: ≤50)
             min_date: Min date filter (ISO format: "2024-01-01")
             max_date: Max date filter (ISO format: "2024-12-31")
-            auto_expand_batches: Extra result batches for filtered searches
-            include_total_count: Include total matching messages count (per-chat only)
+            auto_expand_batches: Extra batches for filtered searches
+            include_total_count: Include total message count (per-chat only)
+
+        Returns:
+            For message_ids: List of message dicts
+            For other modes: Dict with messages, has_more, and optional metadata
         """
         return await search_messages_impl(
             query=query,
             chat_id=chat_id,
+            message_ids=message_ids,
+            post_id=post_id,
             limit=limit,
             min_date=min_date,
             max_date=max_date,
@@ -234,28 +258,67 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp_tool_with_restrictions("read_messages")
     async def read_messages(chat_id: str, message_ids: list[int]) -> list[dict]:
         """
+        [DEPRECATED: Use get_messages(chat_id, message_ids) instead]
         Read specific messages by their IDs from a Telegram chat.
 
-        SUPPORTED CHAT FORMATS:
-        - 'me': Saved Messages
-        - Numeric ID: User/chat ID (e.g., 133526395)
-        - Username: @channel_name or @username
-        - Channel ID: -100xxxxxxxxx
-
-        USAGE:
-        - First use search_messages_globally() or search_messages_in_chat() to find message IDs
-        - Then read specific messages using those IDs
-        - Returns full message content with metadata
+        This is a backward-compatible alias. New code should use get_messages() instead.
 
         EXAMPLES:
-        read_messages(chat_id="me", message_ids=[680204, 680205])  # Saved Messages
-        read_messages(chat_id="-1001234567890", message_ids=[123, 124])  # Channel
+        read_messages(chat_id="me", message_ids=[680204, 680205])
+        # Equivalent to: get_messages(chat_id="me", message_ids=[680204, 680205])
 
         Args:
             chat_id: Target chat identifier (use 'me' for Saved Messages)
-            message_ids: List of message IDs to retrieve (from search results)
+            message_ids: List of message IDs to retrieve
         """
-        return await read_messages_by_ids(chat_id, message_ids)
+        return await search_messages_impl(
+            chat_id=chat_id, message_ids=message_ids
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True, idempotentHint=True, openWorldHint=True
+        )
+    )
+    @mcp_tool_with_restrictions("search_messages_in_chat")
+    async def search_messages_in_chat(
+        chat_id: str,
+        query: str | None = None,
+        limit: int = 50,
+        min_date: str | None = None,
+        max_date: str | None = None,
+        auto_expand_batches: int = 2,
+        include_total_count: bool = False,
+    ) -> dict:
+        """
+        [DEPRECATED: Use get_messages(chat_id, query) instead]
+        Search messages within a specific Telegram chat.
+
+        This is a backward-compatible alias. New code should use get_messages() instead.
+
+        EXAMPLES:
+        search_messages_in_chat(chat_id="me", limit=10)
+        # Equivalent to: get_messages(chat_id="me", limit=10)
+
+        Args:
+            chat_id: Target chat ID
+            query: Search terms (comma-separated)
+            limit: Max results
+            min_date: Min date filter (ISO format)
+            max_date: Max date filter (ISO format)
+            auto_expand_batches: Extra batches for filtered searches
+            include_total_count: Include total count
+        """
+        return await search_messages_impl(
+            query=query,
+            chat_id=chat_id,
+            limit=limit,
+            min_date=min_date,
+            max_date=max_date,
+            chat_type=None,
+            auto_expand_batches=auto_expand_batches,
+            include_total_count=include_total_count,
+        )
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -9,7 +9,6 @@ from src.server_components import errors as server_errors
 from src.tools.contacts import find_chats_impl, get_chat_info_impl
 from src.tools.messages import (
     edit_message_impl,
-    read_messages_by_ids,
     send_message_impl,
     send_message_to_phone_impl,
 )
@@ -248,76 +247,6 @@ def register_tools(mcp: FastMCP) -> None:
             message_id,
             message,
             parse_mode,
-        )
-
-    @mcp.tool(
-        annotations=ToolAnnotations(
-            readOnlyHint=True, idempotentHint=True, openWorldHint=True
-        )
-    )
-    @mcp_tool_with_restrictions("read_messages")
-    async def read_messages(chat_id: str, message_ids: list[int]) -> list[dict]:
-        """
-        [DEPRECATED: Use get_messages(chat_id, message_ids) instead]
-        Read specific messages by their IDs from a Telegram chat.
-
-        This is a backward-compatible alias. New code should use get_messages() instead.
-
-        EXAMPLES:
-        read_messages(chat_id="me", message_ids=[680204, 680205])
-        # Equivalent to: get_messages(chat_id="me", message_ids=[680204, 680205])
-
-        Args:
-            chat_id: Target chat identifier (use 'me' for Saved Messages)
-            message_ids: List of message IDs to retrieve
-        """
-        return await search_messages_impl(
-            chat_id=chat_id, message_ids=message_ids
-        )
-
-    @mcp.tool(
-        annotations=ToolAnnotations(
-            readOnlyHint=True, idempotentHint=True, openWorldHint=True
-        )
-    )
-    @mcp_tool_with_restrictions("search_messages_in_chat")
-    async def search_messages_in_chat(
-        chat_id: str,
-        query: str | None = None,
-        limit: int = 50,
-        min_date: str | None = None,
-        max_date: str | None = None,
-        auto_expand_batches: int = 2,
-        include_total_count: bool = False,
-    ) -> dict:
-        """
-        [DEPRECATED: Use get_messages(chat_id, query) instead]
-        Search messages within a specific Telegram chat.
-
-        This is a backward-compatible alias. New code should use get_messages() instead.
-
-        EXAMPLES:
-        search_messages_in_chat(chat_id="me", limit=10)
-        # Equivalent to: get_messages(chat_id="me", limit=10)
-
-        Args:
-            chat_id: Target chat ID
-            query: Search terms (comma-separated)
-            limit: Max results
-            min_date: Min date filter (ISO format)
-            max_date: Max date filter (ISO format)
-            auto_expand_batches: Extra batches for filtered searches
-            include_total_count: Include total count
-        """
-        return await search_messages_impl(
-            query=query,
-            chat_id=chat_id,
-            limit=limit,
-            min_date=min_date,
-            max_date=max_date,
-            chat_type=None,
-            auto_expand_batches=auto_expand_batches,
-            include_total_count=include_total_count,
         )
 
     @mcp.tool(

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -106,7 +106,7 @@ def register_tools(mcp: FastMCP) -> None:
         chat_id: str,
         query: str | None = None,
         message_ids: list[int] | None = None,
-        post_id: int | None = None,
+        reply_to_id: int | None = None,
         limit: int = 50,
         min_date: str | None = None,
         max_date: str | None = None,
@@ -114,38 +114,43 @@ def register_tools(mcp: FastMCP) -> None:
         include_total_count: bool = False,
     ) -> dict:
         """
-        Get messages from a Telegram chat - supports search, specific IDs, and post comments.
+        Get messages from a Telegram chat - supports search, specific IDs, and replies.
 
         MODES (mutually exclusive):
         1. SEARCH: chat_id + query - Search messages in chat
         2. BROWSE: chat_id only - Get latest messages
         3. READ BY IDs: chat_id + message_ids - Get specific messages
-        4. POST COMMENTS: chat_id + post_id - Get discussion thread comments
-        5. SEARCH COMMENTS: chat_id + post_id + query - Search within comments
+        4. GET REPLIES: chat_id + reply_to_id - Get replies to a message
+        5. SEARCH REPLIES: chat_id + reply_to_id + query - Search within replies
+
+        REPLIES MODE AUTOMATICALLY HANDLES:
+        - Channel post comments (via discussion group)
+        - Forum topic messages (topic_id = root message)
+        - Regular message replies
 
         CONFLICTS (will error):
-        - message_ids + post_id: Cannot combine
+        - message_ids + reply_to_id: Cannot combine
         - message_ids + query: Cannot combine
 
         FEATURES:
         - Multiple search queries: "term1, term2, term3"
         - Date filtering: ISO format (min_date="2024-01-01")
         - Total count support for chat searches
-        - Post discussion threads for channels
+        - Automatic discussion group detection for channel posts
 
         EXAMPLES:
-        get_messages(chat_id="me", limit=10)  # Latest messages from Saved Messages
-        get_messages(chat_id="-1001234567890", query="launch")  # Search in chat
-        get_messages(chat_id="telegram", query="update, news")  # Multi-term search
+        get_messages(chat_id="me", limit=10)  # Latest messages
+        get_messages(chat_id="-1001234567890", query="launch")  # Search
         get_messages(chat_id="me", message_ids=[680204, 680205])  # Specific messages
-        get_messages(chat_id="-1001234567890", post_id=123)  # Comments on post
-        get_messages(chat_id="-1001234567890", post_id=123, query="bug")  # Search in comments
+        get_messages(chat_id="-1001234567890", reply_to_id=123)  # Post comments OR topic messages
+        get_messages(chat_id="-1001234567890", reply_to_id=52)  # Forum topic messages
+        get_messages(chat_id="me", reply_to_id=100, query="bug")  # Search in replies
 
         Args:
             chat_id: Target chat ID ('me' for Saved Messages, numeric ID, or username)
             query: Search terms (comma-separated). Optional unless global search.
-            message_ids: List of specific message IDs to retrieve. Conflicts with query/post_id.
-            post_id: Channel post ID to get discussion comments. Conflicts with message_ids.
+            message_ids: List of specific message IDs to retrieve. Conflicts with query/reply_to_id.
+            reply_to_id: Message ID to get replies from (post comments, forum topics, or regular replies)
             limit: Max results (recommended: ≤50)
             min_date: Min date filter (ISO format: "2024-01-01")
             max_date: Max date filter (ISO format: "2024-12-31")
@@ -157,13 +162,14 @@ def register_tools(mcp: FastMCP) -> None:
             - messages: List of message dicts
             - has_more: Boolean (always False for message_ids mode)
             - total_count: Total messages (if include_total_count=True)
-            - discussion_chat_id/discussion_total_count/linked_post_id: (if post_id used)
+            - reply_to_id: Original message ID (if reply_to_id used)
+            - discussion_chat_id/discussion_total_count: (if channel post with discussion)
         """
         return await search_messages_impl(
             query=query,
             chat_id=chat_id,
             message_ids=message_ids,
-            post_id=post_id,
+            reply_to_id=reply_to_id,
             limit=limit,
             min_date=min_date,
             max_date=max_date,

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -112,7 +112,7 @@ def register_tools(mcp: FastMCP) -> None:
         max_date: str | None = None,
         auto_expand_batches: int = 2,
         include_total_count: bool = False,
-    ) -> dict | list[dict]:
+    ) -> dict:
         """
         Get messages from a Telegram chat - supports search, specific IDs, and post comments.
 
@@ -153,8 +153,11 @@ def register_tools(mcp: FastMCP) -> None:
             include_total_count: Include total message count (per-chat only)
 
         Returns:
-            For message_ids: List of message dicts
-            For other modes: Dict with messages, has_more, and optional metadata
+            Dictionary with:
+            - messages: List of message dicts
+            - has_more: Boolean (always False for message_ids mode)
+            - total_count: Total messages (if include_total_count=True)
+            - discussion_chat_id/discussion_total_count/linked_post_id: (if post_id used)
         """
         return await search_messages_impl(
             query=query,

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -70,6 +70,8 @@ async def _get_post_discussion_info(
 ) -> dict[str, Any]:
     """
     Get discussion group information for a channel post.
+    
+    Caller is responsible for logging errors to avoid double-logging.
 
     Returns dict with:
     - discussion_peer: The discussion chat entity
@@ -113,7 +115,7 @@ async def _get_post_discussion_info(
         }
 
     except Exception as e:
-        logger.error(f"Failed to get discussion info for post {post_id}: {e}")
+        # Let caller handle logging to avoid double-logging
         raise ValueError(
             f"Cannot access discussion for post {post_id}: {e!s}"
         ) from e

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from enum import Enum, auto
 from typing import Any
 
 from telethon.tl.functions.messages import GetDiscussionMessageRequest, SearchGlobalRequest
@@ -28,6 +29,75 @@ from src.utils.message_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class MessageRetrievalMode(Enum):
+    """Enumeration of message retrieval modes for get_messages."""
+
+    MESSAGE_IDS = auto()
+    POST_COMMENTS = auto()
+    SEARCH = auto()
+
+
+def _resolve_mode(
+    *,
+    chat_id: str | None,
+    query: str | None,
+    message_ids: list[int] | None,
+    post_id: int | None,
+) -> MessageRetrievalMode:
+    """
+    Determine the message retrieval mode based on parameter combination.
+    
+    Raises ValueError if parameters conflict or required parameters are missing.
+    """
+    # Parameter conflict validation
+    if message_ids and post_id:
+        raise ValueError(
+            "Cannot combine message_ids with post_id. Use one or the other."
+        )
+    if message_ids and query:
+        raise ValueError(
+            "Cannot combine message_ids with query. Specific message IDs don't need search."
+        )
+
+    # Mode selection with validation
+    if message_ids is not None:
+        if not chat_id:
+            raise ValueError("chat_id is required when using message_ids")
+        return MessageRetrievalMode.MESSAGE_IDS
+
+    if post_id is not None:
+        if not chat_id:
+            raise ValueError("chat_id is required when using post_id")
+        return MessageRetrievalMode.POST_COMMENTS
+
+    # Default: search/browse mode
+    return MessageRetrievalMode.SEARCH
+
+
+# ============================================================================
+# Message IDs Mode Handler
+# ============================================================================
+
+
+async def _handle_message_ids_mode(
+    chat_id: str,
+    message_ids: list[int],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handle reading specific messages by IDs with unified output format."""
+    messages_list = await read_messages_by_ids(chat_id, message_ids)
+
+    # Check if it's an error (single-item list with error field)
+    if len(messages_list) == 1 and "error" in messages_list[0]:
+        return messages_list[0]
+
+    # Wrap in unified format for consistency
+    return {
+        "messages": messages_list,
+        "has_more": False,  # Reading by specific IDs never has more
+    }
 
 
 # ============================================================================
@@ -252,6 +322,154 @@ async def _execute_parallel_searches_generators(
 
 
 # ============================================================================
+# Search/Browse Mode Handler
+# ============================================================================
+
+
+async def _handle_search_mode(
+    *,
+    query: str | None,
+    chat_id: str | None,
+    limit: int,
+    min_date: str | None,
+    max_date: str | None,
+    chat_type: str | None,
+    public: bool | None,
+    auto_expand_batches: int,
+    include_total_count: bool,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handle search/browse mode for messages."""
+    # Normalize and validate queries
+    queries: list[str] = (
+        [q.strip() for q in query.split(",") if q.strip()] if query else []
+    )
+
+    if not chat_id and not queries:
+        return log_and_build_error(
+            operation="get_messages",
+            error_message="Search query must not be empty for global search",
+            params=params,
+            exception=ValueError("Search query must not be empty for global search"),
+        )
+
+    min_datetime = datetime.fromisoformat(min_date) if min_date else None
+    max_datetime = datetime.fromisoformat(max_date) if max_date else None
+
+    client = await get_connected_client()
+    try:
+        total_count = None
+        collected: list[dict[str, Any]] = []
+        seen_keys = set()
+
+        if chat_id:
+            # Per-chat search/browse
+            try:
+                entity = await get_entity_by_id(chat_id)
+                if not entity:
+                    raise ValueError(f"Could not find chat with ID '{chat_id}'")
+
+                per_chat_queries = queries if queries else [""]
+                generators = [
+                    _search_chat_messages_generator(
+                        client,
+                        entity,
+                        (q or ""),
+                        limit,
+                        chat_type,
+                        public,
+                        auto_expand_batches,
+                    )
+                    for q in per_chat_queries
+                ]
+                await _execute_parallel_searches_generators(
+                    generators, collected, seen_keys, limit
+                )
+
+                await transcribe_voice_messages(collected, entity)
+
+                if include_total_count:
+                    total_count = await _get_chat_message_count(chat_id)
+
+            except Exception as e:
+                return log_and_build_error(
+                    operation="get_messages",
+                    error_message=f"Failed to search in chat '{chat_id}': {e!s}",
+                    params=params,
+                    exception=e,
+                )
+        else:
+            # Global search
+            try:
+                generators = [
+                    _search_global_messages_generator(
+                        client,
+                        q,
+                        limit,
+                        min_datetime,
+                        max_datetime,
+                        chat_type,
+                        public,
+                        auto_expand_batches,
+                    )
+                    for q in queries
+                    if q and str(q).strip()
+                ]
+                await _execute_parallel_searches_generators(
+                    generators, collected, seen_keys, limit
+                )
+            except Exception as e:
+                return log_and_build_error(
+                    operation="get_messages",
+                    error_message=f"Failed to perform global search: {e!s}",
+                    params=params,
+                    exception=e,
+                )
+
+        # Return results up to limit
+        window = collected[:limit] if limit is not None else collected
+
+        logger.info(f"Found {len(window)} messages matching query: {query}")
+
+        # Check if there are more messages available
+        has_more = len(collected) > len(window) or (
+            len(collected) == limit and len(collected) > 0
+        )
+
+        # If no messages found, return error
+        if not window:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message=f"No messages found matching query '{query}'",
+                params=params,
+                exception=ValueError(f"No messages found matching query '{query}'"),
+            )
+
+        response = {"messages": window, "has_more": has_more}
+
+        if total_count is not None:
+            response["total_count"] = total_count
+
+        return response
+
+    except SessionNotAuthorizedError as e:
+        return log_and_build_error(
+            operation="get_messages",
+            error_message="Session not authorized. Please authenticate your Telegram session first.",
+            params=params,
+            exception=e,
+            action="authenticate_session",
+        )
+    except Exception as e:
+        return log_and_build_error(
+            operation="get_messages",
+            error_message=f"Message retrieval failed: {e!s}",
+            params=params,
+            exception=e,
+        )
+
+
+# ============================================================================
 # Main Implementation
 # ============================================================================
 
@@ -313,6 +531,7 @@ async def search_messages_impl(
         - Total count only available for per-chat searches, not global
         - Post comments require discussion to be enabled on the channel post
     """
+    # Build params for logging
     params = {
         "query": query,
         "chat_id": chat_id,
@@ -331,187 +550,42 @@ async def search_messages_impl(
         "message_count": len(message_ids) if message_ids else 0,
     }
 
-    # Parameter conflict validation
-    if message_ids and post_id:
+    # Resolve mode and validate parameters
+    try:
+        mode = _resolve_mode(
+            chat_id=chat_id,
+            query=query,
+            message_ids=message_ids,
+            post_id=post_id,
+        )
+    except ValueError as e:
         return log_and_build_error(
             operation="get_messages",
-            error_message="Cannot combine message_ids with post_id. Use one or the other.",
+            error_message=str(e),
             params=params,
-            exception=ValueError("Parameter conflict: message_ids and post_id are mutually exclusive"),
+            exception=e,
         )
 
-    if message_ids and query:
-        return log_and_build_error(
-            operation="get_messages",
-            error_message="Cannot combine message_ids with query. Specific message IDs don't need search.",
-            params=params,
-            exception=ValueError("Parameter conflict: message_ids and query are mutually exclusive"),
-        )
+    # Delegate to appropriate handler
+    if mode is MessageRetrievalMode.MESSAGE_IDS:
+        return await _handle_message_ids_mode(chat_id, message_ids, params)
 
-    # Mode: Read specific messages by IDs
-    if message_ids is not None:
-        if not chat_id:
-            return log_and_build_error(
-                operation="get_messages",
-                error_message="chat_id is required when using message_ids",
-                params=params,
-                exception=ValueError("chat_id required for message_ids mode"),
-            )
-        # Delegate to read_messages_by_ids and wrap in unified format
-        messages_list = await read_messages_by_ids(chat_id, message_ids)
-        
-        # Check if it's an error (single-item list with error field)
-        if len(messages_list) == 1 and "error" in messages_list[0]:
-            return messages_list[0]
-        
-        # Wrap in unified format for consistency
-        return {
-            "messages": messages_list,
-            "has_more": False,  # Reading by specific IDs never has more
-        }
-
-    # Mode: Read post comments
-    if post_id is not None:
-        if not chat_id:
-            return log_and_build_error(
-                operation="get_messages",
-                error_message="chat_id is required when using post_id",
-                params=params,
-                exception=ValueError("chat_id required for post_id mode"),
-            )
+    if mode is MessageRetrievalMode.POST_COMMENTS:
         return await _handle_post_comments_mode(chat_id, post_id, limit, query, params)
 
-    # Normalize and validate queries for search modes
-    queries: list[str] = (
-        [q.strip() for q in query.split(",") if q.strip()] if query else []
+    # Mode: Search/browse
+    return await _handle_search_mode(
+        query=query,
+        chat_id=chat_id,
+        limit=limit,
+        min_date=min_date,
+        max_date=max_date,
+        chat_type=chat_type,
+        public=public,
+        auto_expand_batches=auto_expand_batches,
+        include_total_count=include_total_count,
+        params=params,
     )
-
-    if not chat_id and not queries:
-        return log_and_build_error(
-            operation="get_messages",
-            error_message="Search query must not be empty for global search",
-            params=params,
-            exception=ValueError("Search query must not be empty for global search"),
-        )
-    min_datetime = datetime.fromisoformat(min_date) if min_date else None
-    max_datetime = datetime.fromisoformat(max_date) if max_date else None
-    safe_params = sanitize_params_for_logging(params)
-    enhanced_params = add_logging_metadata(safe_params)
-    logger.debug(
-        "Starting Telegram search",
-        extra={"params": enhanced_params},
-    )
-    client = await get_connected_client()
-    try:
-        total_count = None
-        collected: list[dict[str, Any]] = []
-        seen_keys = set()
-
-        if chat_id:
-            # Per-chat search; allow empty queries meaning "all messages"
-            try:
-                entity = await get_entity_by_id(chat_id)
-                if not entity:
-                    raise ValueError(f"Could not find chat with ID '{chat_id}'")
-
-                per_chat_queries = queries if queries else [""]
-                generators = [
-                    _search_chat_messages_generator(
-                        client,
-                        entity,
-                        (q or ""),
-                        limit,
-                        chat_type,
-                        public,
-                        auto_expand_batches,
-                    )
-                    for q in per_chat_queries
-                ]
-                await _execute_parallel_searches_generators(
-                    generators, collected, seen_keys, limit
-                )
-
-                await transcribe_voice_messages(collected, entity)
-
-                if include_total_count:
-                    total_count = await _get_chat_message_count(chat_id)
-
-            except Exception as e:
-                return log_and_build_error(
-                    operation="get_messages",
-                    error_message=f"Failed to search in chat '{chat_id}': {e!s}",
-                    params=params,
-                    exception=e,
-                )
-        else:
-            # Global search across queries (skip empty)
-            try:
-                generators = [
-                    _search_global_messages_generator(
-                        client,
-                        q,
-                        limit,
-                        min_datetime,
-                        max_datetime,
-                        chat_type,
-                        public,
-                        auto_expand_batches,
-                    )
-                    for q in queries
-                    if q and str(q).strip()
-                ]
-                await _execute_parallel_searches_generators(
-                    generators, collected, seen_keys, limit
-                )
-            except Exception as e:
-                return log_and_build_error(
-                    operation="get_messages",
-                    error_message=f"Failed to perform global search: {e!s}",
-                    params=params,
-                    exception=e,
-                )
-
-        # Return results up to limit
-        window = collected[:limit] if limit is not None else collected
-
-        logger.info(f"Found {len(window)} messages matching query: {query}")
-
-        # Check if there are more messages available by collecting one extra message
-        # If we collected exactly limit messages, assume there might be more (conservative approach)
-        has_more = len(collected) > len(window) or (
-            len(collected) == limit and len(collected) > 0
-        )
-
-        # If no messages found, return error instead of empty list for consistency
-        if not window:
-            return log_and_build_error(
-                operation="get_messages",
-                error_message=f"No messages found matching query '{query}'",
-                params=params,
-                exception=ValueError(f"No messages found matching query '{query}'"),
-            )
-
-        response = {"messages": window, "has_more": has_more}
-
-        if total_count is not None:
-            response["total_count"] = total_count
-
-        return response
-    except SessionNotAuthorizedError as e:
-        return log_and_build_error(
-            operation="get_messages",
-            error_message="Session not authorized. Please authenticate your Telegram session first.",
-            params=params,
-            exception=e,
-            action="authenticate_session",
-        )
-    except Exception as e:
-        return log_and_build_error(
-            operation="get_messages",
-            error_message=f"Message retrieval failed: {e!s}",
-            params=params,
-            exception=e,
-        )
 
 
 async def _search_chat_messages_generator(

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -2,11 +2,12 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from telethon.tl.functions.messages import SearchGlobalRequest
+from telethon.tl.functions.messages import GetDiscussionMessageRequest, SearchGlobalRequest
 from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty
 
 from src.client.connection import SessionNotAuthorizedError, get_connected_client
 from src.tools.links import generate_telegram_links
+from src.tools.messages import read_messages_by_ids
 from src.utils.entity import (
     _get_chat_message_count,
     _matches_chat_type,
@@ -69,6 +70,125 @@ async def _process_message_for_results(
         return False
 
 
+async def _get_post_discussion_info(
+    client, channel_entity, post_id: int
+) -> dict[str, Any]:
+    """
+    Get discussion group information for a channel post.
+
+    Returns dict with:
+    - discussion_peer: The discussion chat entity
+    - discussion_chat_id: Chat ID of discussion group
+    - discussion_msg_id: Root message ID in discussion group
+    - discussion_total_count: Total comment count (if available)
+
+    Raises ValueError if post has no discussion enabled.
+    """
+    try:
+        result = await client(
+            GetDiscussionMessageRequest(
+                peer=channel_entity,
+                msg_id=post_id,
+            )
+        )
+
+        if not result or not hasattr(result, "messages") or not result.messages:
+            raise ValueError(f"Post {post_id} has no discussion thread enabled")
+
+        discussion_msg = result.messages[0]
+        discussion_peer = getattr(discussion_msg, "peer_id", None)
+
+        if not discussion_peer:
+            raise ValueError(f"Post {post_id} has no discussion peer")
+
+        # Get the discussion chat entity
+        discussion_entity = await client.get_entity(discussion_peer)
+        discussion_chat_id = compute_entity_identifier(discussion_entity)
+
+        # Get total comment count if available
+        total_count = getattr(result, "count", None)
+        if total_count is None and hasattr(discussion_msg, "replies"):
+            total_count = getattr(discussion_msg.replies, "replies", None)
+
+        return {
+            "discussion_peer": discussion_entity,
+            "discussion_chat_id": discussion_chat_id,
+            "discussion_msg_id": discussion_msg.id,
+            "discussion_total_count": total_count,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to get discussion info for post {post_id}: {e}")
+        raise ValueError(
+            f"Cannot access discussion for post {post_id}: {e!s}"
+        ) from e
+
+
+async def _fetch_post_comments(
+    client,
+    channel_entity,
+    post_id: int,
+    limit: int,
+    query: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """
+    Fetch comments from a channel post's discussion thread.
+
+    Returns tuple of (messages, metadata):
+    - messages: List of comment message dicts
+    - metadata: Discussion metadata (chat_id, total_count, etc.)
+    """
+    # Get discussion information
+    discussion_info = await _get_post_discussion_info(client, channel_entity, post_id)
+
+    discussion_entity = discussion_info["discussion_peer"]
+    discussion_msg_id = discussion_info["discussion_msg_id"]
+
+    # Fetch comments from discussion thread
+    # Comments are replies to the root discussion message
+    collected = []
+    async for message in client.iter_messages(
+        discussion_entity,
+        reply_to=discussion_msg_id,
+        search=query if query else None,
+        limit=limit + 1,  # Fetch one extra to check has_more
+    ):
+        if not message:
+            continue
+
+        has_content = (hasattr(message, "text") and message.text) or _has_any_media(
+            message
+        )
+        if not has_content:
+            continue
+
+        try:
+            identifier = compute_entity_identifier(discussion_entity)
+            links = await generate_telegram_links(
+                identifier, [message.id], resolved_entity=discussion_entity
+            )
+            link = links.get("message_links", [None])[0]
+            result = await build_message_result(client, message, discussion_entity, link)
+            collected.append(result)
+
+            if len(collected) >= limit + 1:
+                break
+        except Exception as e:
+            logger.warning(f"Error processing comment message: {e}")
+            continue
+
+    # Transcribe voice messages if any
+    await transcribe_voice_messages(collected[:limit], discussion_entity)
+
+    metadata = {
+        "discussion_chat_id": discussion_info["discussion_chat_id"],
+        "discussion_total_count": discussion_info["discussion_total_count"],
+        "linked_post_id": post_id,
+    }
+
+    return collected, metadata
+
+
 async def _execute_parallel_searches_generators(
     generators: list, collected: list[dict[str, Any]], seen_keys: set, limit: int
 ) -> None:
@@ -100,8 +220,10 @@ async def _execute_parallel_searches_generators(
 
 
 async def search_messages_impl(
-    query: str,
+    query: str | None = None,
     chat_id: str | None = None,
+    message_ids: list[int] | None = None,
+    post_id: int | None = None,
     limit: int = 20,
     min_date: str | None = None,  # ISO format date string
     max_date: str | None = None,  # ISO format date string
@@ -110,35 +232,56 @@ async def search_messages_impl(
     | None = None,  # True=with username, False=without username, None=no filter
     auto_expand_batches: int = 1,  # Fewer extra batches to reduce RAM
     include_total_count: bool = False,  # Whether to include total count in response
-) -> dict[str, Any]:
+) -> dict[str, Any] | list[dict[str, Any]]:
     """
-    Search for messages in Telegram chats using Telegram's global or per-chat search functionality with optional chat type and public filtering and auto-expansion for filtered results.
+    Unified message retrieval supporting search, specific message IDs, and post comments.
+
+    PARAMETER COMBINATIONS:
+    1. Search in chat: chat_id + query
+    2. Browse chat: chat_id (returns recent messages)
+    3. Read specific messages: chat_id + message_ids
+    4. Read post comments: chat_id + post_id
+    5. Search in comments: chat_id + post_id + query
+    6. Global search: query only (no chat_id)
+
+    CONFLICTS (will return error):
+    - message_ids + post_id: Cannot combine
+    - message_ids + query: Cannot combine (specific IDs don't need search)
 
     Args:
-        query: Search query string (use comma-separated terms for multiple queries). For per-chat, may be empty; for global, must not be empty. Results are merged and deduplicated.
-        chat_id: Optional chat ID to search in a specific chat. If not provided, performs a global search.
+        query: Search query string (comma-separated for multiple queries). Optional for per-chat, required for global.
+        chat_id: Target chat ID. Required for message_ids and post_id modes.
+        message_ids: List of specific message IDs to retrieve. Conflicts with query and post_id.
+        post_id: Channel post ID to retrieve discussion comments from. Conflicts with message_ids.
         limit: Maximum number of results to return
-        min_date: Optional minimum date for search results (ISO format string)
-        max_date: Optional maximum date for search results (ISO format string)
-        chat_type: Optional filter for chat type ('private', 'group', 'channel')
-        public: Optional filter for public discoverability (True=with username, False=without username, None=no filter). Never applies to private chats.
-        auto_expand_batches: Maximum additional batches to fetch if not enough filtered results (default 2)
-        include_total_count: Whether to include total count of matching messages in response (default False)
+        min_date: Minimum date filter (ISO format)
+        max_date: Maximum date filter (ISO format)
+        chat_type: Filter by chat type ('private', 'group', 'channel', comma-separated)
+        public: Filter by public discoverability (True=with username, False=without). Never applies to private chats.
+        auto_expand_batches: Additional batches to fetch for filtered searches (default 1)
+        include_total_count: Include total count in response (per-chat only, default False)
 
     Returns:
-        Dictionary containing:
-        - 'messages': List of dictionaries containing message information
-        - 'total_count': Total number of matching messages (if include_total_count=True)
-        - 'has_more': Boolean indicating if there are more results available
+        For message_ids mode: List of message dicts
+        For all other modes: Dictionary with:
+        - 'messages': List of message dicts
+        - 'has_more': Boolean indicating more results available
+        - 'total_count': Total messages (if include_total_count=True)
+        - 'discussion_chat_id': Discussion group ID (if post_id used)
+        - 'discussion_total_count': Total comments (if post_id used and available)
+        - 'linked_post_id': Original post ID (if post_id used)
 
     Note:
-        - For per-chat search (chat_id provided), an empty query returns all messages in the specified chat (optionally filtered by date).
-        - For global search (no chat_id), query must not be empty.
-        - Total count is only available for per-chat searches, not global searches.
+        - Global search requires non-empty query
+        - Per-chat search allows empty query (returns recent messages)
+        - Total count only available for per-chat searches, not global
+        - Post comments require discussion to be enabled on the channel post
     """
     params = {
         "query": query,
         "chat_id": chat_id,
+        "message_ids": message_ids,
+        "post_id": post_id,
         "limit": limit,
         "min_date": min_date,
         "max_date": max_date,
@@ -149,16 +292,100 @@ async def search_messages_impl(
         "is_global_search": chat_id is None,
         "has_query": bool(query and query.strip()),
         "has_date_filter": bool(min_date or max_date),
+        "message_count": len(message_ids) if message_ids else 0,
     }
 
-    # Normalize and validate queries
+    # Parameter conflict validation
+    if message_ids and post_id:
+        return log_and_build_error(
+            operation="get_messages",
+            error_message="Cannot combine message_ids with post_id. Use one or the other.",
+            params=params,
+            exception=ValueError("Parameter conflict: message_ids and post_id are mutually exclusive"),
+        )
+
+    if message_ids and query:
+        return log_and_build_error(
+            operation="get_messages",
+            error_message="Cannot combine message_ids with query. Specific message IDs don't need search.",
+            params=params,
+            exception=ValueError("Parameter conflict: message_ids and query are mutually exclusive"),
+        )
+
+    # Mode: Read specific messages by IDs
+    if message_ids is not None:
+        if not chat_id:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message="chat_id is required when using message_ids",
+                params=params,
+                exception=ValueError("chat_id required for message_ids mode"),
+            )
+        # Delegate to read_messages_by_ids
+        return await read_messages_by_ids(chat_id, message_ids)
+
+    # Mode: Read post comments
+    if post_id is not None:
+        if not chat_id:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message="chat_id is required when using post_id",
+                params=params,
+                exception=ValueError("chat_id required for post_id mode"),
+            )
+
+        # Fetch post comments
+        client = await get_connected_client()
+        try:
+            entity = await get_entity_by_id(chat_id)
+            if not entity:
+                raise ValueError(f"Could not find chat with ID '{chat_id}'")
+
+            collected, metadata = await _fetch_post_comments(
+                client, entity, post_id, limit, query
+            )
+
+            # Return results up to limit
+            window = collected[:limit] if limit is not None else collected
+            has_more = len(collected) > len(window) or (
+                len(collected) == limit and len(collected) > 0
+            )
+
+            if not window:
+                return log_and_build_error(
+                    operation="get_messages",
+                    error_message=f"No comments found for post {post_id}",
+                    params=params,
+                    exception=ValueError(f"No comments found for post {post_id}"),
+                )
+
+            response = {
+                "messages": window,
+                "has_more": has_more,
+                **metadata,  # Add discussion metadata
+            }
+
+            logger.info(
+                f"Retrieved {len(window)} comments from post {post_id} in chat {chat_id}"
+            )
+            return response
+
+        except Exception as e:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message=f"Failed to fetch comments for post {post_id}: {e!s}",
+                params=params,
+                exception=e,
+            )
+
+    # Normalize and validate queries for search modes
     queries: list[str] = (
         [q.strip() for q in query.split(",") if q.strip()] if query else []
     )
 
     if not chat_id and not queries:
         return log_and_build_error(
-            operation="search_messages",
+            operation="get_messages",
             error_message="Search query must not be empty for global search",
             params=params,
             exception=ValueError("Search query must not be empty for global search"),
@@ -208,7 +435,7 @@ async def search_messages_impl(
 
             except Exception as e:
                 return log_and_build_error(
-                    operation="search_messages",
+                    operation="get_messages",
                     error_message=f"Failed to search in chat '{chat_id}': {e!s}",
                     params=params,
                     exception=e,
@@ -235,7 +462,7 @@ async def search_messages_impl(
                 )
             except Exception as e:
                 return log_and_build_error(
-                    operation="search_messages",
+                    operation="get_messages",
                     error_message=f"Failed to perform global search: {e!s}",
                     params=params,
                     exception=e,
@@ -255,7 +482,7 @@ async def search_messages_impl(
         # If no messages found, return error instead of empty list for consistency
         if not window:
             return log_and_build_error(
-                operation="search_messages",
+                operation="get_messages",
                 error_message=f"No messages found matching query '{query}'",
                 params=params,
                 exception=ValueError(f"No messages found matching query '{query}'"),
@@ -269,7 +496,7 @@ async def search_messages_impl(
         return response
     except SessionNotAuthorizedError as e:
         return log_and_build_error(
-            operation="search_messages",
+            operation="get_messages",
             error_message="Session not authorized. Please authenticate your Telegram session first.",
             params=params,
             exception=e,
@@ -277,8 +504,8 @@ async def search_messages_impl(
         )
     except Exception as e:
         return log_and_build_error(
-            operation="search_messages",
-            error_message=f"Search operation failed: {e!s}",
+            operation="get_messages",
+            error_message=f"Message retrieval failed: {e!s}",
             params=params,
             exception=e,
         )

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -30,44 +30,9 @@ from src.utils.message_format import (
 logger = logging.getLogger(__name__)
 
 
-async def _process_message_for_results(
-    client,
-    message,
-    chat_entity,
-    chat_type: str,
-    public: bool | None,
-    results: list[dict[str, Any]],
-) -> bool:
-    """Process a single message and add it to results if it matches criteria.
-
-    Returns True if the message was added, False otherwise.
-    """
-    if not message:
-        return False
-
-    # Check if message has content (text or any type of media)
-    has_content = (hasattr(message, "text") and message.text) or _has_any_media(message)
-
-    if not has_content:
-        return False
-
-    if not _matches_chat_type(chat_entity, chat_type):
-        return False
-
-    if not _matches_public_filter(chat_entity, public):
-        return False
-
-    try:
-        identifier = compute_entity_identifier(chat_entity)
-        links = await generate_telegram_links(
-            identifier, [message.id], resolved_entity=chat_entity
-        )
-        link = links.get("message_links", [None])[0]
-        results.append(await build_message_result(client, message, chat_entity, link))
-        return True
-    except Exception as e:
-        logger.warning(f"Error processing message: {e}")
-        return False
+# ============================================================================
+# Post Comments / Discussion Threads
+# ============================================================================
 
 
 async def _get_post_discussion_info(
@@ -189,6 +154,11 @@ async def _fetch_post_comments(
     return collected, metadata
 
 
+# ============================================================================
+# Search Execution Helpers
+# ============================================================================
+
+
 async def _execute_parallel_searches_generators(
     generators: list, collected: list[dict[str, Any]], seen_keys: set, limit: int
 ) -> None:
@@ -217,6 +187,11 @@ async def _execute_parallel_searches_generators(
                 continue  # Skip errors in individual generators
 
         active_gens = next_active
+
+
+# ============================================================================
+# Main Implementation
+# ============================================================================
 
 
 async def search_messages_impl(
@@ -567,20 +542,6 @@ async def _search_chat_messages_generator(
         batch_count += 1
 
 
-async def _search_chat_messages(
-    client, entity, query, limit, chat_type, public, auto_expand_batches
-):
-    """Backward compatibility wrapper - collects generator results into list."""
-    results = []
-    async for result in _search_chat_messages_generator(
-        client, entity, query, limit, chat_type, public, auto_expand_batches
-    ):
-        results.append(result)
-        if len(results) >= limit:
-            break
-    return results[:limit]
-
-
 async def _search_global_messages_generator(
     client,
     query,
@@ -651,31 +612,3 @@ async def _search_global_messages_generator(
         if result.messages:
             next_offset_id = result.messages[-1].id
         batch_count += 1
-
-
-async def _search_global_messages(
-    client,
-    query,
-    limit,
-    min_datetime,
-    max_datetime,
-    chat_type,
-    public,
-    auto_expand_batches,
-):
-    """Backward compatibility wrapper - collects generator results into list."""
-    results = []
-    async for result in _search_global_messages_generator(
-        client,
-        query,
-        limit,
-        min_datetime,
-        max_datetime,
-        chat_type,
-        public,
-        auto_expand_batches,
-    ):
-        results.append(result)
-        if len(results) >= limit:
-            break
-    return results[:limit]

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -35,7 +35,7 @@ class MessageRetrievalMode(Enum):
     """Enumeration of message retrieval modes for get_messages."""
 
     MESSAGE_IDS = auto()
-    POST_COMMENTS = auto()
+    REPLIES = auto()  # Unified: post comments, forum topics, message replies
     SEARCH = auto()
 
 
@@ -44,7 +44,7 @@ def _resolve_mode(
     chat_id: str | None,
     query: str | None,
     message_ids: list[int] | None,
-    post_id: int | None,
+    reply_to_id: int | None,
 ) -> MessageRetrievalMode:
     """
     Determine the message retrieval mode based on parameter combination.
@@ -52,9 +52,9 @@ def _resolve_mode(
     Raises ValueError if parameters conflict or required parameters are missing.
     """
     # Parameter conflict validation
-    if message_ids and post_id:
+    if message_ids and reply_to_id:
         raise ValueError(
-            "Cannot combine message_ids with post_id. Use one or the other."
+            "Cannot combine message_ids with reply_to_id. Use one or the other."
         )
     if message_ids and query:
         raise ValueError(
@@ -67,10 +67,10 @@ def _resolve_mode(
             raise ValueError("chat_id is required when using message_ids")
         return MessageRetrievalMode.MESSAGE_IDS
 
-    if post_id is not None:
+    if reply_to_id is not None:
         if not chat_id:
-            raise ValueError("chat_id is required when using post_id")
-        return MessageRetrievalMode.POST_COMMENTS
+            raise ValueError("chat_id is required when using reply_to_id")
+        return MessageRetrievalMode.REPLIES
 
     # Default: search/browse mode
     return MessageRetrievalMode.SEARCH
@@ -240,22 +240,51 @@ async def _fetch_post_comments(
     return collected, metadata
 
 
-async def _handle_post_comments_mode(
+async def _handle_replies_mode(
     chat_id: str,
-    post_id: int,
+    reply_to_id: int,
     limit: int,
     query: str | None,
     params: dict[str, Any],
 ) -> dict[str, Any]:
-    """Handle fetching and returning post comments with unified error handling."""
+    """
+    Handle fetching replies to a message.
+    
+    Automatically handles:
+    - Channel post comments (via discussion group)
+    - Forum topic messages
+    - Regular message replies
+    """
     client = await get_connected_client()
     try:
         entity = await get_entity_by_id(chat_id)
         if not entity:
             raise ValueError(f"Could not find chat with ID '{chat_id}'")
 
+        # Check if this is a channel post with discussion
+        discussion_info = None
+        effective_entity = entity
+        effective_reply_to = reply_to_id
+        
+        if hasattr(entity, "broadcast") and entity.broadcast:
+            # It's a channel - try to get discussion group
+            try:
+                discussion_info = await _get_post_discussion_info(
+                    client, entity, reply_to_id
+                )
+                # Use discussion chat instead of channel
+                effective_entity = discussion_info["discussion_peer"]
+                effective_reply_to = discussion_info["discussion_msg_id"]
+                logger.debug(
+                    f"Detected channel post with discussion, using discussion chat"
+                )
+            except ValueError:
+                # No discussion enabled - will search for replies in channel itself
+                logger.debug(f"Channel post {reply_to_id} has no discussion enabled")
+                pass
+
         collected, metadata = await _fetch_post_comments(
-            client, entity, post_id, limit, query
+            client, effective_entity, effective_reply_to, limit, query
         )
 
         window = collected[:limit] if limit is not None else collected
@@ -264,23 +293,31 @@ async def _handle_post_comments_mode(
         if not window:
             return log_and_build_error(
                 operation="get_messages",
-                error_message=f"No comments found for post {post_id}",
+                error_message=f"No replies found for message {reply_to_id}",
                 params=params,
-                exception=ValueError(f"No comments found for post {post_id}"),
+                exception=ValueError(f"No replies to message {reply_to_id}"),
             )
 
         logger.info(
-            f"Retrieved {len(window)} comments from post {post_id} in chat {chat_id}"
+            f"Retrieved {len(window)} replies to message {reply_to_id} in chat {chat_id}"
         )
-        return {
+        
+        response = {
             "messages": window,
             "has_more": has_more,
-            **metadata,
+            "reply_to_id": reply_to_id,
         }
+        
+        # Add discussion metadata if it was a channel post
+        if discussion_info:
+            response.update(metadata)
+        
+        return response
+        
     except Exception as e:
         return log_and_build_error(
             operation="get_messages",
-            error_message=f"Failed to fetch comments for post {post_id}: {e!s}",
+            error_message=f"Failed to fetch replies to message {reply_to_id}: {e!s}",
             params=params,
             exception=e,
         )
@@ -478,7 +515,7 @@ async def search_messages_impl(
     query: str | None = None,
     chat_id: str | None = None,
     message_ids: list[int] | None = None,
-    post_id: int | None = None,
+    reply_to_id: int | None = None,
     limit: int = 20,
     min_date: str | None = None,  # ISO format date string
     max_date: str | None = None,  # ISO format date string
@@ -489,25 +526,28 @@ async def search_messages_impl(
     include_total_count: bool = False,  # Whether to include total count in response
 ) -> dict[str, Any]:
     """
-    Unified message retrieval supporting search, specific message IDs, and post comments.
+    Unified message retrieval supporting search, specific message IDs, and replies.
 
     PARAMETER COMBINATIONS:
     1. Search in chat: chat_id + query
     2. Browse chat: chat_id (returns recent messages)
     3. Read specific messages: chat_id + message_ids
-    4. Read post comments: chat_id + post_id
-    5. Search in comments: chat_id + post_id + query
+    4. Get replies: chat_id + reply_to_id (post comments, forum topics, message replies)
+    5. Search in replies: chat_id + reply_to_id + query
     6. Global search: query only (no chat_id)
 
     CONFLICTS (will return error):
-    - message_ids + post_id: Cannot combine
+    - message_ids + reply_to_id: Cannot combine
     - message_ids + query: Cannot combine (specific IDs don't need search)
 
     Args:
         query: Search query string (comma-separated for multiple queries). Optional for per-chat, required for global.
-        chat_id: Target chat ID. Required for message_ids and post_id modes.
-        message_ids: List of specific message IDs to retrieve. Conflicts with query and post_id.
-        post_id: Channel post ID to retrieve discussion comments from. Conflicts with message_ids.
+        chat_id: Target chat ID. Required for message_ids and reply_to_id modes.
+        message_ids: List of specific message IDs to retrieve. Conflicts with query and reply_to_id.
+        reply_to_id: Message ID to get replies from. Works for:
+            - Channel posts (fetches discussion comments automatically)
+            - Forum topics (fetches topic messages)
+            - Regular messages (fetches direct replies)
         limit: Maximum number of results to return
         min_date: Minimum date filter (ISO format)
         max_date: Maximum date filter (ISO format)
@@ -521,22 +561,22 @@ async def search_messages_impl(
         - 'messages': List of message dicts
         - 'has_more': Boolean indicating more results available (always False for message_ids mode)
         - 'total_count': Total messages (if include_total_count=True, chat search only)
-        - 'discussion_chat_id': Discussion group ID (if post_id used)
-        - 'discussion_total_count': Total comments (if post_id used and available)
-        - 'linked_post_id': Original post ID (if post_id used)
+        - 'reply_to_id': Original message ID (if reply_to_id used)
+        - 'discussion_chat_id': Discussion group ID (if channel post with discussion)
+        - 'discussion_total_count': Total replies (if available)
 
     Note:
         - Global search requires non-empty query
         - Per-chat search allows empty query (returns recent messages)
         - Total count only available for per-chat searches, not global
-        - Post comments require discussion to be enabled on the channel post
+        - reply_to_id automatically detects channel posts and uses discussion group
     """
     # Build params for logging
     params = {
         "query": query,
         "chat_id": chat_id,
         "message_ids": message_ids,
-        "post_id": post_id,
+        "reply_to_id": reply_to_id,
         "limit": limit,
         "min_date": min_date,
         "max_date": max_date,
@@ -556,7 +596,7 @@ async def search_messages_impl(
             chat_id=chat_id,
             query=query,
             message_ids=message_ids,
-            post_id=post_id,
+            reply_to_id=reply_to_id,
         )
     except ValueError as e:
         return log_and_build_error(
@@ -570,8 +610,8 @@ async def search_messages_impl(
     if mode is MessageRetrievalMode.MESSAGE_IDS:
         return await _handle_message_ids_mode(chat_id, message_ids, params)
 
-    if mode is MessageRetrievalMode.POST_COMMENTS:
-        return await _handle_post_comments_mode(chat_id, post_id, limit, query, params)
+    if mode is MessageRetrievalMode.REPLIES:
+        return await _handle_replies_mode(chat_id, reply_to_id, limit, query, params)
 
     # Mode: Search/browse
     return await _handle_search_mode(

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -35,6 +35,36 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 
+async def _build_result_for_message(
+    client,
+    message,
+    chat_entity,
+) -> dict[str, Any] | None:
+    """Build result dict for a single message with link generation.
+    
+    Returns None if message is invalid or has no content.
+    """
+    if not message:
+        return None
+
+    has_content = (hasattr(message, "text") and message.text) or _has_any_media(
+        message
+    )
+    if not has_content:
+        return None
+
+    try:
+        identifier = compute_entity_identifier(chat_entity)
+        links = await generate_telegram_links(
+            identifier, [message.id], resolved_entity=chat_entity
+        )
+        link = links.get("message_links", [None])[0]
+        return await build_message_result(client, message, chat_entity, link)
+    except Exception as e:
+        logger.warning(f"Error processing message: {e}")
+        return None
+
+
 async def _get_post_discussion_info(
     client, channel_entity, post_id: int
 ) -> dict[str, Any]:
@@ -118,29 +148,13 @@ async def _fetch_post_comments(
         search=query if query else None,
         limit=limit + 1,  # Fetch one extra to check has_more
     ):
-        if not message:
+        result = await _build_result_for_message(client, message, discussion_entity)
+        if not result:
             continue
 
-        has_content = (hasattr(message, "text") and message.text) or _has_any_media(
-            message
-        )
-        if not has_content:
-            continue
-
-        try:
-            identifier = compute_entity_identifier(discussion_entity)
-            links = await generate_telegram_links(
-                identifier, [message.id], resolved_entity=discussion_entity
-            )
-            link = links.get("message_links", [None])[0]
-            result = await build_message_result(client, message, discussion_entity, link)
-            collected.append(result)
-
-            if len(collected) >= limit + 1:
-                break
-        except Exception as e:
-            logger.warning(f"Error processing comment message: {e}")
-            continue
+        collected.append(result)
+        if len(collected) >= limit + 1:
+            break
 
     # Transcribe voice messages if any
     await transcribe_voice_messages(collected[:limit], discussion_entity)
@@ -152,6 +166,52 @@ async def _fetch_post_comments(
     }
 
     return collected, metadata
+
+
+async def _handle_post_comments_mode(
+    chat_id: str,
+    post_id: int,
+    limit: int,
+    query: str | None,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handle fetching and returning post comments with unified error handling."""
+    client = await get_connected_client()
+    try:
+        entity = await get_entity_by_id(chat_id)
+        if not entity:
+            raise ValueError(f"Could not find chat with ID '{chat_id}'")
+
+        collected, metadata = await _fetch_post_comments(
+            client, entity, post_id, limit, query
+        )
+
+        window = collected[:limit] if limit is not None else collected
+        has_more = len(collected) > len(window)
+
+        if not window:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message=f"No comments found for post {post_id}",
+                params=params,
+                exception=ValueError(f"No comments found for post {post_id}"),
+            )
+
+        logger.info(
+            f"Retrieved {len(window)} comments from post {post_id} in chat {chat_id}"
+        )
+        return {
+            "messages": window,
+            "has_more": has_more,
+            **metadata,
+        }
+    except Exception as e:
+        return log_and_build_error(
+            operation="get_messages",
+            error_message=f"Failed to fetch comments for post {post_id}: {e!s}",
+            params=params,
+            exception=e,
+        )
 
 
 # ============================================================================
@@ -207,7 +267,7 @@ async def search_messages_impl(
     | None = None,  # True=with username, False=without username, None=no filter
     auto_expand_batches: int = 1,  # Fewer extra batches to reduce RAM
     include_total_count: bool = False,  # Whether to include total count in response
-) -> dict[str, Any] | list[dict[str, Any]]:
+) -> dict[str, Any]:
     """
     Unified message retrieval supporting search, specific message IDs, and post comments.
 
@@ -237,11 +297,10 @@ async def search_messages_impl(
         include_total_count: Include total count in response (per-chat only, default False)
 
     Returns:
-        For message_ids mode: List of message dicts
-        For all other modes: Dictionary with:
+        Dictionary with:
         - 'messages': List of message dicts
-        - 'has_more': Boolean indicating more results available
-        - 'total_count': Total messages (if include_total_count=True)
+        - 'has_more': Boolean indicating more results available (always False for message_ids mode)
+        - 'total_count': Total messages (if include_total_count=True, chat search only)
         - 'discussion_chat_id': Discussion group ID (if post_id used)
         - 'discussion_total_count': Total comments (if post_id used and available)
         - 'linked_post_id': Original post ID (if post_id used)
@@ -296,8 +355,18 @@ async def search_messages_impl(
                 params=params,
                 exception=ValueError("chat_id required for message_ids mode"),
             )
-        # Delegate to read_messages_by_ids
-        return await read_messages_by_ids(chat_id, message_ids)
+        # Delegate to read_messages_by_ids and wrap in unified format
+        messages_list = await read_messages_by_ids(chat_id, message_ids)
+        
+        # Check if it's an error (single-item list with error field)
+        if len(messages_list) == 1 and "error" in messages_list[0]:
+            return messages_list[0]
+        
+        # Wrap in unified format for consistency
+        return {
+            "messages": messages_list,
+            "has_more": False,  # Reading by specific IDs never has more
+        }
 
     # Mode: Read post comments
     if post_id is not None:
@@ -308,50 +377,7 @@ async def search_messages_impl(
                 params=params,
                 exception=ValueError("chat_id required for post_id mode"),
             )
-
-        # Fetch post comments
-        client = await get_connected_client()
-        try:
-            entity = await get_entity_by_id(chat_id)
-            if not entity:
-                raise ValueError(f"Could not find chat with ID '{chat_id}'")
-
-            collected, metadata = await _fetch_post_comments(
-                client, entity, post_id, limit, query
-            )
-
-            # Return results up to limit
-            window = collected[:limit] if limit is not None else collected
-            has_more = len(collected) > len(window) or (
-                len(collected) == limit and len(collected) > 0
-            )
-
-            if not window:
-                return log_and_build_error(
-                    operation="get_messages",
-                    error_message=f"No comments found for post {post_id}",
-                    params=params,
-                    exception=ValueError(f"No comments found for post {post_id}"),
-                )
-
-            response = {
-                "messages": window,
-                "has_more": has_more,
-                **metadata,  # Add discussion metadata
-            }
-
-            logger.info(
-                f"Retrieved {len(window)} comments from post {post_id} in chat {chat_id}"
-            )
-            return response
-
-        except Exception as e:
-            return log_and_build_error(
-                operation="get_messages",
-                error_message=f"Failed to fetch comments for post {post_id}: {e!s}",
-                params=params,
-                exception=e,
-            )
+        return await _handle_post_comments_mode(chat_id, post_id, limit, query, params)
 
     # Normalize and validate queries for search modes
     queries: list[str] = (
@@ -514,24 +540,12 @@ async def _search_chat_messages_generator(
             if not _matches_public_filter(entity, public):
                 continue
 
-            has_content = (hasattr(message, "text") and message.text) or _has_any_media(
-                message
-            )
-            if not has_content:
+            result = await _build_result_for_message(client, message, entity)
+            if not result:
                 continue
 
-            try:
-                identifier = compute_entity_identifier(entity)
-                links = await generate_telegram_links(
-                    identifier, [message.id], resolved_entity=entity
-                )
-                link = links.get("message_links", [None])[0]
-                result = await build_message_result(client, message, entity, link)
-                yield result
-                yielded_count += 1
-            except Exception as e:
-                logger.warning(f"Error processing message: {e}")
-                continue
+            yield result
+            yielded_count += 1
 
             # Continue processing all messages in this batch to ensure we can detect has_more
 
@@ -591,18 +605,10 @@ async def _search_global_messages_generator(
                 if not _matches_public_filter(chat, public):
                     continue
 
-                has_content = (
-                    hasattr(message, "text") and message.text
-                ) or _has_any_media(message)
-                if not has_content:
+                msg_result = await _build_result_for_message(client, message, chat)
+                if not msg_result:
                     continue
 
-                identifier = compute_entity_identifier(chat)
-                links = await generate_telegram_links(
-                    identifier, [message.id], resolved_entity=chat
-                )
-                link = links.get("message_links", [None])[0]
-                msg_result = await build_message_result(client, message, chat, link)
                 yield msg_result
                 yielded_count += 1
             except Exception as e:

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -52,17 +52,19 @@ def _resolve_mode(
     Raises ValueError if parameters conflict or required parameters are missing.
     """
     # Parameter conflict validation
-    if message_ids and reply_to_id:
+    if message_ids is not None and reply_to_id is not None:
         raise ValueError(
             "Cannot combine message_ids with reply_to_id. Use one or the other."
         )
-    if message_ids and query:
+    if message_ids is not None and query is not None:
         raise ValueError(
             "Cannot combine message_ids with query. Specific message IDs don't need search."
         )
 
     # Mode selection with validation
     if message_ids is not None:
+        if not message_ids:
+            raise ValueError("message_ids cannot be empty when provided")
         if not chat_id:
             raise ValueError("chat_id is required when using message_ids")
         return MessageRetrievalMode.MESSAGE_IDS
@@ -191,36 +193,57 @@ async def _get_post_discussion_info(
         ) from e
 
 
-async def _fetch_post_comments(
+async def _fetch_replies(
     client,
-    channel_entity,
-    post_id: int,
+    chat_entity,
+    reply_to_id: int,
     limit: int,
     query: str | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     """
-    Fetch comments from a channel post's discussion thread.
+    Fetch replies/comments for a message.
+    
+    Automatically handles:
+    - Channel posts with discussion (detects and uses discussion group)
+    - Forum topics (uses reply_to directly)
+    - Regular message replies (uses reply_to directly)
 
-    Returns tuple of (messages, metadata):
-    - messages: List of comment message dicts
-    - metadata: Discussion metadata (chat_id, total_count, etc.)
+    Returns tuple of (messages, discussion_metadata_or_none):
+    - messages: List of reply message dicts
+    - discussion_metadata: Dict with discussion info if channel post, None otherwise
     """
-    # Get discussion information
-    discussion_info = await _get_post_discussion_info(client, channel_entity, post_id)
+    effective_entity = chat_entity
+    effective_reply_to = reply_to_id
+    discussion_metadata = None
 
-    discussion_entity = discussion_info["discussion_peer"]
-    discussion_msg_id = discussion_info["discussion_msg_id"]
+    # Detect channel post with discussion
+    if hasattr(chat_entity, "broadcast") and chat_entity.broadcast:
+        try:
+            discussion_info = await _get_post_discussion_info(
+                client, chat_entity, reply_to_id
+            )
+            # Use discussion chat instead of channel
+            effective_entity = discussion_info["discussion_peer"]
+            effective_reply_to = discussion_info["discussion_msg_id"]
+            discussion_metadata = {
+                "discussion_chat_id": discussion_info["discussion_chat_id"],
+                "discussion_total_count": discussion_info["discussion_total_count"],
+                "linked_post_id": reply_to_id,
+            }
+            logger.debug("Detected channel post with discussion, using discussion chat")
+        except ValueError:
+            # No discussion enabled - will fetch replies from channel itself
+            logger.debug(f"Channel post {reply_to_id} has no discussion enabled")
 
-    # Fetch comments from discussion thread
-    # Comments are replies to the root discussion message
+    # Fetch replies/comments
     collected = []
     async for message in client.iter_messages(
-        discussion_entity,
-        reply_to=discussion_msg_id,
+        effective_entity,
+        reply_to=effective_reply_to,
         search=query if query else None,
         limit=limit + 1,  # Fetch one extra to check has_more
     ):
-        result = await _build_result_for_message(client, message, discussion_entity)
+        result = await _build_result_for_message(client, message, effective_entity)
         if not result:
             continue
 
@@ -228,16 +251,10 @@ async def _fetch_post_comments(
         if len(collected) >= limit + 1:
             break
 
-    # Transcribe voice messages if any
-    await transcribe_voice_messages(collected[:limit], discussion_entity)
+    # Transcribe voice messages
+    await transcribe_voice_messages(collected[:limit], effective_entity)
 
-    metadata = {
-        "discussion_chat_id": discussion_info["discussion_chat_id"],
-        "discussion_total_count": discussion_info["discussion_total_count"],
-        "linked_post_id": post_id,
-    }
-
-    return collected, metadata
+    return collected, discussion_metadata
 
 
 async def _handle_replies_mode(
@@ -261,30 +278,9 @@ async def _handle_replies_mode(
         if not entity:
             raise ValueError(f"Could not find chat with ID '{chat_id}'")
 
-        # Check if this is a channel post with discussion
-        discussion_info = None
-        effective_entity = entity
-        effective_reply_to = reply_to_id
-        
-        if hasattr(entity, "broadcast") and entity.broadcast:
-            # It's a channel - try to get discussion group
-            try:
-                discussion_info = await _get_post_discussion_info(
-                    client, entity, reply_to_id
-                )
-                # Use discussion chat instead of channel
-                effective_entity = discussion_info["discussion_peer"]
-                effective_reply_to = discussion_info["discussion_msg_id"]
-                logger.debug(
-                    f"Detected channel post with discussion, using discussion chat"
-                )
-            except ValueError:
-                # No discussion enabled - will search for replies in channel itself
-                logger.debug(f"Channel post {reply_to_id} has no discussion enabled")
-                pass
-
-        collected, metadata = await _fetch_post_comments(
-            client, effective_entity, effective_reply_to, limit, query
+        # Fetch replies (handles all detection internally)
+        collected, discussion_metadata = await _fetch_replies(
+            client, entity, reply_to_id, limit, query
         )
 
         window = collected[:limit] if limit is not None else collected
@@ -308,9 +304,9 @@ async def _handle_replies_mode(
             "reply_to_id": reply_to_id,
         }
         
-        # Add discussion metadata if it was a channel post
-        if discussion_info:
-            response.update(metadata)
+        # Add discussion metadata if present (channel post with discussion)
+        if discussion_metadata:
+            response.update(discussion_metadata)
         
         return response
         

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,12 +94,37 @@ def test_server(mock_client):
 
     conn._get_client_by_token = AsyncMock(return_value=mock_client)
 
-    # Register the actual tool functions (we can't import them directly due to decorators)
-    # Instead, we'll create simplified versions for testing
+    # Register simplified mock versions of tools for testing
     @mcp.tool()
-    async def search_messages(query: str, chat_id: str | None = None, limit: int = 50):
-        """Search Telegram messages with advanced filtering."""
-        messages = mock_client.messages.get(chat_id or "me", [])
+    async def search_messages_globally(query: str, limit: int = 50, chat_type: str | None = None):
+        """Search across all Telegram chats."""
+        all_messages = []
+        for chat_messages in mock_client.messages.values():
+            all_messages.extend(chat_messages)
+        
+        if query:
+            all_messages = [msg for msg in all_messages if query.lower() in msg["text"].lower()]
+        window = all_messages[:limit]
+        has_more = len(all_messages) > len(window)
+        return {"messages": window, "has_more": has_more}
+
+    @mcp.tool()
+    async def get_messages(
+        chat_id: str,
+        query: str | None = None,
+        message_ids: list[int] | None = None,
+        post_id: int | None = None,
+        limit: int = 50
+    ):
+        """Unified message retrieval - search, browse, read by IDs, or get post comments."""
+        messages = mock_client.messages.get(chat_id, [])
+        
+        # Mode: Read by IDs
+        if message_ids:
+            found_messages = [msg for msg in messages if msg["id"] in message_ids]
+            return {"messages": found_messages, "has_more": False}
+        
+        # Mode: Search or browse
         if query:
             messages = [msg for msg in messages if query.lower() in msg["text"].lower()]
         window = messages[:limit]
@@ -107,20 +132,14 @@ def test_server(mock_client):
         return {"messages": window, "has_more": has_more}
 
     @mcp.tool()
-    async def send_or_edit_message(
-        chat_id: str, message: str, message_id: int | None = None
-    ):
-        """Send new message or edit existing message in Telegram chat."""
-        if message_id:
-            return {"action": "edited", "message_id": message_id, "text": message}
+    async def send_message(chat_id: str, message: str, reply_to: int | None = None):
+        """Send new message in Telegram chat."""
         return {"action": "sent", "chat_id": chat_id, "text": message}
 
     @mcp.tool()
-    async def read_messages(chat_id: str, message_ids: list[int]):
-        """Read specific messages by their IDs from a Telegram chat."""
-        messages = mock_client.messages.get(chat_id, [])
-        found_messages = [msg for msg in messages if msg["id"] in message_ids]
-        return {"messages": found_messages}
+    async def edit_message(chat_id: str, message_id: int, message: str):
+        """Edit existing message in Telegram chat."""
+        return {"action": "edited", "message_id": message_id, "text": message}
 
     return mcp
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,16 +113,36 @@ def test_server(mock_client):
         chat_id: str,
         query: str | None = None,
         message_ids: list[int] | None = None,
-        post_id: int | None = None,
+        reply_to_id: int | None = None,
         limit: int = 50
     ):
-        """Unified message retrieval - search, browse, read by IDs, or get post comments."""
+        """Unified message retrieval - search, browse, read by IDs, or get replies."""
         messages = mock_client.messages.get(chat_id, [])
         
         # Mode: Read by IDs
         if message_ids:
             found_messages = [msg for msg in messages if msg["id"] in message_ids]
             return {"messages": found_messages, "has_more": False}
+        
+        # Mode: Get replies
+        if reply_to_id:
+            # Mock replies: messages with matching reply_to field
+            reply_messages = [
+                msg for msg in messages 
+                if msg.get("reply_to_msg_id") == reply_to_id
+            ]
+            if query:
+                reply_messages = [
+                    msg for msg in reply_messages 
+                    if query.lower() in msg["text"].lower()
+                ]
+            window = reply_messages[:limit]
+            has_more = len(reply_messages) > len(window)
+            return {
+                "messages": window, 
+                "has_more": has_more,
+                "reply_to_id": reply_to_id
+            }
         
         # Mode: Search or browse
         if query:

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -92,6 +92,21 @@ async def test_get_messages_by_ids(client_session):
 
 
 @pytest.mark.asyncio
+async def test_get_messages_replies_mode(client_session):
+    """Test get_messages with reply_to_id mode (post comments, forum topics, message replies)."""
+    result = await client_session.call_tool(
+        "get_messages", {"chat_id": "me", "reply_to_id": 1}
+    )
+
+    assert result.data is not None
+    assert isinstance(result.data, dict)
+    assert "messages" in result.data
+    assert "has_more" in result.data
+    assert "reply_to_id" in result.data
+    assert result.data["reply_to_id"] == 1
+
+
+@pytest.mark.asyncio
 async def test_with_bearer_token(test_server):
     """Test with proper Bearer token authentication."""
     # For FastMCP in-memory testing, we need to set up authentication differently

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -17,18 +17,19 @@ async def test_basic_functionality(client_session):
 
     # Test tool listing
     tools = await client_session.list_tools()
-    assert len(tools) == 3
+    assert len(tools) == 4
     tool_names = [t.name for t in tools]
-    assert "search_messages" in tool_names
-    assert "send_or_edit_message" in tool_names
-    assert "read_messages" in tool_names
+    assert "search_messages_globally" in tool_names
+    assert "get_messages" in tool_names
+    assert "send_message" in tool_names
+    assert "edit_message" in tool_names
 
 
 @pytest.mark.asyncio
-async def test_search_messages(client_session):
-    """Test search messages functionality with mock data."""
+async def test_get_messages_search(client_session):
+    """Test get_messages search functionality with mock data."""
     result = await client_session.call_tool(
-        "search_messages", {"query": "Test", "chat_id": "me", "limit": 10}
+        "get_messages", {"query": "Test", "chat_id": "me", "limit": 10}
     )
 
     assert result.data is not None
@@ -42,10 +43,10 @@ async def test_search_messages(client_session):
 
 
 @pytest.mark.asyncio
-async def test_search_messages_has_more(client_session):
+async def test_get_messages_has_more(client_session):
     """Test has_more flag logic when there are more messages than limit."""
     result = await client_session.call_tool(
-        "search_messages", {"query": "Test", "chat_id": "me", "limit": 1}
+        "get_messages", {"query": "Test", "chat_id": "me", "limit": 1}
     )
 
     assert result.data is not None
@@ -64,7 +65,7 @@ async def test_search_messages_has_more(client_session):
 async def test_send_message(client_session):
     """Test send message functionality."""
     result = await client_session.call_tool(
-        "send_or_edit_message",
+        "send_message",
         {"chat_id": "me", "message": "Test message from MCP"},
     )
 
@@ -76,16 +77,18 @@ async def test_send_message(client_session):
 
 
 @pytest.mark.asyncio
-async def test_read_messages(client_session):
-    """Test read messages functionality."""
+async def test_get_messages_by_ids(client_session):
+    """Test get_messages with message_ids mode."""
     result = await client_session.call_tool(
-        "read_messages", {"chat_id": "me", "message_ids": [1, 2]}
+        "get_messages", {"chat_id": "me", "message_ids": [1, 2]}
     )
 
     assert result.data is not None
     assert isinstance(result.data, dict)
     assert "messages" in result.data
+    assert "has_more" in result.data
     assert len(result.data["messages"]) == 2  # Should find both messages
+    assert result.data["has_more"] is False  # Unified format includes has_more
 
 
 @pytest.mark.asyncio
@@ -100,7 +103,7 @@ async def test_with_bearer_token(test_server):
         set_request_token("test-token")
 
         result = await client.call_tool(
-            "search_messages", {"query": "test", "limit": 5}
+            "search_messages_globally", {"query": "test", "limit": 5}
         )
 
         assert result.data is not None

--- a/tests/test_decorator_order_fix.py
+++ b/tests/test_decorator_order_fix.py
@@ -89,41 +89,6 @@ class TestDecoratorOrderFix:
             )
 
     @pytest.mark.asyncio
-    async def test_token_extraction_works_correctly(self, http_auth_config):
-        """Test that token extraction from HTTP headers works correctly."""
-
-        with patch("fastmcp.server.dependencies.get_http_headers") as mock_headers:
-            test_token = "ExtractionTestToken123"
-            mock_headers.return_value = {"authorization": f"Bearer {test_token}"}
-
-            # Test token extraction
-            extracted_token = extract_bearer_token()
-
-            assert extracted_token == test_token, (
-                f"Expected {test_token}, got {extracted_token}"
-            )
-
-    @pytest.mark.asyncio
-    async def test_context_token_setting_works(self):
-        """Test that setting tokens in context works correctly."""
-
-        test_token = "ContextTestToken123"
-
-        # Set token in context
-        set_request_token(test_token)
-
-        # Verify it's set
-        current_token = _current_token.get()
-        assert current_token == test_token, (
-            f"Expected {test_token}, got {current_token}"
-        )
-
-        # Test setting None (fallback behavior)
-        set_request_token(None)
-        current_token = _current_token.get()
-        assert current_token is None, "Expected None, got {current_token}"
-
-    @pytest.mark.asyncio
     async def test_http_mode_requires_authentication(self, http_auth_config):
         """Test that HTTP mode requires authentication when no token is provided."""
 
@@ -158,26 +123,6 @@ class TestDecoratorOrderFix:
             )
             assert result["token"] is None, "Token should be None (default session)"
             return None
-
-    @pytest.mark.asyncio
-    async def test_decorator_order_verification(self):
-        """Test that verifies the tool registration exposes expected tools."""
-
-        from fastmcp import Client, FastMCP
-
-        from src.server_components.tools_register import register_tools
-
-        temp_mcp = FastMCP("Temp Server")
-        register_tools(temp_mcp)
-
-        async with Client(temp_mcp) as client:
-            tools = await client.list_tools()
-            names = [t.name for t in tools]
-            assert "search_messages_globally" in names
-            assert "get_messages" in names
-            assert "send_message" in names
-            assert "edit_message" in names
-            assert "find_chats" in names
 
     @pytest.mark.asyncio
     async def test_original_issue_reproduction_and_fix(self, http_auth_config):

--- a/tests/test_decorator_order_fix.py
+++ b/tests/test_decorator_order_fix.py
@@ -174,10 +174,9 @@ class TestDecoratorOrderFix:
             tools = await client.list_tools()
             names = [t.name for t in tools]
             assert "search_messages_globally" in names
-            assert "search_messages_in_chat" in names
+            assert "get_messages" in names
             assert "send_message" in names
             assert "edit_message" in names
-            assert "read_messages" in names
             assert "find_chats" in names
 
     @pytest.mark.asyncio

--- a/tests/test_fastmcp_decorator_integration.py
+++ b/tests/test_fastmcp_decorator_integration.py
@@ -159,6 +159,49 @@ class TestFastMCPToolIntegration:
         assert "edit_message" in names
         assert "find_chats" in names
 
+    def test_get_messages_tool_schema(self):
+        """Verify get_messages tool exposes new parameters correctly."""
+        from fastmcp import Client, FastMCP
+
+        from src.server_components.tools_register import register_tools
+
+        temp_mcp = FastMCP("Temp Server")
+        register_tools(temp_mcp)
+
+        async def get_tool_schema():
+            async with Client(temp_mcp) as client:
+                tools = await client.list_tools()
+                get_messages_tool = next(
+                    t for t in tools if t.name == "get_messages"
+                )
+                return get_messages_tool.inputSchema
+
+        schema = asyncio.run(get_tool_schema())
+
+        # Verify schema structure
+        assert schema["type"] == "object"
+        properties = schema["properties"]
+
+        # New parameters: message_ids and post_id
+        assert "message_ids" in properties
+        message_ids_schema = properties["message_ids"]
+        assert "array" in str(
+            message_ids_schema.get("type", message_ids_schema.get("anyOf", []))
+        )
+
+        assert "post_id" in properties
+        post_id_schema = properties["post_id"]
+        assert "integer" in str(
+            post_id_schema.get("type", post_id_schema.get("anyOf", []))
+        )
+
+        # Existing parameters remain
+        assert "chat_id" in properties
+        assert "query" in properties
+        assert "limit" in properties
+        assert "auto_expand_batches" in properties
+        assert "include_total_count" in properties
+
 
 class TestEndToEndTokenFlow:
     """Test the complete token flow from HTTP request to session management."""

--- a/tests/test_fastmcp_decorator_integration.py
+++ b/tests/test_fastmcp_decorator_integration.py
@@ -182,17 +182,17 @@ class TestFastMCPToolIntegration:
         assert schema["type"] == "object"
         properties = schema["properties"]
 
-        # New parameters: message_ids and post_id
+        # New parameters: message_ids and reply_to_id
         assert "message_ids" in properties
         message_ids_schema = properties["message_ids"]
         assert "array" in str(
             message_ids_schema.get("type", message_ids_schema.get("anyOf", []))
         )
 
-        assert "post_id" in properties
-        post_id_schema = properties["post_id"]
+        assert "reply_to_id" in properties
+        reply_to_id_schema = properties["reply_to_id"]
         assert "integer" in str(
-            post_id_schema.get("type", post_id_schema.get("anyOf", []))
+            reply_to_id_schema.get("type", reply_to_id_schema.get("anyOf", []))
         )
 
         # Existing parameters remain

--- a/tests/test_fastmcp_decorator_integration.py
+++ b/tests/test_fastmcp_decorator_integration.py
@@ -154,10 +154,9 @@ class TestFastMCPToolIntegration:
 
         names = asyncio.run(list_names())
         assert "search_messages_globally" in names
-        assert "search_messages_in_chat" in names
+        assert "get_messages" in names
         assert "send_message" in names
         assert "edit_message" in names
-        assert "read_messages" in names
         assert "find_chats" in names
 
 
@@ -225,10 +224,9 @@ class TestDecoratorOrderRegression:
 
         names = asyncio.run(list_names())
         assert "search_messages_globally" in names
-        assert "search_messages_in_chat" in names
+        assert "get_messages" in names
         assert "send_message" in names
         assert "edit_message" in names
-        assert "read_messages" in names
         assert "find_chats" in names
 
         print(

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -3,8 +3,9 @@ Tests for the unified get_messages tool and its various modes.
 
 Tests cover:
 - Parameter conflict validation
-- Mode-specific functionality (search, browse, read by IDs, post comments)
-- Backward compatibility with read_messages and search_messages_in_chat
+- Mode-specific functionality (search, browse, read by IDs, replies)
+- Empty parameter edge cases
+- Error handling for all modes
 """
 
 import pytest
@@ -216,14 +217,14 @@ class TestGetMessagesRepliesErrors:
     @pytest.mark.asyncio
     @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
     @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
-    @patch("src.tools.search._fetch_post_comments", new_callable=AsyncMock)
+    @patch("src.tools.search._fetch_replies", new_callable=AsyncMock)
     async def test_fetch_replies_failure_returns_error(
-        self, mock_fetch_comments, mock_get_entity, mock_get_client
+        self, mock_fetch_replies, mock_get_entity, mock_get_client
     ):
         """Should return error when fetching replies raises."""
         mock_get_client.return_value = AsyncMock()
         mock_get_entity.return_value = Mock()
-        mock_fetch_comments.side_effect = RuntimeError("network error")
+        mock_fetch_replies.side_effect = RuntimeError("network error")
 
         result = await search_messages_impl(
             chat_id="me",

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -1,0 +1,342 @@
+"""
+Tests for the unified get_messages tool and its various modes.
+
+Tests cover:
+- Parameter conflict validation
+- Mode-specific functionality (search, browse, read by IDs, post comments)
+- Backward compatibility with read_messages and search_messages_in_chat
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from src.tools.search import search_messages_impl
+
+
+class TestGetMessagesParameterConflicts:
+    """Test parameter conflict validation."""
+
+    @pytest.mark.asyncio
+    async def test_message_ids_and_post_id_conflict(self):
+        """Should reject message_ids + post_id combination."""
+        result = await search_messages_impl(
+            chat_id="me",
+            message_ids=[1, 2, 3],
+            post_id=100,
+        )
+
+        assert "error" in result
+        assert "Cannot combine message_ids with post_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_message_ids_and_query_conflict(self):
+        """Should reject message_ids + query combination."""
+        result = await search_messages_impl(
+            chat_id="me",
+            message_ids=[1, 2, 3],
+            query="test",
+        )
+
+        assert "error" in result
+        assert "Cannot combine message_ids with query" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_message_ids_requires_chat_id(self):
+        """Should require chat_id when using message_ids."""
+        result = await search_messages_impl(
+            message_ids=[1, 2, 3],
+        )
+
+        assert "error" in result
+        assert "chat_id is required" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_post_id_requires_chat_id(self):
+        """Should require chat_id when using post_id."""
+        result = await search_messages_impl(
+            post_id=100,
+        )
+
+        assert "error" in result
+        assert "chat_id is required" in result["error"]
+
+
+class TestGetMessagesReadByIds:
+    """Test read by message IDs mode."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.read_messages_by_ids")
+    async def test_delegates_to_read_messages_by_ids(self, mock_read):
+        """Should delegate to read_messages_by_ids when message_ids provided."""
+        mock_read.return_value = [
+            {"id": 1, "text": "Message 1"},
+            {"id": 2, "text": "Message 2"},
+        ]
+
+        result = await search_messages_impl(
+            chat_id="me",
+            message_ids=[1, 2],
+        )
+
+        mock_read.assert_called_once_with("me", [1, 2])
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.read_messages_by_ids")
+    async def test_message_ids_ignores_other_params(self, mock_read):
+        """Should ignore limit/date filters when using message_ids."""
+        mock_read.return_value = [{"id": 1, "text": "Message"}]
+
+        await search_messages_impl(
+            chat_id="me",
+            message_ids=[1],
+            limit=100,
+            min_date="2024-01-01",
+        )
+
+        # Should call with only chat_id and message_ids
+        mock_read.assert_called_once_with("me", [1])
+
+
+class TestGetMessagesPostComments:
+    """Test post comments mode."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client")
+    @patch("src.tools.search.get_entity_by_id")
+    @patch("src.tools.search._fetch_post_comments")
+    async def test_fetches_post_comments(
+        self, mock_fetch_comments, mock_get_entity, mock_get_client
+    ):
+        """Should fetch post comments when post_id provided."""
+        # Setup mocks
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_entity = Mock()
+        mock_get_entity.return_value = mock_entity
+
+        mock_fetch_comments.return_value = (
+            [
+                {"id": 1, "text": "Comment 1"},
+                {"id": 2, "text": "Comment 2"},
+            ],
+            {
+                "discussion_chat_id": "-1001234567890",
+                "discussion_total_count": 10,
+                "linked_post_id": 100,
+            },
+        )
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+            limit=50,
+        )
+
+        # Verify fetch was called correctly
+        mock_fetch_comments.assert_called_once_with(
+            mock_client, mock_entity, 100, 50, None
+        )
+
+        # Verify response structure
+        assert "messages" in result
+        assert "has_more" in result
+        assert "discussion_chat_id" in result
+        assert "discussion_total_count" in result
+        assert "linked_post_id" in result
+
+        assert len(result["messages"]) == 2
+        assert result["discussion_chat_id"] == "-1001234567890"
+        assert result["linked_post_id"] == 100
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client")
+    @patch("src.tools.search.get_entity_by_id")
+    @patch("src.tools.search._fetch_post_comments")
+    async def test_search_in_post_comments(
+        self, mock_fetch_comments, mock_get_entity, mock_get_client
+    ):
+        """Should search within post comments when both post_id and query provided."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_entity = Mock()
+        mock_get_entity.return_value = mock_entity
+
+        mock_fetch_comments.return_value = (
+            [{"id": 1, "text": "Bug report"}],
+            {
+                "discussion_chat_id": "-1001234567890",
+                "discussion_total_count": 5,
+                "linked_post_id": 100,
+            },
+        )
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+            query="bug",
+            limit=20,
+        )
+
+        # Verify search query was passed to fetch
+        mock_fetch_comments.assert_called_once_with(
+            mock_client, mock_entity, 100, 20, "bug"
+        )
+
+        assert len(result["messages"]) == 1
+        assert "bug" in result["messages"][0]["text"].lower()
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client")
+    @patch("src.tools.search.get_entity_by_id")
+    @patch("src.tools.search._fetch_post_comments")
+    async def test_no_comments_error(
+        self, mock_fetch_comments, mock_get_entity, mock_get_client
+    ):
+        """Should return error when no comments found."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_entity = Mock()
+        mock_get_entity.return_value = mock_entity
+
+        # Empty comments
+        mock_fetch_comments.return_value = (
+            [],
+            {
+                "discussion_chat_id": "-1001234567890",
+                "discussion_total_count": 0,
+                "linked_post_id": 100,
+            },
+        )
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+        )
+
+        assert "error" in result
+        assert "No comments found" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client")
+    @patch("src.tools.search.get_entity_by_id")
+    async def test_invalid_chat_for_post_comments(
+        self, mock_get_entity, mock_get_client
+    ):
+        """Should return error when chat not found."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_get_entity.return_value = None  # Chat not found
+
+        result = await search_messages_impl(
+            chat_id="invalid_chat",
+            post_id=100,
+        )
+
+        assert "error" in result
+        assert "Could not find chat" in result["error"]
+
+
+class TestGetMessagesHasMoreLogic:
+    """Test has_more flag logic for post comments."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client")
+    @patch("src.tools.search.get_entity_by_id")
+    @patch("src.tools.search._fetch_post_comments")
+    async def test_has_more_when_extra_message_collected(
+        self, mock_fetch_comments, mock_get_entity, mock_get_client
+    ):
+        """Should set has_more=True when collected limit+1 messages."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_entity = Mock()
+        mock_get_entity.return_value = mock_entity
+
+        # Return limit+1 messages
+        mock_fetch_comments.return_value = (
+            [
+                {"id": i, "text": f"Comment {i}"} for i in range(11)
+            ],  # 11 messages for limit=10
+            {
+                "discussion_chat_id": "-1001234567890",
+                "discussion_total_count": 20,
+                "linked_post_id": 100,
+            },
+        )
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+            limit=10,
+        )
+
+        assert len(result["messages"]) == 10  # Windowed to limit
+        assert result["has_more"] is True
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client")
+    @patch("src.tools.search.get_entity_by_id")
+    @patch("src.tools.search._fetch_post_comments")
+    async def test_has_more_false_when_fewer_than_limit(
+        self, mock_fetch_comments, mock_get_entity, mock_get_client
+    ):
+        """Should set has_more=False when collected fewer than limit messages."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_entity = Mock()
+        mock_get_entity.return_value = mock_entity
+
+        # Return fewer than limit
+        mock_fetch_comments.return_value = (
+            [{"id": i, "text": f"Comment {i}"} for i in range(5)],  # 5 messages
+            {
+                "discussion_chat_id": "-1001234567890",
+                "discussion_total_count": 5,
+                "linked_post_id": 100,
+            },
+        )
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+            limit=10,
+        )
+
+        assert len(result["messages"]) == 5
+        assert result["has_more"] is False
+
+
+class TestBackwardCompatibility:
+    """Test backward compatibility with old tool names."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.read_messages_by_ids")
+    async def test_read_messages_mode_works(self, mock_read):
+        """read_messages functionality should work through get_messages."""
+        mock_read.return_value = [{"id": 1, "text": "Message"}]
+
+        result = await search_messages_impl(
+            chat_id="me",
+            message_ids=[1],
+        )
+
+        mock_read.assert_called_once()
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_search_in_chat_mode_requires_query_or_empty(self):
+        """search_messages_in_chat functionality should work with or without query."""
+        # This tests that chat_id alone doesn't error (browse mode)
+        # We'll test with global search error to verify logic path
+        result = await search_messages_impl()
+
+        assert "error" in result
+        assert "global search" in result["error"].lower()

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -259,58 +259,6 @@ class TestGetMessagesPostCommentsErrors:
         assert "Could not find chat" in result["error"]
 
 
-class TestGetMessagesPostCommentsOld:
-    """Old post comments tests (to be removed after migration)."""
-
-    @pytest.mark.asyncio
-    @patch("src.tools.search.get_connected_client")
-    @patch("src.tools.search.get_entity_by_id")
-    @patch("src.tools.search._fetch_post_comments")
-    async def test_fetches_post_comments_old(
-        self, mock_fetch_comments, mock_get_entity, mock_get_client
-    ):
-        """Should fetch post comments when post_id provided."""
-        # Setup mocks
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
-
-        mock_entity = Mock()
-        mock_get_entity.return_value = mock_entity
-
-        mock_fetch_comments.return_value = (
-            [
-                {"id": 1, "text": "Comment 1"},
-                {"id": 2, "text": "Comment 2"},
-            ],
-            {
-                "discussion_chat_id": "-1001234567890",
-                "discussion_total_count": 10,
-                "linked_post_id": 100,
-            },
-        )
-
-        result = await search_messages_impl(
-            chat_id="-1001111111111",
-            post_id=100,
-            limit=50,
-        )
-
-        # Verify fetch was called correctly
-        mock_fetch_comments.assert_called_once_with(
-            mock_client, mock_entity, 100, 50, None
-        )
-
-        # Verify response structure
-        assert "messages" in result
-        assert "has_more" in result
-        assert "discussion_chat_id" in result
-        assert "discussion_total_count" in result
-        assert "linked_post_id" in result
-
-        assert len(result["messages"]) == 2
-        assert result["discussion_chat_id"] == "-1001234567890"
-        assert result["linked_post_id"] == 100
-
 class TestGetMessagesSuccessPaths:
     """Test successful execution paths for different modes."""
 

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -65,7 +65,7 @@ class TestGetMessagesReadByIds:
     """Test read by message IDs mode."""
 
     @pytest.mark.asyncio
-    @patch("src.tools.search.read_messages_by_ids")
+    @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
     async def test_delegates_to_read_messages_by_ids(self, mock_read):
         """Should delegate to read_messages_by_ids when message_ids provided."""
         mock_read.return_value = [
@@ -79,16 +79,19 @@ class TestGetMessagesReadByIds:
         )
 
         mock_read.assert_called_once_with("me", [1, 2])
-        assert isinstance(result, list)
-        assert len(result) == 2
+        assert isinstance(result, dict)
+        assert "messages" in result
+        assert "has_more" in result
+        assert len(result["messages"]) == 2
+        assert result["has_more"] is False
 
     @pytest.mark.asyncio
-    @patch("src.tools.search.read_messages_by_ids")
+    @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
     async def test_message_ids_ignores_other_params(self, mock_read):
         """Should ignore limit/date filters when using message_ids."""
         mock_read.return_value = [{"id": 1, "text": "Message"}]
 
-        await search_messages_impl(
+        result = await search_messages_impl(
             chat_id="me",
             message_ids=[1],
             limit=100,
@@ -97,16 +100,152 @@ class TestGetMessagesReadByIds:
 
         # Should call with only chat_id and message_ids
         mock_read.assert_called_once_with("me", [1])
+        assert isinstance(result, dict)
+        assert result["has_more"] is False
 
 
 class TestGetMessagesPostComments:
     """Test post comments mode."""
 
     @pytest.mark.asyncio
+    @patch("src.tools.search._handle_post_comments_mode", new_callable=AsyncMock)
+    async def test_fetches_post_comments(self, mock_handler):
+        """Should delegate to post comments handler when post_id provided."""
+        mock_handler.return_value = {
+            "messages": [
+                {"id": 1, "text": "Comment 1"},
+                {"id": 2, "text": "Comment 2"},
+            ],
+            "has_more": False,
+            "discussion_chat_id": "-1001234567890",
+            "discussion_total_count": 10,
+            "linked_post_id": 100,
+        }
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+            limit=50,
+        )
+
+        # Verify handler was called correctly
+        mock_handler.assert_called_once()
+        call_args = mock_handler.call_args
+        assert call_args[0][0] == "-1001111111111"  # chat_id
+        assert call_args[0][1] == 100  # post_id
+        assert call_args[0][2] == 50  # limit
+        assert call_args[0][3] is None  # query
+
+        # Verify response structure
+        assert "messages" in result
+        assert "has_more" in result
+        assert "discussion_chat_id" in result
+        assert len(result["messages"]) == 2
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search._handle_post_comments_mode", new_callable=AsyncMock)
+    async def test_search_in_post_comments(self, mock_handler):
+        """Should pass query to handler when both post_id and query provided."""
+        mock_handler.return_value = {
+            "messages": [{"id": 1, "text": "Bug report"}],
+            "has_more": False,
+            "discussion_chat_id": "-1001234567890",
+            "discussion_total_count": 5,
+            "linked_post_id": 100,
+        }
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+            query="bug",
+            limit=20,
+        )
+
+        # Verify query was passed
+        call_args = mock_handler.call_args
+        assert call_args[0][3] == "bug"  # query
+        assert len(result["messages"]) == 1
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search._handle_post_comments_mode", new_callable=AsyncMock)
+    async def test_no_comments_error(self, mock_handler):
+        """Should return error when no comments found."""
+        mock_handler.return_value = {
+            "error": "No comments found for post 100",
+            "ok": False,
+        }
+
+        result = await search_messages_impl(
+            chat_id="-1001111111111",
+            post_id=100,
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_chat_for_post_comments(self):
+        """Should return error when chat_id missing for post_id."""
+        result = await search_messages_impl(
+            post_id=100,
+        )
+
+        assert "error" in result
+        assert "chat_id is required" in result["error"]
+
+
+class TestGetMessagesPostCommentsErrors:
+    """Error paths for post comments mode."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search._fetch_post_comments", new_callable=AsyncMock)
+    async def test_fetch_post_comments_failure_returns_error(
+        self, mock_fetch_comments, mock_get_entity, mock_get_client
+    ):
+        """Should return error when fetching post comments raises."""
+        mock_get_client.return_value = AsyncMock()
+        mock_get_entity.return_value = Mock()
+        mock_fetch_comments.side_effect = RuntimeError("network error")
+
+        result = await search_messages_impl(
+            chat_id="me",
+            post_id=123,
+            limit=50,
+        )
+
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "Failed to fetch comments" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    async def test_invalid_entity_for_post_comments(
+        self, mock_get_entity, mock_get_client
+    ):
+        """Should return error when entity not found."""
+        mock_get_client.return_value = AsyncMock()
+        mock_get_entity.return_value = None
+
+        result = await search_messages_impl(
+            chat_id="invalid_chat",
+            post_id=100,
+        )
+
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "Could not find chat" in result["error"]
+
+
+class TestGetMessagesPostCommentsOld:
+    """Old post comments tests (to be removed after migration)."""
+
+    @pytest.mark.asyncio
     @patch("src.tools.search.get_connected_client")
     @patch("src.tools.search.get_entity_by_id")
     @patch("src.tools.search._fetch_post_comments")
-    async def test_fetches_post_comments(
+    async def test_fetches_post_comments_old(
         self, mock_fetch_comments, mock_get_entity, mock_get_client
     ):
         """Should fetch post comments when post_id provided."""
@@ -151,176 +290,13 @@ class TestGetMessagesPostComments:
         assert result["discussion_chat_id"] == "-1001234567890"
         assert result["linked_post_id"] == 100
 
-    @pytest.mark.asyncio
-    @patch("src.tools.search.get_connected_client")
-    @patch("src.tools.search.get_entity_by_id")
-    @patch("src.tools.search._fetch_post_comments")
-    async def test_search_in_post_comments(
-        self, mock_fetch_comments, mock_get_entity, mock_get_client
-    ):
-        """Should search within post comments when both post_id and query provided."""
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
-
-        mock_entity = Mock()
-        mock_get_entity.return_value = mock_entity
-
-        mock_fetch_comments.return_value = (
-            [{"id": 1, "text": "Bug report"}],
-            {
-                "discussion_chat_id": "-1001234567890",
-                "discussion_total_count": 5,
-                "linked_post_id": 100,
-            },
-        )
-
-        result = await search_messages_impl(
-            chat_id="-1001111111111",
-            post_id=100,
-            query="bug",
-            limit=20,
-        )
-
-        # Verify search query was passed to fetch
-        mock_fetch_comments.assert_called_once_with(
-            mock_client, mock_entity, 100, 20, "bug"
-        )
-
-        assert len(result["messages"]) == 1
-        assert "bug" in result["messages"][0]["text"].lower()
-
-    @pytest.mark.asyncio
-    @patch("src.tools.search.get_connected_client")
-    @patch("src.tools.search.get_entity_by_id")
-    @patch("src.tools.search._fetch_post_comments")
-    async def test_no_comments_error(
-        self, mock_fetch_comments, mock_get_entity, mock_get_client
-    ):
-        """Should return error when no comments found."""
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
-
-        mock_entity = Mock()
-        mock_get_entity.return_value = mock_entity
-
-        # Empty comments
-        mock_fetch_comments.return_value = (
-            [],
-            {
-                "discussion_chat_id": "-1001234567890",
-                "discussion_total_count": 0,
-                "linked_post_id": 100,
-            },
-        )
-
-        result = await search_messages_impl(
-            chat_id="-1001111111111",
-            post_id=100,
-        )
-
-        assert "error" in result
-        assert "No comments found" in result["error"]
-
-    @pytest.mark.asyncio
-    @patch("src.tools.search.get_connected_client")
-    @patch("src.tools.search.get_entity_by_id")
-    async def test_invalid_chat_for_post_comments(
-        self, mock_get_entity, mock_get_client
-    ):
-        """Should return error when chat not found."""
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
-
-        mock_get_entity.return_value = None  # Chat not found
-
-        result = await search_messages_impl(
-            chat_id="invalid_chat",
-            post_id=100,
-        )
-
-        assert "error" in result
-        assert "Could not find chat" in result["error"]
-
-
-class TestGetMessagesHasMoreLogic:
-    """Test has_more flag logic for post comments."""
-
-    @pytest.mark.asyncio
-    @patch("src.tools.search.get_connected_client")
-    @patch("src.tools.search.get_entity_by_id")
-    @patch("src.tools.search._fetch_post_comments")
-    async def test_has_more_when_extra_message_collected(
-        self, mock_fetch_comments, mock_get_entity, mock_get_client
-    ):
-        """Should set has_more=True when collected limit+1 messages."""
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
-
-        mock_entity = Mock()
-        mock_get_entity.return_value = mock_entity
-
-        # Return limit+1 messages
-        mock_fetch_comments.return_value = (
-            [
-                {"id": i, "text": f"Comment {i}"} for i in range(11)
-            ],  # 11 messages for limit=10
-            {
-                "discussion_chat_id": "-1001234567890",
-                "discussion_total_count": 20,
-                "linked_post_id": 100,
-            },
-        )
-
-        result = await search_messages_impl(
-            chat_id="-1001111111111",
-            post_id=100,
-            limit=10,
-        )
-
-        assert len(result["messages"]) == 10  # Windowed to limit
-        assert result["has_more"] is True
-
-    @pytest.mark.asyncio
-    @patch("src.tools.search.get_connected_client")
-    @patch("src.tools.search.get_entity_by_id")
-    @patch("src.tools.search._fetch_post_comments")
-    async def test_has_more_false_when_fewer_than_limit(
-        self, mock_fetch_comments, mock_get_entity, mock_get_client
-    ):
-        """Should set has_more=False when collected fewer than limit messages."""
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
-
-        mock_entity = Mock()
-        mock_get_entity.return_value = mock_entity
-
-        # Return fewer than limit
-        mock_fetch_comments.return_value = (
-            [{"id": i, "text": f"Comment {i}"} for i in range(5)],  # 5 messages
-            {
-                "discussion_chat_id": "-1001234567890",
-                "discussion_total_count": 5,
-                "linked_post_id": 100,
-            },
-        )
-
-        result = await search_messages_impl(
-            chat_id="-1001111111111",
-            post_id=100,
-            limit=10,
-        )
-
-        assert len(result["messages"]) == 5
-        assert result["has_more"] is False
-
-
 class TestBackwardCompatibility:
-    """Test backward compatibility with old tool names."""
+    """Test backward compatibility with message_ids mode."""
 
     @pytest.mark.asyncio
-    @patch("src.tools.search.read_messages_by_ids")
+    @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
     async def test_read_messages_mode_works(self, mock_read):
-        """read_messages functionality should work through get_messages."""
+        """message_ids mode should return unified dict format."""
         mock_read.return_value = [{"id": 1, "text": "Message"}]
 
         result = await search_messages_impl(
@@ -329,7 +305,10 @@ class TestBackwardCompatibility:
         )
 
         mock_read.assert_called_once()
-        assert isinstance(result, list)
+        assert isinstance(result, dict)
+        assert "messages" in result
+        assert "has_more" in result
+        assert result["has_more"] is False
 
     @pytest.mark.asyncio
     async def test_search_in_chat_mode_requires_query_or_empty(self):

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -17,16 +17,16 @@ class TestGetMessagesParameterConflicts:
     """Test parameter conflict validation."""
 
     @pytest.mark.asyncio
-    async def test_message_ids_and_post_id_conflict(self):
-        """Should reject message_ids + post_id combination."""
+    async def test_message_ids_and_reply_to_id_conflict(self):
+        """Should reject message_ids + reply_to_id combination."""
         result = await search_messages_impl(
             chat_id="me",
             message_ids=[1, 2, 3],
-            post_id=100,
+            reply_to_id=100,
         )
 
         assert "error" in result
-        assert "Cannot combine message_ids with post_id" in result["error"]
+        assert "Cannot combine message_ids with reply_to_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_message_ids_and_query_conflict(self):
@@ -51,10 +51,10 @@ class TestGetMessagesParameterConflicts:
         assert "chat_id is required" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_post_id_requires_chat_id(self):
-        """Should require chat_id when using post_id."""
+    async def test_reply_to_id_requires_chat_id(self):
+        """Should require chat_id when using reply_to_id."""
         result = await search_messages_impl(
-            post_id=100,
+            reply_to_id=100,
         )
 
         assert "error" in result
@@ -125,27 +125,25 @@ class TestGetMessagesReadByIds:
         assert "messages" not in result
 
 
-class TestGetMessagesPostComments:
-    """Test post comments mode."""
+class TestGetMessagesReplies:
+    """Test replies mode (post comments, forum topics, message replies)."""
 
     @pytest.mark.asyncio
-    @patch("src.tools.search._handle_post_comments_mode", new_callable=AsyncMock)
-    async def test_fetches_post_comments(self, mock_handler):
-        """Should delegate to post comments handler when post_id provided."""
+    @patch("src.tools.search._handle_replies_mode", new_callable=AsyncMock)
+    async def test_fetches_replies(self, mock_handler):
+        """Should delegate to replies handler when reply_to_id provided."""
         mock_handler.return_value = {
             "messages": [
-                {"id": 1, "text": "Comment 1"},
-                {"id": 2, "text": "Comment 2"},
+                {"id": 1, "text": "Reply 1"},
+                {"id": 2, "text": "Reply 2"},
             ],
             "has_more": False,
-            "discussion_chat_id": "-1001234567890",
-            "discussion_total_count": 10,
-            "linked_post_id": 100,
+            "reply_to_id": 100,
         }
 
         result = await search_messages_impl(
             chat_id="-1001111111111",
-            post_id=100,
+            reply_to_id=100,
             limit=50,
         )
 
@@ -153,31 +151,29 @@ class TestGetMessagesPostComments:
         mock_handler.assert_called_once()
         call_args = mock_handler.call_args
         assert call_args[0][0] == "-1001111111111"  # chat_id
-        assert call_args[0][1] == 100  # post_id
+        assert call_args[0][1] == 100  # reply_to_id
         assert call_args[0][2] == 50  # limit
         assert call_args[0][3] is None  # query
 
         # Verify response structure
         assert "messages" in result
         assert "has_more" in result
-        assert "discussion_chat_id" in result
+        assert "reply_to_id" in result
         assert len(result["messages"]) == 2
 
     @pytest.mark.asyncio
-    @patch("src.tools.search._handle_post_comments_mode", new_callable=AsyncMock)
-    async def test_search_in_post_comments(self, mock_handler):
-        """Should pass query to handler when both post_id and query provided."""
+    @patch("src.tools.search._handle_replies_mode", new_callable=AsyncMock)
+    async def test_search_in_replies(self, mock_handler):
+        """Should pass query to handler when both reply_to_id and query provided."""
         mock_handler.return_value = {
             "messages": [{"id": 1, "text": "Bug report"}],
             "has_more": False,
-            "discussion_chat_id": "-1001234567890",
-            "discussion_total_count": 5,
-            "linked_post_id": 100,
+            "reply_to_id": 100,
         }
 
         result = await search_messages_impl(
             chat_id="-1001111111111",
-            post_id=100,
+            reply_to_id=100,
             query="bug",
             limit=20,
         )
@@ -188,61 +184,61 @@ class TestGetMessagesPostComments:
         assert len(result["messages"]) == 1
 
     @pytest.mark.asyncio
-    @patch("src.tools.search._handle_post_comments_mode", new_callable=AsyncMock)
-    async def test_no_comments_error(self, mock_handler):
-        """Should return error when no comments found."""
+    @patch("src.tools.search._handle_replies_mode", new_callable=AsyncMock)
+    async def test_no_replies_error(self, mock_handler):
+        """Should return error when no replies found."""
         mock_handler.return_value = {
-            "error": "No comments found for post 100",
+            "error": "No replies found for message 100",
             "ok": False,
         }
 
         result = await search_messages_impl(
             chat_id="-1001111111111",
-            post_id=100,
+            reply_to_id=100,
         )
 
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_invalid_chat_for_post_comments(self):
-        """Should return error when chat_id missing for post_id."""
+    async def test_invalid_chat_for_replies(self):
+        """Should return error when chat_id missing for reply_to_id."""
         result = await search_messages_impl(
-            post_id=100,
+            reply_to_id=100,
         )
 
         assert "error" in result
         assert "chat_id is required" in result["error"]
 
 
-class TestGetMessagesPostCommentsErrors:
-    """Error paths for post comments mode."""
+class TestGetMessagesRepliesErrors:
+    """Error paths for replies mode."""
 
     @pytest.mark.asyncio
     @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
     @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
     @patch("src.tools.search._fetch_post_comments", new_callable=AsyncMock)
-    async def test_fetch_post_comments_failure_returns_error(
+    async def test_fetch_replies_failure_returns_error(
         self, mock_fetch_comments, mock_get_entity, mock_get_client
     ):
-        """Should return error when fetching post comments raises."""
+        """Should return error when fetching replies raises."""
         mock_get_client.return_value = AsyncMock()
         mock_get_entity.return_value = Mock()
         mock_fetch_comments.side_effect = RuntimeError("network error")
 
         result = await search_messages_impl(
             chat_id="me",
-            post_id=123,
+            reply_to_id=123,
             limit=50,
         )
 
         assert isinstance(result, dict)
         assert "error" in result
-        assert "Failed to fetch comments" in result["error"]
+        assert "Failed to fetch replies" in result["error"]
 
     @pytest.mark.asyncio
     @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
     @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
-    async def test_invalid_entity_for_post_comments(
+    async def test_invalid_entity_for_replies(
         self, mock_get_entity, mock_get_client
     ):
         """Should return error when entity not found."""
@@ -251,7 +247,7 @@ class TestGetMessagesPostCommentsErrors:
 
         result = await search_messages_impl(
             chat_id="invalid_chat",
-            post_id=100,
+            reply_to_id=100,
         )
 
         assert isinstance(result, dict)

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -103,6 +103,27 @@ class TestGetMessagesReadByIds:
         assert isinstance(result, dict)
         assert result["has_more"] is False
 
+    @pytest.mark.asyncio
+    @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
+    async def test_returns_error_when_read_messages_by_ids_returns_error(
+        self, mock_read
+    ):
+        """Should return raw error dict when read_messages_by_ids returns error."""
+        mock_read.return_value = [{"error": "Message not found", "ok": False}]
+
+        result = await search_messages_impl(
+            chat_id="me",
+            message_ids=[999],
+        )
+
+        mock_read.assert_called_once_with("me", [999])
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert result["error"] == "Message not found"
+        assert result["ok"] is False
+        # Should NOT be wrapped in {"messages": ...}
+        assert "messages" not in result
+
 
 class TestGetMessagesPostComments:
     """Test post comments mode."""
@@ -290,12 +311,12 @@ class TestGetMessagesPostCommentsOld:
         assert result["discussion_chat_id"] == "-1001234567890"
         assert result["linked_post_id"] == 100
 
-class TestBackwardCompatibility:
-    """Test backward compatibility with message_ids mode."""
+class TestGetMessagesSuccessPaths:
+    """Test successful execution paths for different modes."""
 
     @pytest.mark.asyncio
     @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
-    async def test_read_messages_mode_works(self, mock_read):
+    async def test_message_ids_mode_success(self, mock_read):
         """message_ids mode should return unified dict format."""
         mock_read.return_value = [{"id": 1, "text": "Message"}]
 
@@ -311,10 +332,8 @@ class TestBackwardCompatibility:
         assert result["has_more"] is False
 
     @pytest.mark.asyncio
-    async def test_search_in_chat_mode_requires_query_or_empty(self):
-        """search_messages_in_chat functionality should work with or without query."""
-        # This tests that chat_id alone doesn't error (browse mode)
-        # We'll test with global search error to verify logic path
+    async def test_global_search_requires_query(self):
+        """Global search without query should return error."""
         result = await search_messages_impl()
 
         assert "error" in result


### PR DESCRIPTION
Consolidate message retrieval tools into a single `get_messages` API and add support for reading post comments to simplify the API surface and enhance functionality.

The existing API had separate tools for searching and reading specific messages, and no high-level tool for accessing post comments. This PR unifies these functionalities into a single, extensible `get_messages` tool, reducing cognitive load for LLMs and providing a clear path for future message-related features like discussion threads.

---
<p><a href="https://cursor.com/agents/bc-02fe93c6-e0b2-468b-b63e-b9e0e23a5e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02fe93c6-e0b2-468b-b63e-b9e0e23a5e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

Новые возможности:
- Добавлена поддержка получения и поиска комментариев к обсуждениям постов канала по `post_id` с возвратом связанной метаинформации об обсуждении.
- Предоставлен унифицированный инструмент `get_messages`, поддерживающий несколько режимов: поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по их ID и работа с комментариями к постам.

Улучшения:
- Логика получения сообщений переработана в центральную функцию `search_messages_impl` с явным выбором режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок `get_messages`.
- Повторно используется общий вспомогательный модуль для построения результатов сообщений и удалены неиспользуемые обёртки, что упрощает конвейеры чатового и глобального поиска.
- Обновлена регистрация серверных инструментов: теперь предоставляется `get_messages` вместо отдельных инструментов `search_messages_in_chat` и `read_messages` при сохранении семантики обратной совместимости.

Документация:
- Задокументирован новый API `get_messages` в Tools-Reference, включая его режимы, ответы, конфликтующие параметры и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновлены рекомендации по поиску, README, документация о прогрессе memory-bank и активном контексте, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам.

Тесты:
- Добавлен отдельный набор тестов `test_get_messages`, покрывающий конфликт параметров, все режимы операций (поиск, просмотр, чтение по ID, комментарии к постам), обработку `has_more` и поведение для обеспечения обратной совместимости.
- Актуализированы существующие интеграционные тесты, чтобы проверять наличие `get_messages` вместо устаревших инструментов `search_messages_in_chat` и `read_messages`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

</details>

Новые возможности:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск, просмотр последних сообщений, чтение конкретных сообщений по их ID, а также работу с комментариями к постам каналов, включая поиск по комментариям.
- Добавить поддержку получения и поиска комментариев из тредов обсуждения постов каналов с возвратом связанной метаинформации об обсуждении, такой как `discussion_chat_id`, `discussion_total_count` и `linked_post_id`.

Улучшения:
- Централизовать логику получения сообщений в `search_messages_impl` с явным выбором режима, валидацией параметров и стандартизированной обработкой ошибок под общим именем операции `get_messages`.
- Упростить вспомогательные функции поиска, удалив неиспользуемые обёртки и полагаясь на реализации на основе генераторов для поиска по чату и глобального поиска.
- Обновить регистрацию серверных инструментов, чтобы предоставлять `get_messages` вместо отдельных инструментов `search_messages_in_chat` и `read_messages`, при этом сохранив совместимость базового поведения.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference, включая его режимы, конфликты параметров, структуру ответа и рекомендации по миграции с устаревших `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, README, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированный API для работы с сообщениями.

Тесты:
- Добавить отдельный набор тестов `test_get_messages`, покрывающий конфликты параметров, все режимы операций (поиск, просмотр, чтение по ID, комментарии к постам), обработку `has_more` и поведение для обеспечения обратной совместимости.
- Адаптировать существующие интеграционные тесты так, чтобы они ожидали новое имя инструмента `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

Новые возможности:
- Добавлена поддержка получения и поиска комментариев к обсуждениям постов канала по `post_id` с возвратом связанной метаинформации об обсуждении.
- Предоставлен унифицированный инструмент `get_messages`, поддерживающий несколько режимов: поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по их ID и работа с комментариями к постам.

Улучшения:
- Логика получения сообщений переработана в центральную функцию `search_messages_impl` с явным выбором режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок `get_messages`.
- Повторно используется общий вспомогательный модуль для построения результатов сообщений и удалены неиспользуемые обёртки, что упрощает конвейеры чатового и глобального поиска.
- Обновлена регистрация серверных инструментов: теперь предоставляется `get_messages` вместо отдельных инструментов `search_messages_in_chat` и `read_messages` при сохранении семантики обратной совместимости.

Документация:
- Задокументирован новый API `get_messages` в Tools-Reference, включая его режимы, ответы, конфликтующие параметры и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновлены рекомендации по поиску, README, документация о прогрессе memory-bank и активном контексте, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам.

Тесты:
- Добавлен отдельный набор тестов `test_get_messages`, покрывающий конфликт параметров, все режимы операций (поиск, просмотр, чтение по ID, комментарии к постам), обработку `has_more` и поведение для обеспечения обратной совместимости.
- Актуализированы существующие интеграционные тесты, чтобы проверять наличие `get_messages` вместо устаревших инструментов `search_messages_in_chat` и `read_messages`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

</details>

</details>

Новые возможности:
- Добавлена поддержка получения и поиска комментариев к обсуждению поста в канале через параметр `post_id`, с возвратом метаданных обсуждения, включая `discussion_chat_id`, `discussion_total_count` и `linked_post_id`.
- Предоставлен унифицированный инструмент `get_messages`, который поддерживает несколько режимов: поиск в чате, просмотр последних сообщений, чтение по конкретным ID и работа с комментариями к постам.

Улучшения:
- Централизована логика получения сообщений в `search_messages_impl`, включая проверку сочетаний параметров и более понятную отчётность об ошибках под единым именем операции `get_messages`.
- Обновлена регистрация серверных инструментов и документация, чтобы отразить новый унифицированный API, описать поддерживаемые режимы и конфликты, а также дать рекомендации по миграции с устаревших инструментов.

Документация:
- Обновлён файл `Tools-Reference.md` для документирования нового API `get_messages`, его режимов, структуры ответа и советов по использованию, а также для пометки `read_messages` и `search_messages_in_chat` как устаревших, с примерами миграции.
- Обновлена документация по memory-bank для фиксации введения `get_messages`, поддержки комментариев к постам и связанных изменений в поведении.

Тесты:
- Добавлен отдельный набор тестов `test_get_messages.py`, покрывающий обработку конфликтующих параметров, каждый режим операции (поиск, просмотр, чтение по ID, комментарии к постам), логику `has_more` и обратную совместимость с депрекейтед‑инструментами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

Новые возможности:
- Добавлена поддержка получения и поиска комментариев к обсуждениям постов канала по `post_id` с возвратом связанной метаинформации об обсуждении.
- Предоставлен унифицированный инструмент `get_messages`, поддерживающий несколько режимов: поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по их ID и работа с комментариями к постам.

Улучшения:
- Логика получения сообщений переработана в центральную функцию `search_messages_impl` с явным выбором режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок `get_messages`.
- Повторно используется общий вспомогательный модуль для построения результатов сообщений и удалены неиспользуемые обёртки, что упрощает конвейеры чатового и глобального поиска.
- Обновлена регистрация серверных инструментов: теперь предоставляется `get_messages` вместо отдельных инструментов `search_messages_in_chat` и `read_messages` при сохранении семантики обратной совместимости.

Документация:
- Задокументирован новый API `get_messages` в Tools-Reference, включая его режимы, ответы, конфликтующие параметры и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновлены рекомендации по поиску, README, документация о прогрессе memory-bank и активном контексте, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам.

Тесты:
- Добавлен отдельный набор тестов `test_get_messages`, покрывающий конфликт параметров, все режимы операций (поиск, просмотр, чтение по ID, комментарии к постам), обработку `has_more` и поведение для обеспечения обратной совместимости.
- Актуализированы существующие интеграционные тесты, чтобы проверять наличие `get_messages` вместо устаревших инструментов `search_messages_in_chat` и `read_messages`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

</details>

Новые возможности:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск, просмотр последних сообщений, чтение конкретных сообщений по их ID, а также работу с комментариями к постам каналов, включая поиск по комментариям.
- Добавить поддержку получения и поиска комментариев из тредов обсуждения постов каналов с возвратом связанной метаинформации об обсуждении, такой как `discussion_chat_id`, `discussion_total_count` и `linked_post_id`.

Улучшения:
- Централизовать логику получения сообщений в `search_messages_impl` с явным выбором режима, валидацией параметров и стандартизированной обработкой ошибок под общим именем операции `get_messages`.
- Упростить вспомогательные функции поиска, удалив неиспользуемые обёртки и полагаясь на реализации на основе генераторов для поиска по чату и глобального поиска.
- Обновить регистрацию серверных инструментов, чтобы предоставлять `get_messages` вместо отдельных инструментов `search_messages_in_chat` и `read_messages`, при этом сохранив совместимость базового поведения.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference, включая его режимы, конфликты параметров, структуру ответа и рекомендации по миграции с устаревших `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, README, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированный API для работы с сообщениями.

Тесты:
- Добавить отдельный набор тестов `test_get_messages`, покрывающий конфликты параметров, все режимы операций (поиск, просмотр, чтение по ID, комментарии к постам), обработку `has_more` и поведение для обеспечения обратной совместимости.
- Адаптировать существующие интеграционные тесты так, чтобы они ожидали новое имя инструмента `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

Новые возможности:
- Добавлена поддержка получения и поиска комментариев к обсуждениям постов канала по `post_id` с возвратом связанной метаинформации об обсуждении.
- Предоставлен унифицированный инструмент `get_messages`, поддерживающий несколько режимов: поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по их ID и работа с комментариями к постам.

Улучшения:
- Логика получения сообщений переработана в центральную функцию `search_messages_impl` с явным выбором режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок `get_messages`.
- Повторно используется общий вспомогательный модуль для построения результатов сообщений и удалены неиспользуемые обёртки, что упрощает конвейеры чатового и глобального поиска.
- Обновлена регистрация серверных инструментов: теперь предоставляется `get_messages` вместо отдельных инструментов `search_messages_in_chat` и `read_messages` при сохранении семантики обратной совместимости.

Документация:
- Задокументирован новый API `get_messages` в Tools-Reference, включая его режимы, ответы, конфликтующие параметры и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновлены рекомендации по поиску, README, документация о прогрессе memory-bank и активном контексте, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам.

Тесты:
- Добавлен отдельный набор тестов `test_get_messages`, покрывающий конфликт параметров, все режимы операций (поиск, просмотр, чтение по ID, комментарии к постам), обработку `has_more` и поведение для обеспечения обратной совместимости.
- Актуализированы существующие интеграционные тесты, чтобы проверять наличие `get_messages` вместо устаревших инструментов `search_messages_in_chat` и `read_messages`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

Новые возможности:
- Ввести единый инструмент `get_messages`, который может выполнять поиск в чатах, просматривать последние сообщения, читать конкретные сообщения по ID и получать/искать ответы, включая комментарии к постам в каналах и темам форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов в каналах с сопутствующими метаданными, такими как `discussion_chat_id` и `discussion_total_count`.

Улучшения:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режима, проверкой конфликтующих параметров и стандартизированной обработкой ошибок в рамках `get_messages`.
- Рефакторинг общей логики построения сообщений и генераторных вспомогательных функций поиска для удаления неиспользуемых обёрток и упрощения конвейеров поиска по чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив при этом прежнюю семантику поведения для обратной совместимости.

Документация:
- Задокументировать новый API `get_messages` в Tools-Reference и README, включая его режимы работы, конфликты параметров, форму ответа и рекомендации по миграции с `read_messages` и `search_messages_in_chat`.
- Обновить рекомендации по поиску, прогресс по memory-bank и документацию по активному контексту, чтобы ссылаться на `get_messages` и описывать поддержку комментариев к постам и унифицированных ответов.

Тесты:
- Добавить выделенный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы получения (поиск, просмотр, ID, ответы/комментарии), обработку `has_more` и поведение на совместимость.
- Скорректировать существующие модульные и интеграционные тесты так, чтобы они ожидали `get_messages` вместо устаревших `search_messages_in_chat` и `read_messages`, и проверяли обновлённые схемы инструментов и базовую функциональность.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Унифицировать получение сообщений для отдельного чата в единый API `get_messages`, который поддерживает поиск, просмотр, чтение по ID и получение ответов/комментариев, при этом пометив старые инструменты как устаревшие и задокументировав новый интерфейс.

New Features:
- Ввести унифицированный инструмент `get_messages`, который поддерживает поиск по чату, просмотр последних сообщений, чтение конкретных сообщений по ID и получение/поиск ответов, включая комментарии к постам в каналах и темы форумов.
- Добавить поддержку получения и поиска комментариев к обсуждениям постов канала по ID поста/сообщения с возвратом связанной метаинформации обсуждения, такой как `discussion_chat_id` и `discussion_total_count`.

Enhancements:
- Централизовать оркестрацию получения сообщений в `search_messages_impl` с явным определением режимов, проверкой конфликтов параметров и стандартизованной обработкой ошибок для `get_messages`.
- Рефакторизовать общую логику построения сообщений и вспомогательные функции поиска, чтобы убрать неиспользуемые обёртки, опираться на конвейеры поиска на базе генераторов и упростить потоки поиска по отдельному чату и глобального поиска.
- Заменить серверную регистрацию `search_messages_in_chat` и `read_messages` новым инструментом `get_messages`, сохранив существующую поведенческую семантику для обратной совместимости.

Documentation:
- Обновить Tools-Reference, README, рекомендации по поиску, документацию по прогрессу memory-bank и активному контексту, чтобы описать API `get_messages`, его режимы, поведение `reply_to_id`, конфликты параметров и миграцию с устаревших инструментов.

Tests:
- Добавить отдельный набор тестов `test_get_messages`, охватывающий конфликты параметров, все режимы работы (поиск, просмотр, IDs, ответы/комментарии), обработку `has_more` и пути ошибок.
- Адаптировать существующие модульные и интеграционные тесты к ожиданию `get_messages` вместо `search_messages_in_chat` и `read_messages`, а также для проверки обновлённых схем инструментов и базовой функциональности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify per-chat message retrieval into a single get_messages API that supports search, browsing, reading by IDs, and fetching replies/comments, while deprecating older tools and documenting the new interface.

New Features:
- Introduce a unified get_messages tool that supports chat search, browsing recent messages, reading specific messages by ID, and fetching/searching replies including channel post comments and forum topics.
- Add support for retrieving and searching channel post discussion comments by post/message ID, returning associated discussion metadata like discussion_chat_id and discussion_total_count.

Enhancements:
- Centralize message retrieval orchestration in search_messages_impl with explicit mode resolution, parameter conflict validation, and standardized error handling for get_messages.
- Refactor shared message-building and search helper logic to remove unused wrappers, rely on generator-based search pipelines, and simplify per-chat and global search flows.
- Replace server-side registration of search_messages_in_chat and read_messages with the new get_messages tool while preserving existing behavioral semantics for backward compatibility.

Documentation:
- Update Tools-Reference, README, search guidelines, memory-bank progress, and active context documentation to describe the get_messages API, its modes, reply_to_id behavior, parameter conflicts, and migration from deprecated tools.

Tests:
- Add a dedicated test_get_messages suite covering parameter conflicts, all operation modes (search, browse, IDs, replies/comments), has_more handling, and error paths.
- Adjust existing unit and integration tests to expect get_messages instead of search_messages_in_chat and read_messages, and to validate the updated tool schemas and basic functionality.

</details>

</details>

</details>

</details>

</details>

</details>

Fixes #12