### PR TITLE
Clarify stdio-only local file paths in tool docstrings

### DIFF
--- a/src/tools/messages/phone.py
+++ b/src/tools/messages/phone.py
@@ -50,7 +50,8 @@ async def send_message_to_phone_impl(
         remove_if_new: Whether to remove the contact if it was newly created (default: False)
         reply_to_msg_id: ID of the message to reply to (optional)
         parse_mode: Parse mode for message formatting (optional)
-        files: Single file or list of files (URLs or local paths)
+        files: Single file or list of files. URLs (http/https) work in all server modes;
+            local filesystem paths are only allowed in stdio mode (blocked for HTTP transports).
 
     Returns:
         Dictionary with operation results consistent with send_message format, plus:

--- a/src/tools/messages/security.py
+++ b/src/tools/messages/security.py
@@ -82,6 +82,9 @@ def _validate_file_paths(
     """
     Normalize and validate file paths with security checks.
 
+    Local paths (non-URL strings) are rejected unless the server runs in stdio mode;
+    HTTP transports (http-no-auth, http-auth) only accept http(s) URLs.
+
     Returns:
         (file_list, error): file_list if valid, error dict if validation fails
     """

--- a/src/tools/messages/sending.py
+++ b/src/tools/messages/sending.py
@@ -143,7 +143,8 @@ async def send_message_impl(
         reply_to_id: ID of the message to reply to. For forum chats, pass topic root ID.
             For channel posts, automatically posts comment in discussion group.
         parse_mode: Parse mode ('markdown' or 'html')
-        files: Single file or list of files (URLs or local paths)
+        files: Single file or list of files. URLs (http/https) work in all server modes;
+            local filesystem paths are only allowed in stdio mode (blocked for HTTP transports).
     """
     parse_mode = _normalize_parse_mode(parse_mode)
     resolved_parse_mode = parse_mode


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

1. **Docstrings**: Clarify that local file paths only work in stdio; URLs work in all modes (`sending.py`, `phone.py`, `security.py`).

2. **MediaInvalidError fix**: Single-URL `send_message` previously passed the raw URL string to Telethon, which could trigger `UploadMediaRequest` / `MediaInvalidError` for non-photo content (e.g. session export, HTML). Now all http(s) entries are downloaded to `BytesIO` with a basename-derived `.name` (same as multi-URL). `force_document` is `True` unless every basename looks like a raster image (`.jpg`, `.png`, etc.), so generic files upload as documents instead of failed photo uploads.

## Tests

- New: `tests/test_file_handling_send.py` for `prepare_files_for_send` and `force_document_for_file_list`.

## Note

Unrelated pre-existing failure: `tests/test_auth_url_token.py::TestUrlTokenMiddlewareIntegration::test_full_flow_with_valid_token` (Starlette `route` vs `router`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67716339-5bc7-4722-91c5-65f4f2845678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67716339-5bc7-4722-91c5-65f4f2845678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Уточнить документацию инструментов отправки сообщений в отношении вложений файлов по URL и из локальной файловой системы в разных режимах сервера.

Документация:
- Задокументировать, что инструменты отправки сообщений принимают http/https URL во всех режимах сервера, но позволяют использовать пути локальной файловой системы только при работе в режиме stdio.
- Описать поведение `_validate_file_paths`, которое отклоняет локальные пути для HTTP‑транспортов и ограничивает их использованием только в режиме stdio.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify documentation of message-sending tools regarding URL and local filesystem file attachments across different server modes.

Documentation:
- Document that message tools accept http/https URLs in all server modes but only allow local filesystem paths when running in stdio mode.
- Describe `_validate_file_paths` behavior rejecting local paths for HTTP transports and limiting them to stdio mode.

</details>

Документация:
- Объяснить, что инструменты обмена сообщениями принимают http/https URL во всех режимах сервера, но допускают использование локальных путей файловой системы только при запуске в режиме stdio.
- Задокументировать поведение `_validate_file_paths`, связанное с отклонением локальных путей для HTTP-транспортов и ограничением их использования режимом stdio.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Уточнить документацию инструментов отправки сообщений в отношении вложений файлов по URL и из локальной файловой системы в разных режимах сервера.

Документация:
- Задокументировать, что инструменты отправки сообщений принимают http/https URL во всех режимах сервера, но позволяют использовать пути локальной файловой системы только при работе в режиме stdio.
- Описать поведение `_validate_file_paths`, которое отклоняет локальные пути для HTTP‑транспортов и ограничивает их использованием только в режиме stdio.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify documentation of message-sending tools regarding URL and local filesystem file attachments across different server modes.

Documentation:
- Document that message tools accept http/https URLs in all server modes but only allow local filesystem paths when running in stdio mode.
- Describe `_validate_file_paths` behavior rejecting local paths for HTTP transports and limiting them to stdio mode.

</details>

</details>