### PR TITLE
Channel post comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ curl -X POST "https://tg-mcp.redevest.ru/mtproto-api/messages.SendMessage" \
 |------|---------|--------------|
 | `search_messages_globally` | Search across all chats | Multi-term queries, date filtering, chat type filtering |
 | `get_messages` | Unified message retrieval | Search/browse, read by IDs, get replies (posts/topics/messages), 5 modes |
-| `send_message` | Send new message | File attachments (URLs/local), formatting (markdown/html), unified `reply_to` (message or forum topic root id) |
+| `send_message` | Send new message | File attachments (URLs/local), formatting (markdown/html), unified `reply_to_id` (message, forum topic, or channel post comment) |
 | `edit_message` | Edit existing message | Text formatting, preserves message structure |
 | `find_chats` | Find users/groups/channels | Multi-term search, contact discovery, username/phone lookup |
 | `get_chat_info` | Get detailed profile info | Member counts, bio/about, online status, forum topics, enriched data |

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -344,11 +344,16 @@ get_messages(
 send_message(
   chat_id: str,                  // Target chat ID (see Supported Chat ID Formats above)
   message: str,                  // Message content (becomes caption when files sent)
-  reply_to?: number,             // Reply target ID (message ID or forum topic root ID)
+  reply_to_id?: number,          // Reply target (message ID, forum topic root, or channel post for comments)
   parse_mode?: 'markdown'|'html'|'auto' = 'auto', // Text formatting (auto-detect by default)
   files?: string | string[]      // File URL(s) or local path(s)
 )
 ```
+
+**reply_to_id automatically handles:**
+- 📢 **Channel post comments** - Detects discussion group and posts comment there
+- 📋 **Forum topic messages** - Posts into forum topic
+- 💬 **Message replies** - Replies to any message
 
 **File Sending:**
 - `files`: Single file or array of files (URLs or local paths)
@@ -393,14 +398,21 @@ send_message(
   "chat_id": "@username",
   "message": "*Important:* Meeting at 3 PM",
   "parse_mode": "markdown",
-  "reply_to": 67890
+  "reply_to_id": 67890
 }}
 
-// Post into a forum topic (use topic_id from get_chat_info topics list as reply_to)
+// Post into a forum topic (use topic_id from get_chat_info topics list as reply_to_id)
 {"tool": "send_message", "params": {
   "chat_id": "-1001234567890",
   "message": "Hello forum thread!",
-  "reply_to": 52
+  "reply_to_id": 52
+}}
+
+// Post comment on channel post (auto-detects discussion group)
+{"tool": "send_message", "params": {
+  "chat_id": "-1001234567890",
+  "message": "Great post!",
+  "reply_to_id": 42
 }}
 ```
 

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -183,7 +183,7 @@ def register_tools(mcp: FastMCP) -> None:
     async def send_message(
         chat_id: str,
         message: str,
-        reply_to: int | None = None,
+        reply_to_id: int | None = None,
         parse_mode: Literal["markdown", "html", "auto"] | None = "auto",
         files: str | list[str] | None = None,
     ) -> dict:
@@ -204,8 +204,9 @@ def register_tools(mcp: FastMCP) -> None:
 
         EXAMPLES:
         send_message(chat_id="me", message="Hello!")  # Send text to Saved Messages
-        send_message(chat_id="-1001234567890", message="New message", reply_to=12345)  # Reply
-        send_message(chat_id="-1001234567890", message="Topic message", reply_to=52)  # Post into forum topic
+        send_message(chat_id="-1001234567890", message="New message", reply_to_id=12345)  # Reply
+        send_message(chat_id="-1001234567890", message="Topic message", reply_to_id=52)  # Post into forum topic
+        send_message(chat_id="-1001234567890", message="My comment", reply_to_id=42)  # Channel post comment
         send_message(chat_id="me", message="Check this", files="https://example.com/doc.pdf")  # Send file from URL
         send_message(chat_id="me", message="Photos", files=["https://ex.com/1.jpg", "https://ex.com/2.jpg"])  # Multiple files
         send_message(chat_id="me", message="Report", files="/path/to/file.pdf")  # Local file (stdio mode only)
@@ -213,12 +214,12 @@ def register_tools(mcp: FastMCP) -> None:
         Args:
             chat_id: Target chat ID ('me' for Saved Messages, numeric ID, or username)
             message: Message text to send (becomes caption when files are provided)
-            reply_to: Message ID to reply to. For forum chats, pass topic root message ID here.
+            reply_to_id: Message ID to reply to. For forum chats, topic root ID. For channel posts, post ID (auto-posts comment).
             parse_mode: Text formatting ("markdown", "html", "auto", or None). Default: "auto"
             files: Single file or list of files to send (URLs or local paths, optional)
         """
         return await send_message_impl(
-            chat_id, message, reply_to, parse_mode, files
+            chat_id, message, reply_to_id, parse_mode, files
         )
 
     @mcp.tool(

--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -463,10 +463,9 @@ async def send_message_impl(
                 "Detected channel post with discussion, posting comment in discussion group"
             )
         except ValueError as e:
-            raw_msg = str(e.__cause__) if e.__cause__ is not None else str(e)
             return log_and_build_error(
                 operation="send_message",
-                error_message=raw_msg,
+                error_message=str(e),
                 params=params,
                 exception=e,
             )
@@ -485,7 +484,7 @@ async def send_message_impl(
         return error
 
     result = build_send_edit_result(sent_message, effective_entity, "sent")
-    log_operation_success("Message sent", chat_id)
+    log_operation_success("Message sent", params["chat_id"])
     return result
 
 

--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -12,7 +12,7 @@ from src.client.connection import get_connected_client
 from src.config.server_config import ServerMode, get_config
 from src.tools.links import generate_telegram_links
 from src.utils.discussion import get_post_discussion_info
-from src.utils.entity import build_entity_dict, get_entity_by_id
+from src.utils.entity import build_entity_dict, compute_entity_identifier, get_entity_by_id
 from src.utils.error_handling import handle_telegram_errors, log_and_build_error
 from src.utils.logging_utils import log_operation_start, log_operation_success
 from src.utils.message_format import (
@@ -456,13 +456,17 @@ async def send_message_impl(
             )
             effective_entity = discussion_info["discussion_peer"]
             effective_reply_to_id = discussion_info["discussion_msg_id"]
+            params["chat_id"] = discussion_info["discussion_chat_id"]
+            params["reply_to_id"] = effective_reply_to_id
+            params["has_reply"] = True
             logger.debug(
                 "Detected channel post with discussion, posting comment in discussion group"
             )
         except ValueError as e:
+            raw_msg = str(e.__cause__) if e.__cause__ is not None else str(e)
             return log_and_build_error(
                 operation="send_message",
-                error_message=str(e),
+                error_message=raw_msg,
                 params=params,
                 exception=e,
             )

--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -383,7 +383,10 @@ def _extract_send_message_params(
     parse_mode: str | None = None,
     files: str | list[str] | None = None,
 ) -> dict:
-    """Extract params for send_message error handling."""
+    """Extract params for send_message error handling and logging.
+
+    parse_mode: Effective parse mode used for sending (resolved when input is 'auto').
+    """
     return {
         "chat_id": chat_id,
         "message": message,
@@ -422,7 +425,7 @@ async def send_message_impl(
         resolved_parse_mode = detect_message_formatting(message)
 
     params = _extract_send_message_params(
-        chat_id, message, reply_to_id, parse_mode, files
+        chat_id, message, reply_to_id, resolved_parse_mode, files
     )
     log_operation_start("Sending message to chat", params)
 

--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -11,6 +11,7 @@ from telethon.tl.types import InputPhoneContact
 from src.client.connection import get_connected_client
 from src.config.server_config import ServerMode, get_config
 from src.tools.links import generate_telegram_links
+from src.utils.discussion import get_post_discussion_info
 from src.utils.entity import build_entity_dict, get_entity_by_id
 from src.utils.error_handling import handle_telegram_errors, log_and_build_error
 from src.utils.logging_utils import log_operation_start, log_operation_success
@@ -378,7 +379,7 @@ async def _send_message_or_files(
 def _extract_send_message_params(
     chat_id: str,
     message: str,
-    reply_to_msg_id: int | None = None,
+    reply_to_id: int | None = None,
     parse_mode: str | None = None,
     files: str | list[str] | None = None,
 ) -> dict:
@@ -387,9 +388,9 @@ def _extract_send_message_params(
         "chat_id": chat_id,
         "message": message,
         "message_length": len(message),
-        "reply_to_msg_id": reply_to_msg_id,
+        "reply_to_id": reply_to_id,
         "parse_mode": parse_mode,
-        "has_reply": reply_to_msg_id is not None,
+        "has_reply": reply_to_id is not None,
         "has_files": bool(files),
         "file_count": _calculate_file_count(files),
     }
@@ -401,7 +402,7 @@ def _extract_send_message_params(
 async def send_message_impl(
     chat_id: str,
     message: str,
-    reply_to_msg_id: int | None = None,
+    reply_to_id: int | None = None,
     parse_mode: str | None = None,
     files: str | list[str] | None = None,
 ) -> dict[str, Any]:
@@ -411,26 +412,19 @@ async def send_message_impl(
     Args:
         chat_id: The ID of the chat to send the message to
         message: The text message to send (becomes caption when files are provided)
-        reply_to_msg_id: ID of the message to reply to. For forum chats,
-            pass the topic root message id here to post into a topic.
+        reply_to_id: ID of the message to reply to. For forum chats, pass topic root ID.
+            For channel posts, automatically posts comment in discussion group.
         parse_mode: Parse mode ('markdown' or 'html')
         files: Single file or list of files (URLs or local paths)
-            - URLs work in all modes (http:// or https://)
-            - Local file paths only work in stdio mode
-            - Supports images, videos, documents, audio, etc.
     """
-    # Resolve auto parse mode
     resolved_parse_mode = parse_mode
     if parse_mode == "auto":
         resolved_parse_mode = detect_message_formatting(message)
-        # Note: params will be built by the decorator
 
-    log_operation_start(
-        "Sending message to chat",
-        _extract_send_message_params(
-            chat_id, message, reply_to_msg_id, parse_mode, files
-        ),
+    params = _extract_send_message_params(
+        chat_id, message, reply_to_id, parse_mode, files
     )
+    log_operation_start("Sending message to chat", params)
 
     client = await get_connected_client()
     chat = await get_entity_by_id(chat_id)
@@ -438,31 +432,52 @@ async def send_message_impl(
         return log_and_build_error(
             operation="send_message",
             error_message=f"Cannot find chat with ID '{chat_id}'",
-            params=_extract_send_message_params(
-                chat_id, message, reply_to_msg_id, parse_mode, files
-            ),
+            params=params,
             exception=ValueError(
                 f"Cannot find any entity corresponding to '{chat_id}'"
             ),
         )
 
-    # Send message with or without files
+    effective_entity = chat
+    effective_reply_to_id = reply_to_id
+
+    # Channel post comment: redirect to discussion group
+    if (
+        reply_to_id is not None
+        and hasattr(chat, "broadcast")
+        and chat.broadcast
+    ):
+        try:
+            discussion_info = await get_post_discussion_info(
+                client, chat, reply_to_id
+            )
+            effective_entity = discussion_info["discussion_peer"]
+            effective_reply_to_id = discussion_info["discussion_msg_id"]
+            logger.debug(
+                "Detected channel post with discussion, posting comment in discussion group"
+            )
+        except ValueError as e:
+            return log_and_build_error(
+                operation="send_message",
+                error_message=str(e),
+                params=params,
+                exception=e,
+            )
+
     error, sent_message = await _send_message_or_files(
         client,
-        chat,
+        effective_entity,
         message,
         files,
-        reply_to_msg_id,
+        effective_reply_to_id,
         resolved_parse_mode,
         "send_message",
-        _extract_send_message_params(
-            chat_id, message, reply_to_msg_id, parse_mode, files
-        ),
+        params,
     )
     if error:
         return error
 
-    result = build_send_edit_result(sent_message, chat, "sent")
+    result = build_send_edit_result(sent_message, effective_entity, "sent")
     log_operation_success("Message sent", chat_id)
     return result
 

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -3,17 +3,17 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any
 
-from telethon.tl.functions.messages import GetDiscussionMessageRequest, SearchGlobalRequest
+from telethon.tl.functions.messages import SearchGlobalRequest
 from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty
 
 from src.client.connection import SessionNotAuthorizedError, get_connected_client
 from src.tools.links import generate_telegram_links
 from src.tools.messages import read_messages_by_ids
+from src.utils.discussion import get_post_discussion_info
 from src.utils.entity import (
     _get_chat_message_count,
     _matches_chat_type,
     _matches_public_filter,
-    compute_entity_identifier,
     get_entity_by_id,
 )
 from src.utils.error_handling import (
@@ -137,62 +137,6 @@ async def _build_result_for_message(
         return None
 
 
-async def _get_post_discussion_info(
-    client, channel_entity, post_id: int
-) -> dict[str, Any]:
-    """
-    Get discussion group information for a channel post.
-    
-    Caller is responsible for logging errors to avoid double-logging.
-
-    Returns dict with:
-    - discussion_peer: The discussion chat entity
-    - discussion_chat_id: Chat ID of discussion group
-    - discussion_msg_id: Root message ID in discussion group
-    - discussion_total_count: Total comment count (if available)
-
-    Raises ValueError if post has no discussion enabled.
-    """
-    try:
-        result = await client(
-            GetDiscussionMessageRequest(
-                peer=channel_entity,
-                msg_id=post_id,
-            )
-        )
-
-        if not result or not hasattr(result, "messages") or not result.messages:
-            raise ValueError(f"Post {post_id} has no discussion thread enabled")
-
-        discussion_msg = result.messages[0]
-        discussion_peer = getattr(discussion_msg, "peer_id", None)
-
-        if not discussion_peer:
-            raise ValueError(f"Post {post_id} has no discussion peer")
-
-        # Get the discussion chat entity
-        discussion_entity = await client.get_entity(discussion_peer)
-        discussion_chat_id = compute_entity_identifier(discussion_entity)
-
-        # Get total comment count if available
-        total_count = getattr(result, "count", None)
-        if total_count is None and hasattr(discussion_msg, "replies"):
-            total_count = getattr(discussion_msg.replies, "replies", None)
-
-        return {
-            "discussion_peer": discussion_entity,
-            "discussion_chat_id": discussion_chat_id,
-            "discussion_msg_id": discussion_msg.id,
-            "discussion_total_count": total_count,
-        }
-
-    except Exception as e:
-        # Let caller handle logging to avoid double-logging
-        raise ValueError(
-            f"Cannot access discussion for post {post_id}: {e!s}"
-        ) from e
-
-
 async def _fetch_replies(
     client,
     chat_entity,
@@ -219,7 +163,7 @@ async def _fetch_replies(
     # Detect channel post with discussion
     if hasattr(chat_entity, "broadcast") and chat_entity.broadcast:
         try:
-            discussion_info = await _get_post_discussion_info(
+            discussion_info = await get_post_discussion_info(
                 client, chat_entity, reply_to_id
             )
             # Use discussion chat instead of channel

--- a/src/utils/discussion.py
+++ b/src/utils/discussion.py
@@ -1,5 +1,6 @@
 """Shared utilities for Telegram channel post discussion threads."""
 
+import asyncio
 from typing import Any
 
 from telethon.tl.functions.messages import GetDiscussionMessageRequest
@@ -7,7 +8,9 @@ from telethon.tl.functions.messages import GetDiscussionMessageRequest
 from src.utils.entity import compute_entity_identifier
 
 
-async def get_post_discussion_info(client, channel_entity, post_id: int) -> dict[str, Any]:
+async def get_post_discussion_info(
+    client: Any, channel_entity: Any, post_id: int
+) -> dict[str, Any]:
     """
     Get discussion group information for a channel post.
 
@@ -52,6 +55,8 @@ async def get_post_discussion_info(client, channel_entity, post_id: int) -> dict
             "discussion_total_count": total_count,
         }
 
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
         raise ValueError(
             f"Cannot access discussion for post {post_id}: {e!s}"

--- a/src/utils/discussion.py
+++ b/src/utils/discussion.py
@@ -1,0 +1,58 @@
+"""Shared utilities for Telegram channel post discussion threads."""
+
+from typing import Any
+
+from telethon.tl.functions.messages import GetDiscussionMessageRequest
+
+from src.utils.entity import compute_entity_identifier
+
+
+async def get_post_discussion_info(client, channel_entity, post_id: int) -> dict[str, Any]:
+    """
+    Get discussion group information for a channel post.
+
+    Caller is responsible for logging errors to avoid double-logging.
+
+    Returns dict with:
+    - discussion_peer: The discussion chat entity
+    - discussion_chat_id: Chat ID of discussion group
+    - discussion_msg_id: Root message ID in discussion group
+    - discussion_total_count: Total comment count (if available)
+
+    Raises ValueError if post has no discussion enabled.
+    """
+    try:
+        result = await client(
+            GetDiscussionMessageRequest(
+                peer=channel_entity,
+                msg_id=post_id,
+            )
+        )
+
+        if not result or not hasattr(result, "messages") or not result.messages:
+            raise ValueError(f"Post {post_id} has no discussion thread enabled")
+
+        discussion_msg = result.messages[0]
+        discussion_peer = getattr(discussion_msg, "peer_id", None)
+
+        if not discussion_peer:
+            raise ValueError(f"Post {post_id} has no discussion peer")
+
+        discussion_entity = await client.get_entity(discussion_peer)
+        discussion_chat_id = compute_entity_identifier(discussion_entity)
+
+        total_count = getattr(result, "count", None)
+        if total_count is None and hasattr(discussion_msg, "replies"):
+            total_count = getattr(discussion_msg.replies, "replies", None)
+
+        return {
+            "discussion_peer": discussion_entity,
+            "discussion_chat_id": discussion_chat_id,
+            "discussion_msg_id": discussion_msg.id,
+            "discussion_total_count": total_count,
+        }
+
+    except Exception as e:
+        raise ValueError(
+            f"Cannot access discussion for post {post_id}: {e!s}"
+        ) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,7 @@ def test_server(mock_client):
         return {"messages": window, "has_more": has_more}
 
     @mcp.tool()
-    async def send_message(chat_id: str, message: str, reply_to: int | None = None):
+    async def send_message(chat_id: str, message: str, reply_to_id: int | None = None):
         """Send new message in Telegram chat."""
         return {"action": "sent", "chat_id": chat_id, "text": message}
 

--- a/tests/test_forum_topics_minimal.py
+++ b/tests/test_forum_topics_minimal.py
@@ -704,6 +704,18 @@ async def test_send_message_impl_regular_chat_reply_no_discussion_lookup():
 
     mock_discussion.assert_not_awaited()
     mock_send.assert_awaited_once()
+    (
+        _client,
+        entity,
+        _text,
+        _files,
+        reply_to_msg_id,
+        _parse_mode,
+        _operation,
+        _params,
+    ) = mock_send.await_args[0]
+    assert entity is chat
+    assert reply_to_msg_id == 42
     assert result["status"] == "sent"
 
 

--- a/tests/test_forum_topics_minimal.py
+++ b/tests/test_forum_topics_minimal.py
@@ -671,6 +671,43 @@ def test_extract_topic_metadata_without_reply_data_returns_empty():
 
 
 @pytest.mark.asyncio
+async def test_send_message_impl_channel_post_comment_discussion_lookup_failure():
+    """Channel + reply_to_id -> failing discussion lookup returns error and skips sending."""
+    channel = SimpleNamespace(id=-1001234567890, broadcast=True, megagroup=False)
+
+    with (
+        patch(
+            "src.tools.messages.get_connected_client",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.tools.messages.get_entity_by_id",
+            new_callable=AsyncMock,
+            return_value=channel,
+        ),
+        patch(
+            "src.tools.messages.get_post_discussion_info",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Post 42 has no discussion thread enabled"),
+        ),
+        patch(
+            "src.tools.messages._send_message_or_files",
+            new_callable=AsyncMock,
+        ) as mock_send,
+    ):
+        result = await send_message_impl(
+            chat_id="-1001234567890",
+            message="My comment",
+            reply_to_id=42,
+        )
+
+    mock_send.assert_not_awaited()
+    assert result["ok"] is False
+    assert "error" in result
+    assert "discussion" in result["error"].lower()
+
+
+@pytest.mark.asyncio
 async def test_send_message_impl_channel_post_comment_redirects_to_discussion():
     """Channel + reply_to_id -> resolves discussion and sends to discussion group."""
     channel = SimpleNamespace(id=-1001234567890, broadcast=True, megagroup=False)

--- a/tests/test_forum_topics_minimal.py
+++ b/tests/test_forum_topics_minimal.py
@@ -745,6 +745,42 @@ async def test_send_message_impl_megagroup_non_broadcast_reply_no_discussion_loo
 
 
 @pytest.mark.asyncio
+async def test_send_message_impl_channel_post_no_reply_skips_discussion_lookup():
+    """Broadcast channel without reply_to_id sends normally without discussion lookup."""
+    channel = SimpleNamespace(id=-1001234567890, broadcast=True, megagroup=False)
+    sent_msg = SimpleNamespace(id=1, text="hello", date=datetime.now(UTC))
+
+    with (
+        patch(
+            "src.tools.messages.get_connected_client",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.tools.messages.get_entity_by_id",
+            new_callable=AsyncMock,
+            return_value=channel,
+        ),
+        patch(
+            "src.tools.messages.get_post_discussion_info",
+            new_callable=AsyncMock,
+        ) as mock_discussion,
+        patch(
+            "src.tools.messages._send_message_or_files",
+            new_callable=AsyncMock,
+            return_value=(None, sent_msg),
+        ) as mock_send,
+    ):
+        result = await send_message_impl(
+            chat_id="-1001234567890",
+            message="hello from broadcast",
+        )
+
+    mock_discussion.assert_not_awaited()
+    mock_send.assert_awaited_once()
+    assert result["status"] == "sent"
+
+
+@pytest.mark.asyncio
 async def test_send_message_impl_channel_post_comment_discussion_lookup_failure():
     """Channel + reply_to_id -> failing discussion lookup returns error and skips sending."""
     channel = SimpleNamespace(id=-1001234567890, broadcast=True, megagroup=False)
@@ -827,11 +863,23 @@ async def test_send_message_impl_channel_post_comment_redirects_to_discussion():
         )
 
     mock_discussion.assert_awaited_once()
-    assert mock_discussion.await_args[0][2] == 42
+    client_used, entity_arg, post_id_arg = mock_discussion.await_args[0]
+    assert entity_arg is channel
+    assert post_id_arg == 42
+
     mock_send.assert_awaited_once()
-    call_args = mock_send.await_args[0]
-    assert call_args[1] is discussion_entity  # entity
-    assert call_args[4] == 999  # reply_to_msg_id
+    (
+        _client,
+        entity,
+        text,
+        files,
+        reply_to_msg_id,
+        _parse_mode,
+        _operation,
+        _params,
+    ) = mock_send.await_args[0]
+    assert entity is discussion_entity
+    assert reply_to_msg_id == 999
     assert result["status"] == "sent"
     assert result["chat"]["id"] == discussion_entity.id
 

--- a/tests/test_forum_topics_minimal.py
+++ b/tests/test_forum_topics_minimal.py
@@ -10,6 +10,7 @@ from src.tools.messages import (
     _extract_send_message_params,
     _send_message_or_files,
     edit_message_impl,
+    send_message_impl,
 )
 from src.utils.message_format import _extract_topic_metadata, build_message_result
 
@@ -669,11 +670,66 @@ def test_extract_topic_metadata_without_reply_data_returns_empty():
     assert _extract_topic_metadata(message) == {}
 
 
+@pytest.mark.asyncio
+async def test_send_message_impl_channel_post_comment_redirects_to_discussion():
+    """Channel + reply_to_id -> resolves discussion and sends to discussion group."""
+    channel = SimpleNamespace(id=-1001234567890, broadcast=True, megagroup=False)
+    discussion_entity = SimpleNamespace(id=-1009876543210, broadcast=False)
+    discussion_info = {
+        "discussion_peer": discussion_entity,
+        "discussion_chat_id": "-1009876543210",
+        "discussion_msg_id": 999,
+        "discussion_total_count": 5,
+    }
+    sent_msg = SimpleNamespace(
+        id=100,
+        text="My comment",
+        date=datetime.now(UTC),
+    )
+
+    with (
+        patch(
+            "src.tools.messages.get_connected_client",
+            new_callable=AsyncMock,
+        ) as mock_client,
+        patch(
+            "src.tools.messages.get_entity_by_id",
+            new_callable=AsyncMock,
+            return_value=channel,
+        ),
+        patch(
+            "src.tools.messages.get_post_discussion_info",
+            new_callable=AsyncMock,
+            return_value=discussion_info,
+        ) as mock_discussion,
+        patch(
+            "src.tools.messages._send_message_or_files",
+            new_callable=AsyncMock,
+            return_value=(None, sent_msg),
+        ) as mock_send,
+    ):
+        mock_client.return_value = AsyncMock()
+        result = await send_message_impl(
+            chat_id="-1001234567890",
+            message="My comment",
+            reply_to_id=42,
+        )
+
+    mock_discussion.assert_awaited_once()
+    assert mock_discussion.await_args[0][2] == 42
+    mock_send.assert_awaited_once()
+    call_args = mock_send.await_args[0]
+    assert call_args[1] is discussion_entity  # entity
+    assert call_args[4] == 999  # reply_to_msg_id
+    assert result["status"] == "sent"
+    assert result["chat"]["id"] == discussion_entity.id
+
+
 def test_extract_send_message_params_marks_reply_target_as_reply():
     params = _extract_send_message_params(
         chat_id="-1001",
         message="hello",
-        reply_to_msg_id=77,
+        reply_to_id=77,
         parse_mode=None,
         files=None,
     )
@@ -684,7 +740,7 @@ def test_extract_send_message_params_marks_no_reply_when_no_ids():
     params = _extract_send_message_params(
         chat_id="-1001",
         message="hello",
-        reply_to_msg_id=None,
+        reply_to_id=None,
         parse_mode=None,
         files=None,
     )

--- a/tests/test_forum_topics_minimal.py
+++ b/tests/test_forum_topics_minimal.py
@@ -671,6 +671,80 @@ def test_extract_topic_metadata_without_reply_data_returns_empty():
 
 
 @pytest.mark.asyncio
+async def test_send_message_impl_regular_chat_reply_no_discussion_lookup():
+    """Non-broadcast chat with reply_to_id should bypass discussion lookup."""
+    chat = SimpleNamespace(id=123456, broadcast=False, megagroup=False)
+    sent_msg = SimpleNamespace(id=1, text="hello", date=datetime.now(UTC))
+
+    with (
+        patch(
+            "src.tools.messages.get_connected_client",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.tools.messages.get_entity_by_id",
+            new_callable=AsyncMock,
+            return_value=chat,
+        ),
+        patch(
+            "src.tools.messages.get_post_discussion_info",
+            new_callable=AsyncMock,
+        ) as mock_discussion,
+        patch(
+            "src.tools.messages._send_message_or_files",
+            new_callable=AsyncMock,
+            return_value=(None, sent_msg),
+        ) as mock_send,
+    ):
+        result = await send_message_impl(
+            chat_id="123456",
+            message="hello",
+            reply_to_id=42,
+        )
+
+    mock_discussion.assert_not_awaited()
+    mock_send.assert_awaited_once()
+    assert result["status"] == "sent"
+
+
+@pytest.mark.asyncio
+async def test_send_message_impl_megagroup_non_broadcast_reply_no_discussion_lookup():
+    """Megagroup with broadcast=False and reply_to_id should bypass discussion lookup."""
+    chat = SimpleNamespace(id=-1009876543210, broadcast=False, megagroup=True)
+    sent_msg = SimpleNamespace(id=1, text="hello", date=datetime.now(UTC))
+
+    with (
+        patch(
+            "src.tools.messages.get_connected_client",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.tools.messages.get_entity_by_id",
+            new_callable=AsyncMock,
+            return_value=chat,
+        ),
+        patch(
+            "src.tools.messages.get_post_discussion_info",
+            new_callable=AsyncMock,
+        ) as mock_discussion,
+        patch(
+            "src.tools.messages._send_message_or_files",
+            new_callable=AsyncMock,
+            return_value=(None, sent_msg),
+        ) as mock_send,
+    ):
+        result = await send_message_impl(
+            chat_id="-1009876543210",
+            message="hello from megagroup",
+            reply_to_id=99,
+        )
+
+    mock_discussion.assert_not_awaited()
+    mock_send.assert_awaited_once()
+    assert result["status"] == "sent"
+
+
+@pytest.mark.asyncio
 async def test_send_message_impl_channel_post_comment_discussion_lookup_failure():
     """Channel + reply_to_id -> failing discussion lookup returns error and skips sending."""
     channel = SimpleNamespace(id=-1001234567890, broadcast=True, megagroup=False)
@@ -771,6 +845,7 @@ def test_extract_send_message_params_marks_reply_target_as_reply():
         files=None,
     )
     assert params["has_reply"] is True
+    assert params["reply_to_id"] == 77
 
 
 def test_extract_send_message_params_marks_no_reply_when_no_ids():
@@ -782,6 +857,7 @@ def test_extract_send_message_params_marks_no_reply_when_no_ids():
         files=None,
     )
     assert params["has_reply"] is False
+    assert params["reply_to_id"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Extend `send_message` to support posting comments to channel posts and unify `reply_to_id` parameter name.

Previously, posting a comment to a channel post required manually resolving the linked discussion group and its root message ID. This change allows `send_message` to automatically detect if the target is a broadcast channel with a `reply_to_id` and, if so, resolve the discussion group and post the message there, simplifying the API and aligning with `get_messages` behavior. The `reply_to` parameter was also renamed to `reply_to_id` for consistency across tools.

---
<p><a href="https://cursor.com/agents/bc-dee28959-c95c-4d9b-a85b-a1e7c055377a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee28959-c95c-4d9b-a85b-a1e7c055377a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

Новые возможности:
- Разрешить `send_message` автоматически направлять ответы на посты в канале в соответствующую группу обсуждения с помощью `reply_to_id`.

Улучшения:
- Вынести логику определения обсуждения для поста в канале в переиспользуемый утилитарный модуль, общий для отправки сообщений и поиска.
- Стандартизировать имя параметра ответа, изменив его с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также упростить обработку параметров логирования в `send_message`.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к постам в канале.

Тесты:
- Добавить тесты, проверяющие, что комментарии к постам в канале перенаправляются в корректную группу обсуждения или завершаются с понятной ошибкой, если обсуждение недоступно, а также обновить существующие тесты для параметра `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

Новые возможности:
- Разрешить `send_message` автоматически направлять ответы на посты в канале в соответствующую группу обсуждения с помощью `reply_to_id`.

Улучшения:
- Вынести логику определения обсуждения для поста в канале в переиспользуемый утилитарный модуль, общий для отправки сообщений и поиска.
- Стандартизировать имя параметра ответа, изменив его с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также упростить обработку параметров логирования в `send_message`.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к постам в канале.

Тесты:
- Добавить тесты, проверяющие, что комментарии к постам в канале перенаправляются в корректную группу обсуждения или завершаются с понятной ошибкой, если обсуждение недоступно, а также обновить существующие тесты для параметра `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

</details>

</details>

Новые возможности:
- Разрешить `send_message` автоматически публиковать комментарии в связанной группе обсуждений поста канала при передаче `channel chat_id` и `reply_to_id`.

Улучшения:
- Вынести общую логику разрешения групп обсуждения каналов в переиспользуемую утилитную функцию, используемую как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` в реализации инструмента `send_message`, его регистрации и примерах для обеспечения единообразия.
- Улучшить обработку параметров логирования в `send_message`, вычисляя параметры один раз и переиспользуя их.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к постам в канале.

Тесты:
- Добавить тесты для проверки того, что `send_message_impl` перенаправляет ответы на посты канала в корректную группу обсуждений, и скорректировать существующие тесты под новый параметр `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

Новые возможности:
- Разрешить `send_message` автоматически направлять ответы на посты в канале в соответствующую группу обсуждения с помощью `reply_to_id`.

Улучшения:
- Вынести логику определения обсуждения для поста в канале в переиспользуемый утилитарный модуль, общий для отправки сообщений и поиска.
- Стандартизировать имя параметра ответа, изменив его с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также упростить обработку параметров логирования в `send_message`.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к постам в канале.

Тесты:
- Добавить тесты, проверяющие, что комментарии к постам в канале перенаправляются в корректную группу обсуждения или завершаются с понятной ошибкой, если обсуждение недоступно, а также обновить существующие тесты для параметра `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

Новые возможности:
- Разрешить `send_message` автоматически направлять ответы на посты в канале в соответствующую группу обсуждения с помощью `reply_to_id`.

Улучшения:
- Вынести логику определения обсуждения для поста в канале в переиспользуемый утилитарный модуль, общий для отправки сообщений и поиска.
- Стандартизировать имя параметра ответа, изменив его с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также упростить обработку параметров логирования в `send_message`.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к постам в канале.

Тесты:
- Добавить тесты, проверяющие, что комментарии к постам в канале перенаправляются в корректную группу обсуждения или завершаются с понятной ошибкой, если обсуждение недоступно, а также обновить существующие тесты для параметра `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

Новые возможности:
- Разрешить `send_message` публиковать комментарии к сообщениям в каналах, определяя и используя связанную группу обсуждений, когда передан `reply_to_id`.

Улучшения:
- Вынести логику определения группы обсуждений для сообщений каналов в общий вспомогательный модуль, используемый как при отправке сообщений, так и при поиске.
- Стандартизировать имя параметра ответа с `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и логировании, а также централизовать извлечение параметров для логирования.

Документация:
- Описать семантику `reply_to_id` и поддержку комментариев к сообщениям каналов в справочнике по инструментам, README и примерах использования.

Тесты:
- Добавить тесты, покрывающие поведение ответов в каналах и вне каналов, успешный и неуспешный поиск группы обсуждений для комментариев к сообщениям каналов, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

Новые возможности:
- Позволить `send_message` автоматически публиковать комментарии к сообщениям канала, определяя связанную группу обсуждения, когда указан `reply_to_id`.

Улучшения:
- Стандартизировать параметр ответа, заменив `reply_to` на `reply_to_id` во всей реализации `send_message`, его регистрации и документации.
- Ввести общую утилиту `get_post_discussion_info` для получения метаданных обсуждения сообщений канала, используемую как при отправке сообщений, так и при поиске.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров и повторного использования вычисленных параметров, включая эффективный `parse_mode` и метаданные ответа.

Документация:
- Обновить справочник по инструментам, README и примеры использования, чтобы задокументировать семантику `reply_to_id` и поддержку комментариев к сообщениям канала.

Тесты:
- Добавить тесты, покрывающие поведение `send_message` для ответов в обычных чатах, мегагруппах и вещательных каналах, включая успешные и неуспешные попытки получения данных обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Включена унифицированная обработка ответов в `send_message` и добавлена поддержка комментариев к постам в каналах за счёт их резолва и перенаправления в треды обсуждений.

New Features:
- Разрешить `send_message` отправлять комментарии к постам в каналах, автоматически определяя связанный обсуждаемый чат при переданном `reply_to_id`.

Enhancements:
- Стандартизировать имя параметра ответа, заменив `reply_to` на `reply_to_id` во всех местах реализации, регистрации и логирования `send_message`.
- Ввести общий утилитарный метод `get_post_discussion_info` для получения метаданных обсуждения постов каналов и переиспользовать его как в мессенджинговом, так и в поисковом потоках.
- Улучшить логирование в `send_message` за счёт централизации извлечения параметров, повторного использования вычисленного `parse_mode` и отслеживания фактических целей ответов и сущностей.

Documentation:
- Обновить справочник по инструментам, README и примеры, задокументировав семантику `reply_to_id` и поддержку комментариев к постам в каналах.

Tests:
- Добавить тесты, покрывающие поведение `send_message_impl` для ответов в обычных чатах, мегагруппах и трансляционных каналах, включая успешные и неуспешные сценарии резолва обсуждений, а также обновить существующие тесты для использования `reply_to_id`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable unified reply handling in send_message and support channel post comments by resolving and redirecting to discussion threads.

New Features:
- Allow send_message to post comments on channel posts by automatically resolving the associated discussion group when reply_to_id is provided.

Enhancements:
- Standardize the reply parameter name from reply_to to reply_to_id across the send_message implementation, registration, and logging.
- Introduce a shared get_post_discussion_info utility for retrieving channel post discussion metadata and reuse it in both messaging and search flows.
- Improve send_message logging by centralizing parameter extraction, reusing computed parse_mode, and tracking effective reply targets and entities.

Documentation:
- Update tools reference, README, and examples to document reply_to_id semantics and channel post comment support.

Tests:
- Add tests covering send_message_impl behavior for replies in regular chats, megagroups, and broadcast channels, including discussion resolution success and failure cases, and update existing tests to use reply_to_id.

</details>

</details>

</details>

</details>

</details>

</details>