### PR TITLE
Fix MediaInvalidError for single-URL file sends

### DIFF
--- a/src/tools/messages/file_handling.py
+++ b/src/tools/messages/file_handling.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from io import BytesIO
 
 import httpx
@@ -20,7 +21,13 @@ _IMAGE_SUFFIXES = frozenset(
 
 
 def _basename_from_url_or_path(url_or_path: str) -> str:
-    return url_or_path.split("/")[-1].split("?")[0]
+    """
+    Basename of a URL or filesystem path, without a query string.
+
+    Uses os.path.basename so POSIX and Windows path separators both work.
+    """
+    path_without_query = url_or_path.split("?", 1)[0]
+    return os.path.basename(path_without_query)
 
 
 def _is_likely_image_filename(url_or_path: str) -> bool:
@@ -44,7 +51,7 @@ def force_document_for_file_list(file_list: list[str]) -> bool:
     return not all(_is_likely_image_filename(f) for f in file_list)
 
 
-async def prepare_files_for_send(file_list: list[str]) -> list:
+async def prepare_files_for_send(file_list: list[str]) -> list[BytesIO | str]:
     """
     Resolve http(s) URLs to BytesIO with a .name for type detection; keep local paths as-is.
 
@@ -60,7 +67,7 @@ async def prepare_files_for_send(file_list: list[str]) -> list:
     for u, content in zip(url_entries, downloaded, strict=True):
         url_to_content[u] = content
 
-    out: list = []
+    out: list[BytesIO | str] = []
     for f in file_list:
         if not f.startswith(("http://", "https://")):
             out.append(f)

--- a/src/tools/messages/file_handling.py
+++ b/src/tools/messages/file_handling.py
@@ -13,6 +13,68 @@ from src.tools.messages.security import _validate_url_security
 
 logger = logging.getLogger(__name__)
 
+# Filename suffixes Telethon can reliably treat as photos when force_document=False.
+_IMAGE_SUFFIXES = frozenset(
+    (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tif", ".tiff")
+)
+
+
+def _basename_from_url_or_path(url_or_path: str) -> str:
+    return url_or_path.split("/")[-1].split("?")[0]
+
+
+def _is_likely_image_filename(url_or_path: str) -> bool:
+    """Whether the path/URL basename looks like a raster image (for send_file hint)."""
+    base = _basename_from_url_or_path(url_or_path)
+    if not base:
+        return False
+    lower = base.lower()
+    return any(lower.endswith(s) for s in _IMAGE_SUFFIXES)
+
+
+def force_document_for_file_list(file_list: list[str]) -> bool:
+    """
+    If False, Telethon may upload as photo(s). If True, send as generic file/document.
+
+    Use True unless every entry looks like an image filename — avoids MediaInvalidError
+    when a URL returns HTML or non-photo bytes but Telethon tries photo upload.
+    """
+    if not file_list:
+        return True
+    return not all(_is_likely_image_filename(f) for f in file_list)
+
+
+async def prepare_files_for_send(file_list: list[str]) -> list:
+    """
+    Resolve http(s) URLs to BytesIO with a .name for type detection; keep local paths as-is.
+
+    Single-URL sends previously passed the raw URL string to Telethon, which could trigger
+    MediaInvalidError for non-images; downloading here matches multi-URL behavior.
+    """
+    if not any(f.startswith(("http://", "https://")) for f in file_list):
+        return file_list
+
+    url_entries = [f for f in file_list if f.startswith(("http://", "https://"))]
+    downloaded = await _download_urls_to_bytes(url_entries)
+    url_to_content: dict[str, bytes | str] = {}
+    for u, content in zip(url_entries, downloaded, strict=True):
+        url_to_content[u] = content
+
+    out: list = []
+    for f in file_list:
+        if not f.startswith(("http://", "https://")):
+            out.append(f)
+            continue
+        content = url_to_content[f]
+        if isinstance(content, bytes):
+            filename = _basename_from_url_or_path(f) or "file"
+            file_obj = BytesIO(content)
+            file_obj.name = filename
+            out.append(file_obj)
+        else:
+            out.append(content)
+    return out
+
 
 async def _download_single_file(
     http_client: httpx.AsyncClient, url: str
@@ -96,7 +158,7 @@ def _wrap_bytes_in_file_objects(
     file_objects = []
     for i, content in enumerate(downloaded_files):
         if isinstance(content, bytes):
-            filename = file_list[i].split("/")[-1].split("?")[0]
+            filename = _basename_from_url_or_path(file_list[i]) or "file"
             file_obj = BytesIO(content)
             file_obj.name = filename
             file_objects.append(file_obj)

--- a/src/tools/messages/sending.py
+++ b/src/tools/messages/sending.py
@@ -9,8 +9,8 @@ from src.client.connection import get_connected_client
 from src.tools.messages.core import _normalize_parse_mode, detect_message_formatting
 from src.tools.messages.file_handling import (
     _calculate_file_count,
-    _download_urls_to_bytes,
-    _wrap_bytes_in_file_objects,
+    force_document_for_file_list,
+    prepare_files_for_send,
 )
 from src.tools.messages.security import _validate_file_paths
 from src.utils.discussion import get_post_discussion_info
@@ -38,32 +38,21 @@ async def _send_files_to_entity(
     """
     Send files to an entity, handling both single and multiple files.
 
-    For multiple URLs, downloads them and wraps in BytesIO with .name for proper photo detection.
-    Returns a single message (or first message of album).
+    Http(s) URLs are downloaded first (with .name from the URL) so Telethon does not
+    mis-detect non-images as photos. force_document is set unless all names look like
+    raster images, avoiding MediaInvalidError for HTML/session exports and similar.
     """
-    if len(file_list) > 1 and any(
-        f.startswith(("http://", "https://")) for f in file_list
-    ):
-        logger.debug("Multiple URLs detected, downloading files for album")
-        downloaded_files = await _download_urls_to_bytes(file_list)
-        file_objects = _wrap_bytes_in_file_objects(file_list, downloaded_files)
-
-        result = await client.send_file(
-            entity=entity,
-            file=file_objects,
-            caption=message or None,
-            reply_to=reply_to_msg_id,
-            parse_mode=parse_mode,
-            force_document=False,
-        )
-        return _extract_first_message(result)
+    prepared = await prepare_files_for_send(file_list)
+    force_doc = force_document_for_file_list(file_list)
+    file_arg = prepared[0] if len(prepared) == 1 else prepared
 
     result = await client.send_file(
         entity=entity,
-        file=file_list,
+        file=file_arg,
         caption=message or None,
         reply_to=reply_to_msg_id,
         parse_mode=parse_mode,
+        force_document=force_doc,
     )
     return _extract_first_message(result)
 

--- a/tests/test_file_handling_send.py
+++ b/tests/test_file_handling_send.py
@@ -1,0 +1,52 @@
+"""Tests for file preparation and force_document hints for send_file."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.tools.messages.file_handling import (
+    force_document_for_file_list,
+    prepare_files_for_send,
+)
+
+
+def test_force_document_true_for_non_image_suffix() -> None:
+    assert force_document_for_file_list(["https://x/a/session.export"]) is True
+    assert force_document_for_file_list(["https://x/a/file.html"]) is True
+    assert force_document_for_file_list(["https://x/a/file"]) is True
+
+
+def test_force_document_false_only_when_all_image_suffixes() -> None:
+    assert force_document_for_file_list(["https://x/a/photo.jpg"]) is False
+    assert force_document_for_file_list(["https://x/a/1.png", "https://y/b/2.webp"]) is False
+
+
+def test_force_document_mixed_list() -> None:
+    assert force_document_for_file_list(["https://x/a/1.jpg", "https://y/b/doc.pdf"]) is True
+
+
+@pytest.mark.asyncio
+async def test_prepare_files_for_send_downloads_http_url() -> None:
+    mock_bytes = b"fake-content"
+    with patch(
+        "src.tools.messages.file_handling._download_urls_to_bytes",
+        new_callable=AsyncMock,
+        return_value=[mock_bytes],
+    ) as dl:
+        out = await prepare_files_for_send(["https://example.com/export/session.bin"])
+    dl.assert_awaited_once_with(["https://example.com/export/session.bin"])
+    assert len(out) == 1
+    f = out[0]
+    assert f.name == "session.bin"
+    assert f.getvalue() == mock_bytes
+
+
+@pytest.mark.asyncio
+async def test_prepare_files_for_send_keeps_local_path() -> None:
+    with patch(
+        "src.tools.messages.file_handling._download_urls_to_bytes",
+        new_callable=AsyncMock,
+    ) as dl:
+        out = await prepare_files_for_send(["/tmp/local.pdf"])
+    dl.assert_not_called()
+    assert out == ["/tmp/local.pdf"]

