### PR TITLE
Parse mode lowercasing, autodetection

### DIFF
--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def _normalize_parse_mode(parse_mode: str | None) -> str | None:
-    """Lowercase parse_mode so HTML, AUTO, Markdown etc. are processed correctly."""
+    """Return parse_mode lowercased if not None, otherwise None. Ensures case-insensitive handling."""
     return parse_mode.lower() if parse_mode is not None else None
 
 

--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -25,6 +25,13 @@ from src.utils.message_format import (
 logger = logging.getLogger(__name__)
 
 
+def _normalize_parse_mode(parse_mode: str | None) -> str | None:
+    """Lowercase parse_mode so HTML, AUTO, Markdown etc. are processed correctly."""
+    if parse_mode is None:
+        return None
+    return parse_mode.lower() if isinstance(parse_mode, str) else parse_mode
+
+
 def detect_message_formatting(message: str) -> str | None:
     """
     Detect message formatting based on content patterns.
@@ -420,6 +427,7 @@ async def send_message_impl(
         parse_mode: Parse mode ('markdown' or 'html')
         files: Single file or list of files (URLs or local paths)
     """
+    parse_mode = _normalize_parse_mode(parse_mode)
     resolved_parse_mode = parse_mode
     if parse_mode == "auto":
         resolved_parse_mode = detect_message_formatting(message)
@@ -503,6 +511,7 @@ async def edit_message_impl(
         new_text: The new text content for the message
         parse_mode: Parse mode ('markdown' or 'html')
     """
+    parse_mode = _normalize_parse_mode(parse_mode)
     params = {
         "chat_id": chat_id,
         "message_id": message_id,
@@ -751,6 +760,7 @@ async def send_message_to_phone_impl(
         - contact_was_new: Whether a new contact was created during this operation
         - contact_removed: Whether the contact was removed (only if it was newly created)
     """
+    parse_mode = _normalize_parse_mode(parse_mode)
     params = {
         "phone_number": phone_number,
         "message": message,

--- a/src/tools/messages.py
+++ b/src/tools/messages.py
@@ -27,9 +27,7 @@ logger = logging.getLogger(__name__)
 
 def _normalize_parse_mode(parse_mode: str | None) -> str | None:
     """Lowercase parse_mode so HTML, AUTO, Markdown etc. are processed correctly."""
-    if parse_mode is None:
-        return None
-    return parse_mode.lower() if isinstance(parse_mode, str) else parse_mode
+    return parse_mode.lower() if parse_mode is not None else None
 
 
 def detect_message_formatting(message: str) -> str | None:

--- a/tests/test_message_formatting.py
+++ b/tests/test_message_formatting.py
@@ -2,9 +2,19 @@
 Tests for message formatting detection functionality.
 """
 
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
-from src.tools.messages import detect_message_formatting
+from src.tools.messages import (
+    _normalize_parse_mode,
+    detect_message_formatting,
+    edit_message_impl,
+    send_message_impl,
+    send_message_to_phone_impl,
+)
 
 
 class TestMessageFormattingDetection:
@@ -170,3 +180,161 @@ code block
     def test_parametrized_detection(self, text, expected):
         """Parametrized test for various detection scenarios."""
         assert detect_message_formatting(text) == expected
+
+
+class TestParseModeNormalization:
+    """Test cases for _normalize_parse_mode function."""
+
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            (None, None),
+            ("html", "html"),
+            ("HTML", "html"),
+            ("Html", "html"),
+            ("markdown", "markdown"),
+            ("Markdown", "markdown"),
+            ("MARKDOWN", "markdown"),
+            ("auto", "auto"),
+            ("AUTO", "auto"),
+            ("Auto", "auto"),
+        ],
+    )
+    def test_normalize_parse_mode(self, input_val, expected):
+        """Parse mode should be lowercased for consistent processing."""
+        assert _normalize_parse_mode(input_val) == expected
+
+
+class TestParseModeAutodetectionIntegration:
+    """Integration tests for parse mode processing in send/edit message flows."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "parse_mode_input,message,expected_resolved",
+        [
+            ("auto", "<b>Bold</b>", "html"),
+            ("AUTO", "<b>Bold</b>", "html"),
+            ("Auto", "<b>Bold</b>", "html"),
+            ("auto", "**bold**", "markdown"),
+            ("AUTO", "**bold**", "markdown"),
+            ("auto", "Plain text", None),
+            ("auto", "", None),
+            ("HTML", "<b>Bold</b>", "html"),
+            ("html", "<b>Bold</b>", "html"),
+            ("MARKDOWN", "**bold**", "markdown"),
+            ("markdown", "**bold**", "markdown"),
+        ],
+    )
+    async def test_send_message_impl_parse_mode_resolution(
+        self, parse_mode_input, message, expected_resolved
+    ):
+        """send_message_impl resolves and lowercases parse_mode correctly."""
+        chat = SimpleNamespace(id=123456, broadcast=False, megagroup=False)
+        sent_msg = SimpleNamespace(id=1, text=message, date=datetime.now())
+
+        with (
+            patch(
+                "src.tools.messages.get_connected_client",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.messages.get_entity_by_id",
+                new_callable=AsyncMock,
+                return_value=chat,
+            ),
+            patch(
+                "src.tools.messages.get_post_discussion_info",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.messages._send_message_or_files",
+                new_callable=AsyncMock,
+                return_value=(None, sent_msg),
+            ) as mock_send,
+        ):
+            await send_message_impl(
+                chat_id="123456",
+                message=message,
+                parse_mode=parse_mode_input,
+            )
+
+        mock_send.assert_awaited_once()
+        resolved_parse_mode = mock_send.await_args[0][5]
+        assert resolved_parse_mode == expected_resolved, (
+            f"parse_mode={parse_mode_input!r}, message={message!r} -> "
+            f"expected {expected_resolved!r}, got {resolved_parse_mode!r}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "parse_mode_input,new_text,expected_resolved",
+        [
+            ("auto", "<i>Italic</i>", "html"),
+            ("AUTO", "# Header", "markdown"),
+            ("auto", "Plain", None),
+            ("HTML", "<b>Bold</b>", "html"),
+            ("MARKDOWN", "`code`", "markdown"),
+        ],
+    )
+    async def test_edit_message_impl_parse_mode_resolution(
+        self, parse_mode_input, new_text, expected_resolved
+    ):
+        """edit_message_impl resolves and lowercases parse_mode correctly."""
+        chat = SimpleNamespace(id=123456, broadcast=False, megagroup=False)
+        edited_msg = SimpleNamespace(id=1, text=new_text, date=datetime.now())
+
+        client = AsyncMock()
+        client.edit_message = AsyncMock(return_value=edited_msg)
+
+        with (
+            patch(
+                "src.tools.messages.get_connected_client",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "src.tools.messages.get_entity_by_id",
+                new=AsyncMock(return_value=chat),
+            ),
+        ):
+            result = await edit_message_impl(
+                chat_id="123456",
+                message_id=1,
+                new_text=new_text,
+                parse_mode=parse_mode_input,
+            )
+
+        assert result["status"] == "edited"
+        client.edit_message.assert_awaited_once()
+        call_kwargs = client.edit_message.await_args[1]
+        assert call_kwargs["parse_mode"] == expected_resolved
+
+    @pytest.mark.asyncio
+    async def test_send_message_to_phone_impl_parse_mode_auto_resolution(self):
+        """send_message_to_phone_impl resolves AUTO with content detection."""
+        user = SimpleNamespace(id=999, first_name="Test")
+        sent_msg = SimpleNamespace(id=1, text="<b>Bold</b>", date=datetime.now())
+
+        client = AsyncMock()
+        client.get_entity = AsyncMock(return_value=user)
+
+        with (
+            patch(
+                "src.tools.messages.get_connected_client",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "src.tools.messages._send_message_or_files",
+                new_callable=AsyncMock,
+                return_value=(None, sent_msg),
+            ) as mock_send,
+        ):
+            result = await send_message_to_phone_impl(
+                phone_number="+1234567890",
+                message="<b>Bold</b>",
+                parse_mode="AUTO",
+            )
+
+        mock_send.assert_awaited_once()
+        resolved_parse_mode = mock_send.await_args[0][5]
+        assert resolved_parse_mode == "html"
+        assert result["status"] == "sent"

--- a/tests/test_message_formatting.py
+++ b/tests/test_message_formatting.py
@@ -209,6 +209,115 @@ class TestParseModeAutodetectionIntegration:
     """Integration tests for parse mode processing in send/edit message flows."""
 
     @pytest.mark.asyncio
+    async def test_send_message_impl_parse_mode_none_uses_no_autodetection(self):
+        """parse_mode=None skips autodetection and passes None through."""
+        chat = SimpleNamespace(id=123456, broadcast=False, megagroup=False)
+        sent_msg = SimpleNamespace(id=1, text="hello", date=datetime.now())
+
+        with (
+            patch(
+                "src.tools.messages.get_connected_client",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.messages.get_entity_by_id",
+                new_callable=AsyncMock,
+                return_value=chat,
+            ),
+            patch(
+                "src.tools.messages.get_post_discussion_info",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.tools.messages.detect_message_formatting",
+            ) as mock_detect,
+            patch(
+                "src.tools.messages._send_message_or_files",
+                new_callable=AsyncMock,
+                return_value=(None, sent_msg),
+            ) as mock_send,
+        ):
+            await send_message_impl(
+                chat_id="123456",
+                message="<b>Bold</b>",
+                parse_mode=None,
+            )
+
+        mock_detect.assert_not_called()
+        mock_send.assert_awaited_once()
+        _, _, _, _, _, resolved_parse_mode, _, _ = mock_send.await_args[0]
+        assert resolved_parse_mode is None
+
+    @pytest.mark.asyncio
+    async def test_edit_message_impl_parse_mode_none_uses_no_autodetection(self):
+        """parse_mode=None skips autodetection and passes None through."""
+        chat = SimpleNamespace(id=123456, broadcast=False, megagroup=False)
+        edited_msg = SimpleNamespace(id=1, text="<b>Bold</b>", date=datetime.now())
+
+        client = AsyncMock()
+        client.edit_message = AsyncMock(return_value=edited_msg)
+
+        with (
+            patch(
+                "src.tools.messages.get_connected_client",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "src.tools.messages.get_entity_by_id",
+                new=AsyncMock(return_value=chat),
+            ),
+            patch(
+                "src.tools.messages.detect_message_formatting",
+            ) as mock_detect,
+        ):
+            await edit_message_impl(
+                chat_id="123456",
+                message_id=1,
+                new_text="<b>Bold</b>",
+                parse_mode=None,
+            )
+
+        mock_detect.assert_not_called()
+        client.edit_message.assert_awaited_once()
+        assert client.edit_message.await_args[1]["parse_mode"] is None
+
+    @pytest.mark.asyncio
+    async def test_send_message_to_phone_impl_parse_mode_none_uses_no_autodetection(
+        self,
+    ):
+        """parse_mode=None skips autodetection and passes None through."""
+        user = SimpleNamespace(id=999, first_name="Test")
+        sent_msg = SimpleNamespace(id=1, text="<b>Bold</b>", date=datetime.now())
+
+        client = AsyncMock()
+        client.get_entity = AsyncMock(return_value=user)
+
+        with (
+            patch(
+                "src.tools.messages.get_connected_client",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "src.tools.messages.detect_message_formatting",
+            ) as mock_detect,
+            patch(
+                "src.tools.messages._send_message_or_files",
+                new_callable=AsyncMock,
+                return_value=(None, sent_msg),
+            ) as mock_send,
+        ):
+            await send_message_to_phone_impl(
+                phone_number="+1234567890",
+                message="<b>Bold</b>",
+                parse_mode=None,
+            )
+
+        mock_detect.assert_not_called()
+        mock_send.assert_awaited_once()
+        _, _, _, _, _, resolved_parse_mode, _, _ = mock_send.await_args[0]
+        assert resolved_parse_mode is None
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "parse_mode_input,message,expected_resolved",
         [
@@ -259,7 +368,7 @@ class TestParseModeAutodetectionIntegration:
             )
 
         mock_send.assert_awaited_once()
-        resolved_parse_mode = mock_send.await_args[0][5]
+        _, _, _, _, _, resolved_parse_mode, _, _ = mock_send.await_args[0]
         assert resolved_parse_mode == expected_resolved, (
             f"parse_mode={parse_mode_input!r}, message={message!r} -> "
             f"expected {expected_resolved!r}, got {resolved_parse_mode!r}"
@@ -309,10 +418,27 @@ class TestParseModeAutodetectionIntegration:
         assert call_kwargs["parse_mode"] == expected_resolved
 
     @pytest.mark.asyncio
-    async def test_send_message_to_phone_impl_parse_mode_auto_resolution(self):
-        """send_message_to_phone_impl resolves AUTO with content detection."""
+    @pytest.mark.parametrize(
+        "parse_mode_input,message,expected_resolved",
+        [
+            ("AUTO", "<b>Bold</b>", "html"),
+            ("auto", "<b>Bold</b>", "html"),
+            ("Auto", "<b>Bold</b>", "html"),
+            ("AUTO", "**bold**", "markdown"),
+            ("auto", "**bold**", "markdown"),
+            ("AUTO", "just plain text", None),
+            ("HTML", "<b>Bold</b>", "html"),
+            ("html", "<b>Bold</b>", "html"),
+            ("MARKDOWN", "**bold**", "markdown"),
+            ("markdown", "**bold**", "markdown"),
+        ],
+    )
+    async def test_send_message_to_phone_impl_parse_mode_resolution(
+        self, parse_mode_input, message, expected_resolved
+    ):
+        """send_message_to_phone_impl normalizes and resolves parse_mode for phone messages."""
         user = SimpleNamespace(id=999, first_name="Test")
-        sent_msg = SimpleNamespace(id=1, text="<b>Bold</b>", date=datetime.now())
+        sent_msg = SimpleNamespace(id=1, text=message, date=datetime.now())
 
         client = AsyncMock()
         client.get_entity = AsyncMock(return_value=user)
@@ -330,11 +456,14 @@ class TestParseModeAutodetectionIntegration:
         ):
             result = await send_message_to_phone_impl(
                 phone_number="+1234567890",
-                message="<b>Bold</b>",
-                parse_mode="AUTO",
+                message=message,
+                parse_mode=parse_mode_input,
             )
 
         mock_send.assert_awaited_once()
-        resolved_parse_mode = mock_send.await_args[0][5]
-        assert resolved_parse_mode == "html"
+        _, _, _, _, _, resolved_parse_mode, _, _ = mock_send.await_args[0]
+        assert resolved_parse_mode == expected_resolved, (
+            f"parse_mode={parse_mode_input!r}, message={message!r} -> "
+            f"expected {expected_resolved!r}, got {resolved_parse_mode!r}"
+        )
         assert result["status"] == "sent"

--- a/tests/test_message_formatting.py
+++ b/tests/test_message_formatting.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.tools.messages import (
-    _normalize_parse_mode,
     detect_message_formatting,
     edit_message_impl,
     send_message_impl,
@@ -180,29 +179,6 @@ code block
     def test_parametrized_detection(self, text, expected):
         """Parametrized test for various detection scenarios."""
         assert detect_message_formatting(text) == expected
-
-
-class TestParseModeNormalization:
-    """Test cases for _normalize_parse_mode function."""
-
-    @pytest.mark.parametrize(
-        "input_val,expected",
-        [
-            (None, None),
-            ("html", "html"),
-            ("HTML", "html"),
-            ("Html", "html"),
-            ("markdown", "markdown"),
-            ("Markdown", "markdown"),
-            ("MARKDOWN", "markdown"),
-            ("auto", "auto"),
-            ("AUTO", "auto"),
-            ("Auto", "auto"),
-        ],
-    )
-    def test_normalize_parse_mode(self, input_val, expected):
-        """Parse mode should be lowercased for consistent processing."""
-        assert _normalize_parse_mode(input_val) == expected
 
 
 class TestParseModeAutodetectionIntegration:


### PR DESCRIPTION
Lowercase `parse_mode` values and expand test coverage for parse mode autodetection.

This ensures that `HTML`, `AUTO`, and other parse modes are consistently processed regardless of their casing, improving the reliability of message formatting.

---
<p><a href="https://cursor.com/agents/bc-12dd18e3-c785-46c4-aaa1-c586f79474a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12dd18e3-c785-46c4-aaa1-c586f79474a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

Новые возможности:
- Добавлен вспомогательный метод для нормализации значений `parse_mode` перед обработкой.

Улучшения:
- Применена нормализация `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы `AUTO`/`HTML`/`MARKDOWN` обрабатывались единообразно независимо от регистра.

Тесты:
- Добавлены модульные тесты для нормализации `parse_mode` и интеграционные тесты, покрывающие автоопределение и разрешение в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

Новые возможности:
- Добавлен вспомогательный метод для нормализации значений `parse_mode` перед обработкой.

Улучшения:
- Применена нормализация `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы `AUTO`/`HTML`/`MARKDOWN` обрабатывались единообразно независимо от регистра.

Тесты:
- Добавлены модульные тесты для нормализации `parse_mode` и интеграционные тесты, покрывающие автоопределение и разрешение в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

</details>

</details>

Новые возможности:
- Добавлен специализированный вспомогательный метод нормализации `parse_mode` для стандартизации значений `parse_mode` перед обработкой.

Улучшения:
- Применена нормализация `parse_mode` в реализациях отправки, редактирования и телефонной отправки сообщений, чтобы значения AUTO, HTML, MARKDOWN и им подобные обрабатывались единообразно независимо от регистра.

Тесты:
- Добавлены модульные тесты для нормализации `parse_mode` и интеграционные тесты, проверяющие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

Новые возможности:
- Добавлен вспомогательный метод для нормализации значений `parse_mode` перед обработкой.

Улучшения:
- Применена нормализация `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы `AUTO`/`HTML`/`MARKDOWN` обрабатывались единообразно независимо от регистра.

Тесты:
- Добавлены модульные тесты для нормализации `parse_mode` и интеграционные тесты, покрывающие автоопределение и разрешение в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

Новые возможности:
- Добавлен вспомогательный метод для нормализации значений `parse_mode` перед обработкой.

Улучшения:
- Применена нормализация `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы `AUTO`/`HTML`/`MARKDOWN` обрабатывались единообразно независимо от регистра.

Тесты:
- Добавлены модульные тесты для нормализации `parse_mode` и интеграционные тесты, покрывающие автоопределение и разрешение в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Нормализовать обработку `parse_mode` в потоках отправки и редактирования сообщений и добавить интеграционные тесты для автоопределения и разрешения режима парсинга.

Новые возможности:
- Ввести вспомогательную функцию для нормализации значений `parse_mode` к единому нижнему регистру перед обработкой.

Улучшения:
- Применить нормализацию `parse_mode` в реализациях отправки, редактирования и телефонных сообщений, чтобы значения вида `AUTO`/`HTML`/`MARKDOWN` и подобные обрабатывались без учета регистра.
- Гарантировать, что `parse_mode=None` обходит автоопределение и передается дальше в потоках сообщений без изменений.

Тесты:
- Добавить интеграционные тесты, покрывающие автоопределение и разрешение `parse_mode` в `send_message_impl`, `edit_message_impl` и `send_message_to_phone_impl`.
- Расширить модульные тесты для проверки корректного поведения, когда `parse_mode` имеет значение `None` и когда передаются варианты с разным регистром.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parse_mode handling across message sending and editing flows and add integration tests for parse mode autodetection and resolution.

New Features:
- Introduce a helper to normalize parse_mode values to a consistent lowercase representation before processing.

Enhancements:
- Apply parse_mode normalization in send, edit, and phone message implementations so AUTO/HTML/MARKDOWN and similar values are handled case-insensitively.
- Ensure parse_mode=None bypasses autodetection and is passed through unchanged in message flows.

Tests:
- Add integration tests covering parse_mode autodetection and resolution in send_message_impl, edit_message_impl, and send_message_to_phone_impl.
- Extend unit tests to verify correct behavior when parse_mode is None and when different casing variants are supplied.

</details>

</details>

</details>

</details>