--- a/tests/test_file_handling_send.py
+++ b/tests/test_file_handling_send.py
@@ -25,6 +25,11 @@ def test_force_document_mixed_list() -> None:
     assert force_document_for_file_list(["https://x/a/1.jpg", "https://y/b/doc.pdf"]) is True
 
 
+def test_force_document_windows_style_path_with_forward_slashes() -> None:
+    """os.path.basename handles C:/tmp/image.jpg; backslash paths need a Windows runtime."""
+    assert force_document_for_file_list(["C:/tmp/image.jpg"]) is False
+
+
 @pytest.mark.asyncio
 async def test_prepare_files_for_send_downloads_http_url() -> None:
     mock_bytes = b"fake-content"
@@ -50,3 +55,70 @@ async def test_prepare_files_for_send_keeps_local_path() -> None:
         out = await prepare_files_for_send(["/tmp/local.pdf"])
     dl.assert_not_called()
     assert out == ["/tmp/local.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_files_for_send_multiple_http_urls() -> None:
+    b1, b2 = b"a", b"b"
+    with patch(
+        "src.tools.messages.file_handling._download_urls_to_bytes",
+        new_callable=AsyncMock,
+        return_value=[b1, b2],
+    ) as dl:
+        out = await prepare_files_for_send(
+            [
+                "https://a.com/first/one.png",
+                "https://b.com/second/two.png",
+            ]
+        )
+    dl.assert_awaited_once_with(
+        ["https://a.com/first/one.png", "https://b.com/second/two.png"]
+    )
+    assert len(out) == 2
+    assert out[0].name == "one.png"
+    assert out[0].getvalue() == b1
+    assert out[1].name == "two.png"
+    assert out[1].getvalue() == b2
+
+
+@pytest.mark.asyncio
+async def test_prepare_files_for_send_mixed_local_and_url() -> None:
+    data = b"remote"
+    with patch(
+        "src.tools.messages.file_handling._download_urls_to_bytes",
+        new_callable=AsyncMock,
+        return_value=[data],
+    ) as dl:
+        out = await prepare_files_for_send(
+            ["/tmp/local.txt", "https://x/a/session.bin"]
+        )
+    dl.assert_awaited_once_with(["https://x/a/session.bin"])
+    assert out[0] == "/tmp/local.txt"
+    assert out[1].name == "session.bin"
+    assert out[1].getvalue() == data
+
+
+@pytest.mark.asyncio
+async def test_prepare_files_for_send_fallback_name_when_url_has_no_filename() -> None:
+    mock_bytes = b"x"
+    with patch(
+        "src.tools.messages.file_handling._download_urls_to_bytes",
+        new_callable=AsyncMock,
+        return_value=[mock_bytes],
+    ) as dl:
+        out = await prepare_files_for_send(["https://example.com/"])
+    dl.assert_awaited_once_with(["https://example.com/"])
+    assert out[0].name == "file"
+    assert out[0].getvalue() == mock_bytes
+
+
+@pytest.mark.asyncio
+async def test_prepare_files_for_send_passes_through_str_from_downloader() -> None:
+    with patch(
+        "src.tools.messages.file_handling._download_urls_to_bytes",
+        new_callable=AsyncMock,
+        return_value=["not-bytes"],
+    ) as dl:
+        out = await prepare_files_for_send(["https://example.com/x.bin"])
+    dl.assert_awaited_once()
+    assert out == ["not-bytes"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `Media invalid (caused by UploadMediaRequest)` when `send_message` is called with a **single** http(s) URL in `files` (e.g. session export, HTML, or other non-photo content).

## Problem

Single-URL sends passed the raw URL string to Telethon. Multi-URL sends downloaded to `BytesIO` first. The mismatch led Telethon to mis-classify uploads and fail `UploadMediaRequest`.

## Solution

- Download **all** http(s) entries before `send_file`, with basename-derived `.name` on `BytesIO`.
- Set `force_document=True` unless every basename looks like a raster image (`.jpg`, `.png`, etc.) so generic files upload as documents.

## Tests

- `tests/test_file_handling_send.py` for `prepare_files_for_send` and `force_document_for_file_list`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67716339-5bc7-4722-91c5-65f4f2845678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67716339-5bc7-4722-91c5-65f4f2845678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Единообразная обработка HTTP(S) файловых URL перед отправкой в Telethon, чтобы избежать неправильной классификации загрузок и ошибок MediaInvalidError, а также улучшение эвристики определения типа файлов для `send_file`.

Исправления ошибок:
- Предотвращение MediaInvalidError при отправке одного HTTP(S) URL за счёт предварительного скачивания содержимого перед передачей в Telethon и установки подходящей подсказки `force_document`.

Улучшения:
- Введение эвристик, основанных на `basename`, для решения, когда файлы следует считать изображениями, а когда — обычными документами при загрузках через Telethon.
- Централизация извлечения `basename` из URL/пути для единообразного наименования скачанного содержимого и определения типа во всех ветках кода.

Тесты:
- Добавлены тесты для `prepare_files_for_send` и `force_document_for_file_list`, проверяющие скачивание по URL, обработку имён файлов и эвристику «изображение против документа».

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle HTTP(S) file URLs uniformly before sending to Telethon to avoid misclassification of uploads and MediaInvalidError, and improve file-type heuristics for send_file.

Bug Fixes:
- Prevent MediaInvalidError when sending a single HTTP(S) URL by downloading the content before passing it to Telethon and setting an appropriate force_document hint.

Enhancements:
- Introduce basename-based heuristics to decide when files should be treated as images versus generic documents for Telethon uploads.
- Centralize URL/path basename extraction for consistent naming of downloaded content and type detection across code paths.

Tests:
- Add tests for prepare_files_for_send and force_document_for_file_list covering URL downloading, filename handling, and image-versus-document heuristics.

</details>

Исправления ошибок:
- Исправление `MediaInvalidError` при отправке одного HTTP(S)-URL за счёт предварительного скачивания содержимого перед передачей его в Telethon и установки подходящей подсказки `force_document`.

Улучшения:
- Введение эвристик на основе базовых имён (basename) URL/путей для принятия решения, когда файлы следует обрабатывать как изображения, а когда — как обычные документы.
- Централизация извлечения basename из URL/путей для обеспечения единообразного именования скачанного содержимого при определении типа.

Тесты:
- Добавлены тесты для `prepare_files_for_send` и `force_document_for_file_list`, охватывающие скачивание по URL, обработку имён файлов и эвристики для документов/фотографий.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Единообразная обработка HTTP(S) файловых URL перед отправкой в Telethon, чтобы избежать неправильной классификации загрузок и ошибок MediaInvalidError, а также улучшение эвристики определения типа файлов для `send_file`.

Исправления ошибок:
- Предотвращение MediaInvalidError при отправке одного HTTP(S) URL за счёт предварительного скачивания содержимого перед передачей в Telethon и установки подходящей подсказки `force_document`.

Улучшения:
- Введение эвристик, основанных на `basename`, для решения, когда файлы следует считать изображениями, а когда — обычными документами при загрузках через Telethon.
- Централизация извлечения `basename` из URL/пути для единообразного наименования скачанного содержимого и определения типа во всех ветках кода.

Тесты:
- Добавлены тесты для `prepare_files_for_send` и `force_document_for_file_list`, проверяющие скачивание по URL, обработку имён файлов и эвристику «изображение против документа».

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle HTTP(S) file URLs uniformly before sending to Telethon to avoid misclassification of uploads and MediaInvalidError, and improve file-type heuristics for send_file.

Bug Fixes:
- Prevent MediaInvalidError when sending a single HTTP(S) URL by downloading the content before passing it to Telethon and setting an appropriate force_document hint.

Enhancements:
- Introduce basename-based heuristics to decide when files should be treated as images versus generic documents for Telethon uploads.
- Centralize URL/path basename extraction for consistent naming of downloaded content and type detection across code paths.

Tests:
- Add tests for prepare_files_for_send and force_document_for_file_list covering URL downloading, filename handling, and image-versus-document heuristics.

</details>

</details>

Исправления ошибок:
- Исправить `MediaInvalidError` при отправке одного HTTP(S) URL, предварительно скачивая файл перед передачей в Telethon и устанавливая подходящую подсказку `force_document`.

Улучшения:
- Добавить эвристики для определения, когда файлы следует рассматривать как обычные документы, а когда как фотографии, на основе суффиксов имён файлов.
- Централизовать обработку базовых имён URL для загрузки файлов, чтобы обеспечить единообразное именование скачанного содержимого.

Тесты:
- Добавить модульные тесты для `prepare_files_for_send` и `force_document_for_file_list`, чтобы покрыть скачивание по URL, обработку имён файлов и эвристику документ/фото.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Единообразная обработка HTTP(S) файловых URL перед отправкой в Telethon, чтобы избежать неправильной классификации загрузок и ошибок MediaInvalidError, а также улучшение эвристики определения типа файлов для `send_file`.

Исправления ошибок:
- Предотвращение MediaInvalidError при отправке одного HTTP(S) URL за счёт предварительного скачивания содержимого перед передачей в Telethon и установки подходящей подсказки `force_document`.

Улучшения:
- Введение эвристик, основанных на `basename`, для решения, когда файлы следует считать изображениями, а когда — обычными документами при загрузках через Telethon.
- Централизация извлечения `basename` из URL/пути для единообразного наименования скачанного содержимого и определения типа во всех ветках кода.

Тесты:
- Добавлены тесты для `prepare_files_for_send` и `force_document_for_file_list`, проверяющие скачивание по URL, обработку имён файлов и эвристику «изображение против документа».

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle HTTP(S) file URLs uniformly before sending to Telethon to avoid misclassification of uploads and MediaInvalidError, and improve file-type heuristics for send_file.

Bug Fixes:
- Prevent MediaInvalidError when sending a single HTTP(S) URL by downloading the content before passing it to Telethon and setting an appropriate force_document hint.

Enhancements:
- Introduce basename-based heuristics to decide when files should be treated as images versus generic documents for Telethon uploads.
- Centralize URL/path basename extraction for consistent naming of downloaded content and type detection across code paths.

Tests:
- Add tests for prepare_files_for_send and force_document_for_file_list covering URL downloading, filename handling, and image-versus-document heuristics.

</details>

Исправления ошибок:
- Исправление `MediaInvalidError` при отправке одного HTTP(S)-URL за счёт предварительного скачивания содержимого перед передачей его в Telethon и установки подходящей подсказки `force_document`.

Улучшения:
- Введение эвристик на основе базовых имён (basename) URL/путей для принятия решения, когда файлы следует обрабатывать как изображения, а когда — как обычные документы.
- Централизация извлечения basename из URL/путей для обеспечения единообразного именования скачанного содержимого при определении типа.

Тесты:
- Добавлены тесты для `prepare_files_for_send` и `force_document_for_file_list`, охватывающие скачивание по URL, обработку имён файлов и эвристики для документов/фотографий.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Единообразная обработка HTTP(S) файловых URL перед отправкой в Telethon, чтобы избежать неправильной классификации загрузок и ошибок MediaInvalidError, а также улучшение эвристики определения типа файлов для `send_file`.

Исправления ошибок:
- Предотвращение MediaInvalidError при отправке одного HTTP(S) URL за счёт предварительного скачивания содержимого перед передачей в Telethon и установки подходящей подсказки `force_document`.

Улучшения:
- Введение эвристик, основанных на `basename`, для решения, когда файлы следует считать изображениями, а когда — обычными документами при загрузках через Telethon.
- Централизация извлечения `basename` из URL/пути для единообразного наименования скачанного содержимого и определения типа во всех ветках кода.

Тесты:
- Добавлены тесты для `prepare_files_for_send` и `force_document_for_file_list`, проверяющие скачивание по URL, обработку имён файлов и эвристику «изображение против документа».

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle HTTP(S) file URLs uniformly before sending to Telethon to avoid misclassification of uploads and MediaInvalidError, and improve file-type heuristics for send_file.

Bug Fixes:
- Prevent MediaInvalidError when sending a single HTTP(S) URL by downloading the content before passing it to Telethon and setting an appropriate force_document hint.

Enhancements:
- Introduce basename-based heuristics to decide when files should be treated as images versus generic documents for Telethon uploads.
- Centralize URL/path basename extraction for consistent naming of downloaded content and type detection across code paths.

Tests:
- Add tests for prepare_files_for_send and force_document_for_file_list covering URL downloading, filename handling, and image-versus-document heuristics.

</details>

</details>

</details>