### PR TITLE
Add MTProto proxy support via MTPROTO_PROXY env var

### DIFF
--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,23 +1,18 @@
 ## Current Work Focus
-**Completed**: MTProto Fake TLS Support Investigation (2026-03-31)
+**Completed**: MTProto Fake TLS Integration (2026-03-31)
 
-**Investigation Results**:
-- **Telethon does NOT natively support Fake TLS (EE prefix)** - confirmed via Context7 docs and web search
-- **Solution**: `TelethonFakeTLS` package provides fake TLS support
-- **Installation**: `pip install TelethonFakeTLS`
-- **Secret Format**: Base64 secret, remove "7" from start (e.g., `7i/UefJk...` → `i/UefJk...`)
-- **Connection Class**: `TelethonFakeTLS.Connection.ConnectionTcpMTProxyFakeTLS`
-- **Verified Working**: Connection test successful with MTG proxy `144.31.188.163:443`
+**Implementation**:
+- Added `TelethonFakeTLS` as dependency in `pyproject.toml`
+- Updated `src/utils/proxy.py` with fake TLS detection and secret processing:
+  - Base64 secrets with `7` prefix: strip leading `7` (e.g., `7i/UefJk...` → `i/UefJk...`)
+  - Hex secrets with `ee` prefix: strip leading `ee` (e.g., `ee2fd479...` → `2fd479...`)
+- Integrated `ConnectionTcpMTProxyFakeTLS` into all client creation paths:
+  - `src/client/connection.py` (main client)
+  - `src/server_components/web_setup.py` (web setup)
+  - `src/cli_setup.py` (CLI setup)
+- Graceful fallback with warning if `TelethonFakeTLS` not installed
 
-**Integration Needed**:
-- Add `TelethonFakeTLS` as optional dependency
-- Detect fake TLS secrets (base64 format starting with `7`)
-- Conditionally use `ConnectionTcpMTProxyFakeTLS` when fake TLS detected
-- Update `src/utils/proxy.py` to handle both hex and base64 secrets
-
-**Your MTG Proxy Secrets**:
-- Original secret: `7i/UefJk/RKF0YDxChUNy6BnaXRodWIuY29t`
-- For TelethonFakeTLS: `i/UefJk/RKF0YDxChUNy6BnaXRodWIuY29t` (remove leading `7`)
+**Verified Working**: CLI setup authenticated successfully via MTG proxy `144.31.188.163:443`
 
 ---
 
@@ -31,8 +26,6 @@
   - `src/client/connection.py` (main client)
   - `src/server_components/web_setup.py` (setup flow)
   - `src/cli_setup.py` (CLI setup)
-
-**Note**: Current implementation uses standard MTProto proxy. Fake TLS requires `TelethonFakeTLS` package.
 
 
 ---

--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,4 +1,18 @@
 ## Current Work Focus
+**Completed**: MTProto Proxy Support (2026-03-31)
+
+**Implementation**:
+- Added `mtproto_proxy` config field to `ServerConfig` via `MTPROTO_PROXY` env var
+- Created `src/utils/proxy.py` with `MTProtoProxy` NamedTuple and URL parsing
+- Supports `tg://proxy?server=...&port=...&secret=...` and `host:port:secret` formats
+- Integrated `ConnectionTcpMTProxyRandomizedIntermediate` into:
+  - `src/client/connection.py` (main client)
+  - `src/server_components/web_setup.py` (setup flow)
+  - `src/cli_setup.py` (CLI setup)
+
+
+---
+
 **Completed**: Chat last_activity_date feature (2026-03-31)
 
 **Implementation**:

--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,4 +1,26 @@
 ## Current Work Focus
+**Completed**: MTProto Fake TLS Support Investigation (2026-03-31)
+
+**Investigation Results**:
+- **Telethon does NOT natively support Fake TLS (EE prefix)** - confirmed via Context7 docs and web search
+- **Solution**: `TelethonFakeTLS` package provides fake TLS support
+- **Installation**: `pip install TelethonFakeTLS`
+- **Secret Format**: Base64 secret, remove "7" from start (e.g., `7i/UefJk...` → `i/UefJk...`)
+- **Connection Class**: `TelethonFakeTLS.Connection.ConnectionTcpMTProxyFakeTLS`
+- **Verified Working**: Connection test successful with MTG proxy `144.31.188.163:443`
+
+**Integration Needed**:
+- Add `TelethonFakeTLS` as optional dependency
+- Detect fake TLS secrets (base64 format starting with `7`)
+- Conditionally use `ConnectionTcpMTProxyFakeTLS` when fake TLS detected
+- Update `src/utils/proxy.py` to handle both hex and base64 secrets
+
+**Your MTG Proxy Secrets**:
+- Original secret: `7i/UefJk/RKF0YDxChUNy6BnaXRodWIuY29t`
+- For TelethonFakeTLS: `i/UefJk/RKF0YDxChUNy6BnaXRodWIuY29t` (remove leading `7`)
+
+---
+
 **Completed**: MTProto Proxy Support (2026-03-31)
 
 **Implementation**:
@@ -9,6 +31,8 @@
   - `src/client/connection.py` (main client)
   - `src/server_components/web_setup.py` (setup flow)
   - `src/cli_setup.py` (CLI setup)
+
+**Note**: Current implementation uses standard MTProto proxy. Fake TLS requires `TelethonFakeTLS` package.
 
 
 ---

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,13 +1,13 @@
 ### 2026-03-31
+- **MTProto Fake TLS Integration Complete**: Added `TelethonFakeTLS` package for fake TLS (EE prefix) proxy support. Secret processing strips markers: base64 `7` prefix and hex `ee` prefix. CLI setup verified working via MTG proxy.
 - **MTProto Fake TLS Investigation**: Discovered Telethon does NOT natively support Fake TLS (EE prefix) proxies. Verified via Context7 docs and web search.
 - **Solution Found**: `TelethonFakeTLS` package provides fake TLS support - available on PyPI
-- **Secret Format Discovery**: MTG fake TLS secrets are base64 encoded, must remove leading "7" for TelethonFakeTLS (e.g., `7i/UefJk...` → `i/UefJk...`)
+- **Secret Format Discovery**: MTG fake TLS secrets are base64 encoded, must remove leading "7" for TelethonFakeTLS (e.g., `7i/UefJk...` → `i/UefJk...`). Hex secrets strip `ee` prefix.
 - **Connection Verified**: Successfully connected to MTG proxy `144.31.188.163:443` using `TelethonFakeTLS.ConnectionTcpMTProxyFakeTLS`
-- **Integration Required**: Add `TelethonFakeTLS` as optional dependency, detect secret type, conditionally use appropriate connection class
 - **MTProto Proxy Support**: Added `MTPROTO_PROXY` environment variable for Telegram connection via standard MTProto proxy
 - **New File**: `src/utils/proxy.py` with `MTProtoProxy` NamedTuple and URL parsing (supports `tg://proxy?...` and `host:port:secret` formats)
 - **Proxy Integration**: Uses `ConnectionTcpMTProxyRandomizedIntermediate` for obfuscated MTProto connection
-- **Files Modified**: `src/config/server_config.py`, `src/config/settings.py`, `src/client/connection.py`, `src/server_components/web_setup.py`, `src/cli_setup.py`
+- **Files Modified**: `src/config/server_config.py`, `src/config/settings.py`, `src/client/connection.py`, `src/server_components/web_setup.py`, `src/cli_setup.py`, `pyproject.toml`
 - **Chat Last Activity Date Feature**: Added `last_activity_date` field to chat search results
 - **New Parameters**: `min_date` and `max_date` (ISO format) for filtering chats by last activity
 - **New Implementation**: `build_dialog_entity_dict()` extracts date from Dialog object

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,5 +1,10 @@
 ### 2026-03-31
-- **MTProto Proxy Support**: Added `MTPROTO_PROXY` environment variable for Telegram connection via MTProto proxy
+- **MTProto Fake TLS Investigation**: Discovered Telethon does NOT natively support Fake TLS (EE prefix) proxies. Verified via Context7 docs and web search.
+- **Solution Found**: `TelethonFakeTLS` package provides fake TLS support - available on PyPI
+- **Secret Format Discovery**: MTG fake TLS secrets are base64 encoded, must remove leading "7" for TelethonFakeTLS (e.g., `7i/UefJk...` → `i/UefJk...`)
+- **Connection Verified**: Successfully connected to MTG proxy `144.31.188.163:443` using `TelethonFakeTLS.ConnectionTcpMTProxyFakeTLS`
+- **Integration Required**: Add `TelethonFakeTLS` as optional dependency, detect secret type, conditionally use appropriate connection class
+- **MTProto Proxy Support**: Added `MTPROTO_PROXY` environment variable for Telegram connection via standard MTProto proxy
 - **New File**: `src/utils/proxy.py` with `MTProtoProxy` NamedTuple and URL parsing (supports `tg://proxy?...` and `host:port:secret` formats)
 - **Proxy Integration**: Uses `ConnectionTcpMTProxyRandomizedIntermediate` for obfuscated MTProto connection
 - **Files Modified**: `src/config/server_config.py`, `src/config/settings.py`, `src/client/connection.py`, `src/server_components/web_setup.py`, `src/cli_setup.py`

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,4 +1,8 @@
 ### 2026-03-31
+- **MTProto Proxy Support**: Added `MTPROTO_PROXY` environment variable for Telegram connection via MTProto proxy
+- **New File**: `src/utils/proxy.py` with `MTProtoProxy` NamedTuple and URL parsing (supports `tg://proxy?...` and `host:port:secret` formats)
+- **Proxy Integration**: Uses `ConnectionTcpMTProxyRandomizedIntermediate` for obfuscated MTProto connection
+- **Files Modified**: `src/config/server_config.py`, `src/config/settings.py`, `src/client/connection.py`, `src/server_components/web_setup.py`, `src/cli_setup.py`
 - **Chat Last Activity Date Feature**: Added `last_activity_date` field to chat search results
 - **New Parameters**: `min_date` and `max_date` (ISO format) for filtering chats by last activity
 - **New Implementation**: `build_dialog_entity_dict()` extracts date from Dialog object

--- a/.env.example
+++ b/.env.example
@@ -66,8 +66,13 @@ BLOCK_PRIVATE_IPS=true
 ATTACHMENT_TICKET_TTL_SECONDS=3600
 
 # =============================================================================
-# OPTIONAL PERFORMANCE SETTINGS
+# OPTIONAL MTPROTO PROXY SETTINGS
 # =============================================================================
+
+# MTProto proxy for connecting to Telegram through a proxy
+# Format: tg://proxy?server=host&port=443&secret=xxx
+# Or: host:port:secret
+# MTPROTO_PROXY=
 
 # Maximum number of entities to cache per Telegram client
 # Default: 1000

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ curl -X POST "https://tg-mcp.l1979.ru/mtproto-api/messages.SendMessage" \
 | :shield: **Production Reliability** | Auto-reconnect, structured logging, comprehensive error handling with clear actionable messages |
 | :dart: **AI-Optimized** | Literal parameter constraints, LLM-friendly API design, and MCP ToolAnnotations |
 | :globe_with_meridians: **Web Setup Interface** | Browser-based authentication flow with immediate config generation |
+| :rocket: **MTProto Proxy Support** | Connect via MTProto proxy with automatic Fake TLS (EE prefix) and standard proxy detection |
 
 ## Quick Start
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -184,6 +184,13 @@ SERVER_MODE=stdio              # Local mode (default)
 PORT=8000                      # Server port
 LOG_LEVEL=INFO                 # Logging verbosity
 SESSION_NAME=telegram          # Session identifier
+
+# MTProto Proxy (for connections behind firewall)
+# Supported formats:
+#   tg://proxy?server=host&port=443&secret=xxx
+#   host:port:secret
+# Fake TLS proxies (ee/7 prefix) are auto-detected
+MTPROTO_PROXY=tg://proxy?server=your-proxy.com&port=443&secret=your-secret
 ```
 
 **💡 Tip:** The CLI setup automatically loads `.env` files from your current directory.
@@ -295,11 +302,19 @@ chmod 755 ~/.config/fast-mcp-telegram
 </details>
 
 <details>
-<summary><b>Connection issues</b></summary>
+<summary><b>Connection issues / MTProto Proxy</b></summary>
 
-- Check your internet connection
-- Verify firewall settings
-- For servers, ensure the port is open
+If you're behind a firewall or need to connect via proxy, configure `MTPROTO_PROXY`:
+```bash
+# Add to .env
+MTPROTO_PROXY=tg://proxy?server=your-proxy.com&port=443&secret=your-secret
+```
+
+Supported formats:
+- `tg://proxy?server=host&port=443&secret=xxx` (URL format)
+- `host:port:secret` (simple format)
+
+The server automatically detects Fake TLS proxies (with `ee` or `7` prefix) and handles secret processing.
 </details>
 
 ### 📖 More Resources

--- a/docs/MTProto-Bridge.md
+++ b/docs/MTProto-Bridge.md
@@ -11,6 +11,7 @@
 - **🔧 Case Insensitive**: Accepts `messages.getHistory`, `messages.GetHistory`, or `messages.GetHistoryRequest`
 - **🔐 Multi-Mode Support**: Works in all server modes with appropriate authentication
 - **⚡ Unified Implementation**: Same core logic as MCP tool with HTTP-specific defaults
+- **🚀 MTProto Proxy Support**: Works seamlessly through MTProto proxies with Fake TLS (EE prefix) support
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=3",
     "telethon",
+    "TelethonFakeTLS",  # For fake TLS (EE prefix) MTProto proxy support
     "jinja2",
     "pydantic-settings"
 ]

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -17,6 +17,7 @@ from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermedia
 # Try to import TelethonFakeTLS for fake TLS support
 try:
     from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+
     TELETHONFAKETLS_AVAILABLE = True
 except ImportError:
     ConnectionTcpMTProxyFakeTLS = None
@@ -181,9 +182,13 @@ async def setup_telegram_session(setup_config: SetupConfig) -> tuple[Path, str |
         if _mtproto_proxy.use_fake_tls:
             if TELETHONFAKETLS_AVAILABLE:
                 client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
-                print(f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
+                print(
+                    f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
+                )
             else:
-                print("Warning: Fake TLS proxy configured but TelethonFakeTLS not installed")
+                print(
+                    "Warning: Fake TLS proxy configured but TelethonFakeTLS not installed"
+                )
         else:
             client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
             print(f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -12,9 +12,14 @@ from pydantic import Field
 from pydantic_settings import CliImplicitFlag, SettingsConfigDict
 from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
+from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
 from .config.server_config import ServerConfig, ServerMode
 from .utils.mcp_config import generate_mcp_config_json
+from .utils.proxy import MTProtoProxy, parse_mtproto_proxy
+
+# MTProto proxy configuration
+_mtproto_proxy: MTProtoProxy | None = None
 
 
 class SetupConfig(ServerConfig):
@@ -154,12 +159,21 @@ async def setup_telegram_session(setup_config: SetupConfig) -> tuple[Path, str |
     print(f"\n🔐 Authenticating with session: {setup_config.session_name}")
 
     # Create the client and connect
+    global _mtproto_proxy
+    if _mtproto_proxy is None:
+        _mtproto_proxy = parse_mtproto_proxy(setup_config.mtproto_proxy)
+
+    connection_class = ConnectionTcpMTProxyRandomizedIntermediate if _mtproto_proxy else None
+    proxy_tuple = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret) if _mtproto_proxy else None
+
     api_id_int = int(setup_config.api_id)
     client = TelegramClient(
         session_path,
         api_id_int,
         setup_config.api_hash,
         entity_cache_limit=setup_config.entity_cache_limit,
+        connection=connection_class,
+        proxy=proxy_tuple,
     )
 
     try:

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -163,18 +163,17 @@ async def setup_telegram_session(setup_config: SetupConfig) -> tuple[Path, str |
     if _mtproto_proxy is None:
         _mtproto_proxy = parse_mtproto_proxy(setup_config.mtproto_proxy)
 
-    connection_class = ConnectionTcpMTProxyRandomizedIntermediate if _mtproto_proxy else None
-    proxy_tuple = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret) if _mtproto_proxy else None
+    client_kwargs = {
+        "session": session_path,
+        "api_id": int(setup_config.api_id),
+        "api_hash": setup_config.api_hash,
+        "entity_cache_limit": setup_config.entity_cache_limit,
+    }
+    if _mtproto_proxy:
+        client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+        client_kwargs["proxy"] = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret)
 
-    api_id_int = int(setup_config.api_id)
-    client = TelegramClient(
-        session_path,
-        api_id_int,
-        setup_config.api_hash,
-        entity_cache_limit=setup_config.entity_cache_limit,
-        connection=connection_class,
-        proxy=proxy_tuple,
-    )
+    client = TelegramClient(**client_kwargs)
 
     try:
         await client.connect()

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -14,6 +14,14 @@ from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
 from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
+# Try to import TelethonFakeTLS for fake TLS support
+try:
+    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+    TELETHONFAKETLS_AVAILABLE = True
+except ImportError:
+    ConnectionTcpMTProxyFakeTLS = None
+    TELETHONFAKETLS_AVAILABLE = False
+
 from .config.server_config import ServerConfig, ServerMode
 from .utils.mcp_config import generate_mcp_config_json
 from .utils.proxy import MTProtoProxy, parse_mtproto_proxy
@@ -170,8 +178,20 @@ async def setup_telegram_session(setup_config: SetupConfig) -> tuple[Path, str |
         "entity_cache_limit": setup_config.entity_cache_limit,
     }
     if _mtproto_proxy:
-        client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
-        client_kwargs["proxy"] = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret)
+        if _mtproto_proxy.use_fake_tls:
+            if TELETHONFAKETLS_AVAILABLE:
+                client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
+                print(f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
+            else:
+                print("Warning: Fake TLS proxy configured but TelethonFakeTLS not installed")
+        else:
+            client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+            print(f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
+        client_kwargs["proxy"] = (
+            _mtproto_proxy.server,
+            _mtproto_proxy.port,
+            _mtproto_proxy.secret,
+        )
 
     client = TelegramClient(**client_kwargs)
 

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -12,23 +12,10 @@ from pydantic import Field
 from pydantic_settings import CliImplicitFlag, SettingsConfigDict
 from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
-from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
-
-# Try to import TelethonFakeTLS for fake TLS support
-try:
-    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
-
-    TELETHONFAKETLS_AVAILABLE = True
-except ImportError:
-    ConnectionTcpMTProxyFakeTLS = None
-    TELETHONFAKETLS_AVAILABLE = False
 
 from .config.server_config import ServerConfig, ServerMode
 from .utils.mcp_config import generate_mcp_config_json
-from .utils.proxy import MTProtoProxy, parse_mtproto_proxy
-
-# MTProto proxy configuration
-_mtproto_proxy: MTProtoProxy | None = None
+from .utils.proxy import build_mtproto_client_args
 
 
 class SetupConfig(ServerConfig):
@@ -168,35 +155,13 @@ async def setup_telegram_session(setup_config: SetupConfig) -> tuple[Path, str |
     print(f"\n🔐 Authenticating with session: {setup_config.session_name}")
 
     # Create the client and connect
-    global _mtproto_proxy
-    if _mtproto_proxy is None:
-        _mtproto_proxy = parse_mtproto_proxy(setup_config.mtproto_proxy)
-
     client_kwargs = {
         "session": session_path,
         "api_id": int(setup_config.api_id),
         "api_hash": setup_config.api_hash,
         "entity_cache_limit": setup_config.entity_cache_limit,
     }
-    if _mtproto_proxy:
-        if _mtproto_proxy.use_fake_tls:
-            if TELETHONFAKETLS_AVAILABLE:
-                client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
-                print(
-                    f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
-                )
-            else:
-                print(
-                    "Warning: Fake TLS proxy configured but TelethonFakeTLS not installed"
-                )
-        else:
-            client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
-            print(f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
-        client_kwargs["proxy"] = (
-            _mtproto_proxy.server,
-            _mtproto_proxy.port,
-            _mtproto_proxy.secret,
-        )
+    client_kwargs |= build_mtproto_client_args(setup_config.mtproto_proxy, print)
 
     client = TelegramClient(**client_kwargs)
 

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -7,12 +7,16 @@ import traceback
 from contextvars import ContextVar
 
 from telethon import TelegramClient
+from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
 from ..config.logging import format_diagnostic_info
+from ..utils.proxy import MTProtoProxy, parse_mtproto_proxy
 from ..config.server_config import get_config
 from ..config.settings import API_HASH, API_ID, SESSION_DIR
 
 logger = logging.getLogger(__name__)
+
+_mtproto_proxy: MTProtoProxy | None = None
 
 
 class SessionNotAuthorizedError(Exception):
@@ -103,14 +107,28 @@ async def _get_client_by_token(token: str) -> TelegramClient:
         session_path = SESSION_DIR / f"{token}.session"
 
         try:
+            # Get or create MTProto proxy config
+            global _mtproto_proxy
+            if _mtproto_proxy is None:
+                _mtproto_proxy = parse_mtproto_proxy(get_config().mtproto_proxy)
+
+            # Determine connection class and proxy
+            connection_class = ConnectionTcpMTProxyRandomizedIntermediate if _mtproto_proxy else None
+            proxy_tuple = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret) if _mtproto_proxy else None
+
             api_id_int = int(API_ID)
             client = TelegramClient(
                 session_path,
                 api_id_int,
                 API_HASH,
                 entity_cache_limit=get_config().entity_cache_limit,
+                connection=connection_class,
+                proxy=proxy_tuple,
             )
             await client.connect()
+
+            if _mtproto_proxy:
+                logger.info(f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
 
             if not await client.is_user_authorized():
                 logger.error(

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -112,23 +112,22 @@ async def _get_client_by_token(token: str) -> TelegramClient:
             if _mtproto_proxy is None:
                 _mtproto_proxy = parse_mtproto_proxy(get_config().mtproto_proxy)
 
-            # Determine connection class and proxy
-            connection_class = ConnectionTcpMTProxyRandomizedIntermediate if _mtproto_proxy else None
-            proxy_tuple = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret) if _mtproto_proxy else None
-
             api_id_int = int(API_ID)
-            client = TelegramClient(
-                session_path,
-                api_id_int,
-                API_HASH,
-                entity_cache_limit=get_config().entity_cache_limit,
-                connection=connection_class,
-                proxy=proxy_tuple,
-            )
-            await client.connect()
 
+            # Build client kwargs - only add proxy params if configured
+            client_kwargs = {
+                "session": session_path,
+                "api_id": api_id_int,
+                "api_hash": API_HASH,
+                "entity_cache_limit": get_config().entity_cache_limit,
+            }
             if _mtproto_proxy:
+                client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+                client_kwargs["proxy"] = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret)
                 logger.info(f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
+
+            client = TelegramClient(**client_kwargs)
+            await client.connect()
 
             if not await client.is_user_authorized():
                 logger.error(

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -16,6 +16,18 @@ from ..config.settings import API_HASH, API_ID, SESSION_DIR
 
 logger = logging.getLogger(__name__)
 
+# Try to import TelethonFakeTLS for fake TLS support
+try:
+    from TelethonFakeTLS import Connection as FakeTLSConnection
+    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+    TELTHONFAKETLS_AVAILABLE = True
+    logger.debug("TelethonFakeTLS available for fake TLS proxy support")
+except ImportError:
+    FakeTLSConnection = None
+    ConnectionTcpMTProxyFakeTLS = None
+    TELTHONFAKETLS_AVAILABLE = False
+    logger.debug("TelethonFakeTLS not available, fake TLS proxy not supported")
+
 _mtproto_proxy: MTProtoProxy | None = None
 
 
@@ -122,9 +134,27 @@ async def _get_client_by_token(token: str) -> TelegramClient:
                 "entity_cache_limit": get_config().entity_cache_limit,
             }
             if _mtproto_proxy:
-                client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
-                client_kwargs["proxy"] = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret)
-                logger.info(f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}")
+                if _mtproto_proxy.use_fake_tls:
+                    if TELTHONFAKETLS_AVAILABLE:
+                        client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
+                        logger.info(
+                            f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
+                        )
+                    else:
+                        logger.warning(
+                            "Fake TLS proxy configured but TelethonFakeTLS not installed. "
+                            "Install with: pip install TelethonFakeTLS"
+                        )
+                else:
+                    client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+                    logger.info(
+                        f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
+                    )
+                client_kwargs["proxy"] = (
+                    _mtproto_proxy.server,
+                    _mtproto_proxy.port,
+                    _mtproto_proxy.secret,
+                )
 
             client = TelegramClient(**client_kwargs)
             await client.connect()

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -7,29 +7,13 @@ import traceback
 from contextvars import ContextVar
 
 from telethon import TelegramClient
-from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
 from ..config.logging import format_diagnostic_info
 from ..config.server_config import get_config
 from ..config.settings import API_HASH, API_ID, SESSION_DIR
-from ..utils.proxy import MTProtoProxy, parse_mtproto_proxy
+from ..utils.proxy import build_mtproto_client_args
 
 logger = logging.getLogger(__name__)
-
-# Try to import TelethonFakeTLS for fake TLS support
-try:
-    from TelethonFakeTLS import Connection as FakeTLSConnection
-    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
-
-    TELTHONFAKETLS_AVAILABLE = True
-    logger.debug("TelethonFakeTLS available for fake TLS proxy support")
-except ImportError:
-    FakeTLSConnection = None
-    ConnectionTcpMTProxyFakeTLS = None
-    TELTHONFAKETLS_AVAILABLE = False
-    logger.debug("TelethonFakeTLS not available, fake TLS proxy not supported")
-
-_mtproto_proxy: MTProtoProxy | None = None
 
 
 class SessionNotAuthorizedError(Exception):
@@ -120,44 +104,16 @@ async def _get_client_by_token(token: str) -> TelegramClient:
         session_path = SESSION_DIR / f"{token}.session"
 
         try:
-            # Get or create MTProto proxy config
-            global _mtproto_proxy
-            if _mtproto_proxy is None:
-                _mtproto_proxy = parse_mtproto_proxy(get_config().mtproto_proxy)
-
             api_id_int = int(API_ID)
 
-            # Build client kwargs - only add proxy params if configured
+            # Build client kwargs with MTProto proxy support
             client_kwargs = {
                 "session": session_path,
                 "api_id": api_id_int,
                 "api_hash": API_HASH,
                 "entity_cache_limit": get_config().entity_cache_limit,
             }
-            if _mtproto_proxy:
-                if _mtproto_proxy.use_fake_tls:
-                    if TELTHONFAKETLS_AVAILABLE:
-                        client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
-                        logger.info(
-                            f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
-                        )
-                    else:
-                        logger.warning(
-                            "Fake TLS proxy configured but TelethonFakeTLS not installed. "
-                            "Install with: pip install TelethonFakeTLS"
-                        )
-                else:
-                    client_kwargs["connection"] = (
-                        ConnectionTcpMTProxyRandomizedIntermediate
-                    )
-                    logger.info(
-                        f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
-                    )
-                client_kwargs["proxy"] = (
-                    _mtproto_proxy.server,
-                    _mtproto_proxy.port,
-                    _mtproto_proxy.secret,
-                )
+            client_kwargs |= build_mtproto_client_args(get_config().mtproto_proxy, logger.info)
 
             client = TelegramClient(**client_kwargs)
             await client.connect()

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -10,9 +10,9 @@ from telethon import TelegramClient
 from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
 from ..config.logging import format_diagnostic_info
-from ..utils.proxy import MTProtoProxy, parse_mtproto_proxy
 from ..config.server_config import get_config
 from ..config.settings import API_HASH, API_ID, SESSION_DIR
+from ..utils.proxy import MTProtoProxy, parse_mtproto_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 try:
     from TelethonFakeTLS import Connection as FakeTLSConnection
     from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+
     TELTHONFAKETLS_AVAILABLE = True
     logger.debug("TelethonFakeTLS available for fake TLS proxy support")
 except ImportError:
@@ -146,7 +147,9 @@ async def _get_client_by_token(token: str) -> TelegramClient:
                             "Install with: pip install TelethonFakeTLS"
                         )
                 else:
-                    client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+                    client_kwargs["connection"] = (
+                        ConnectionTcpMTProxyRandomizedIntermediate
+                    )
                     logger.info(
                         f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
                     )

--- a/src/config/server_config.py
+++ b/src/config/server_config.py
@@ -145,6 +145,15 @@ class ServerConfig(BaseSettings):
         description="Maximum number of entities to cache per Telegram client",
     )
 
+    # MTProto proxy configuration
+    mtproto_proxy: str | None = Field(
+        default=None,
+        description=(
+            "MTProto proxy URL in format: tg://proxy?server=host&port=443&secret=xxx "
+            "or just: host:port:secret"
+        ),
+    )
+
     # File download security
     allow_http_urls: bool = Field(
         default=False, description="Allow HTTP URLs (insecure, only for development)"
@@ -264,6 +273,9 @@ class ServerConfig(BaseSettings):
             logger.info("🔐 Authentication REQUIRED - Bearer token mandatory")
 
         logger.info(f"📁 Session directory: {self.session_directory}")
+
+        if self.mtproto_proxy:
+            logger.info("🔌 MTProto proxy: enabled")
 
         # Mark as logged to prevent repeated messages
         self._config_logged = True

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -29,3 +29,6 @@ SERVER_VERSION = __version__
 
 # Authentication configuration (deprecated - use config.disable_auth)
 DISABLE_AUTH = config.disable_auth
+
+# MTProto proxy configuration
+MTPROTO_PROXY = config.mtproto_proxy

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -18,6 +18,7 @@ from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermedia
 # Try to import TelethonFakeTLS for fake TLS support
 try:
     from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+
     TELETHONFAKETLS_AVAILABLE = True
 except ImportError:
     ConnectionTcpMTProxyFakeTLS = None

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -14,6 +14,14 @@ from telethon import TelegramClient
 from telethon.errors import PasswordHashInvalidError, SessionPasswordNeededError
 from telethon.errors.rpcerrorlist import PhoneNumberFloodError
 from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
+
+# Try to import TelethonFakeTLS for fake TLS support
+try:
+    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+    TELETHONFAKETLS_AVAILABLE = True
+except ImportError:
+    ConnectionTcpMTProxyFakeTLS = None
+    TELETHONFAKETLS_AVAILABLE = False
 from telethon.tl.functions.account import GetPasswordRequest
 
 from src.client.connection import _cache_lock, _session_cache, generate_bearer_token
@@ -159,8 +167,27 @@ def create_session_client(session_path: Path) -> TelegramClient:
         "entity_cache_limit": get_config().entity_cache_limit,
     }
     if _mtproto_proxy:
-        client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
-        client_kwargs["proxy"] = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret)
+        if _mtproto_proxy.use_fake_tls:
+            if TELETHONFAKETLS_AVAILABLE:
+                client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
+                logger.info(
+                    f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
+                )
+            else:
+                logger.warning(
+                    "Fake TLS proxy configured but TelethonFakeTLS not installed. "
+                    "Install with: pip install TelethonFakeTLS"
+                )
+        else:
+            client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+            logger.info(
+                f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
+            )
+        client_kwargs["proxy"] = (
+            _mtproto_proxy.server,
+            _mtproto_proxy.port,
+            _mtproto_proxy.secret,
+        )
 
     return TelegramClient(**client_kwargs)
 

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -152,17 +152,17 @@ def create_session_client(session_path: Path) -> TelegramClient:
     if _mtproto_proxy is None:
         _mtproto_proxy = parse_mtproto_proxy(MTPROTO_PROXY)
 
-    connection_class = ConnectionTcpMTProxyRandomizedIntermediate if _mtproto_proxy else None
-    proxy_tuple = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret) if _mtproto_proxy else None
+    client_kwargs = {
+        "session": session_path,
+        "api_id": int(API_ID),
+        "api_hash": API_HASH,
+        "entity_cache_limit": get_config().entity_cache_limit,
+    }
+    if _mtproto_proxy:
+        client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+        client_kwargs["proxy"] = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret)
 
-    return TelegramClient(
-        session_path,
-        int(API_ID),
-        API_HASH,
-        entity_cache_limit=get_config().entity_cache_limit,
-        connection=connection_class,
-        proxy=proxy_tuple,
-    )
+    return TelegramClient(**client_kwargs)
 
 
 async def cleanup_stale_setup_sessions():

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -13,25 +13,15 @@ from starlette.templating import Jinja2Templates
 from telethon import TelegramClient
 from telethon.errors import PasswordHashInvalidError, SessionPasswordNeededError
 from telethon.errors.rpcerrorlist import PhoneNumberFloodError
-from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
-
-# Try to import TelethonFakeTLS for fake TLS support
-try:
-    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
-
-    TELETHONFAKETLS_AVAILABLE = True
-except ImportError:
-    ConnectionTcpMTProxyFakeTLS = None
-    TELETHONFAKETLS_AVAILABLE = False
 from telethon.tl.functions.account import GetPasswordRequest
 
 from src.client.connection import _cache_lock, _session_cache, generate_bearer_token
 from src.config.server_config import ServerMode, get_config
-from src.config.settings import API_HASH, API_ID, MTPROTO_PROXY
+from src.config.settings import API_HASH, API_ID
 from src.server_components.auth import RESERVED_SESSION_NAMES
 from src.server_components.auth_middleware import generate_url_based_config
 from src.utils.mcp_config import generate_mcp_config_json
-from src.utils.proxy import MTProtoProxy, parse_mtproto_proxy
+from src.utils.proxy import build_mtproto_client_args
 
 # Constants
 SETUP_SESSION_PREFIX = "setup-"
@@ -82,9 +72,6 @@ templates = Jinja2Templates(
 _setup_sessions: dict[str, dict] = {}
 # Use unified config for TTL
 SETUP_SESSION_TTL_SECONDS = get_config().setup_session_ttl_seconds
-
-# MTProto proxy configuration
-_mtproto_proxy: MTProtoProxy | None = None
 
 logger = logging.getLogger(__name__)
 
@@ -157,39 +144,13 @@ def _2fa_form_context(
 
 def create_session_client(session_path: Path) -> TelegramClient:
     """Create and return a configured TelegramClient."""
-    global _mtproto_proxy
-    if _mtproto_proxy is None:
-        _mtproto_proxy = parse_mtproto_proxy(MTPROTO_PROXY)
-
     client_kwargs = {
         "session": session_path,
         "api_id": int(API_ID),
         "api_hash": API_HASH,
         "entity_cache_limit": get_config().entity_cache_limit,
     }
-    if _mtproto_proxy:
-        if _mtproto_proxy.use_fake_tls:
-            if TELETHONFAKETLS_AVAILABLE:
-                client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
-                logger.info(
-                    f"Using MTProto Fake TLS proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
-                )
-            else:
-                logger.warning(
-                    "Fake TLS proxy configured but TelethonFakeTLS not installed. "
-                    "Install with: pip install TelethonFakeTLS"
-                )
-        else:
-            client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
-            logger.info(
-                f"Using MTProto proxy: {_mtproto_proxy.server}:{_mtproto_proxy.port}"
-            )
-        client_kwargs["proxy"] = (
-            _mtproto_proxy.server,
-            _mtproto_proxy.port,
-            _mtproto_proxy.secret,
-        )
-
+    client_kwargs |= build_mtproto_client_args(get_config().mtproto_proxy, logger.info)
     return TelegramClient(**client_kwargs)
 
 

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -13,14 +13,16 @@ from starlette.templating import Jinja2Templates
 from telethon import TelegramClient
 from telethon.errors import PasswordHashInvalidError, SessionPasswordNeededError
 from telethon.errors.rpcerrorlist import PhoneNumberFloodError
+from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 from telethon.tl.functions.account import GetPasswordRequest
 
 from src.client.connection import _cache_lock, _session_cache, generate_bearer_token
 from src.config.server_config import ServerMode, get_config
-from src.config.settings import API_HASH, API_ID
+from src.config.settings import API_HASH, API_ID, MTPROTO_PROXY
 from src.server_components.auth import RESERVED_SESSION_NAMES
 from src.server_components.auth_middleware import generate_url_based_config
 from src.utils.mcp_config import generate_mcp_config_json
+from src.utils.proxy import MTProtoProxy, parse_mtproto_proxy
 
 # Constants
 SETUP_SESSION_PREFIX = "setup-"
@@ -71,6 +73,9 @@ templates = Jinja2Templates(
 _setup_sessions: dict[str, dict] = {}
 # Use unified config for TTL
 SETUP_SESSION_TTL_SECONDS = get_config().setup_session_ttl_seconds
+
+# MTProto proxy configuration
+_mtproto_proxy: MTProtoProxy | None = None
 
 logger = logging.getLogger(__name__)
 
@@ -143,11 +148,20 @@ def _2fa_form_context(
 
 def create_session_client(session_path: Path) -> TelegramClient:
     """Create and return a configured TelegramClient."""
+    global _mtproto_proxy
+    if _mtproto_proxy is None:
+        _mtproto_proxy = parse_mtproto_proxy(MTPROTO_PROXY)
+
+    connection_class = ConnectionTcpMTProxyRandomizedIntermediate if _mtproto_proxy else None
+    proxy_tuple = (_mtproto_proxy.server, _mtproto_proxy.port, _mtproto_proxy.secret) if _mtproto_proxy else None
+
     return TelegramClient(
         session_path,
         int(API_ID),
         API_HASH,
         entity_cache_limit=get_config().entity_cache_limit,
+        connection=connection_class,
+        proxy=proxy_tuple,
     )
 
 

--- a/src/tools/messages/file_handling.py
+++ b/src/tools/messages/file_handling.py
@@ -63,10 +63,9 @@ async def prepare_files_for_send(file_list: list[str]) -> list[BytesIO | str]:
 
     url_entries = [f for f in file_list if f.startswith(("http://", "https://"))]
     downloaded = await _download_urls_to_bytes(url_entries)
-    url_to_content: dict[str, bytes | str] = {}
-    for u, content in zip(url_entries, downloaded, strict=True):
-        url_to_content[u] = content
-
+    url_to_content: dict[str, bytes | str] = dict(
+        zip(url_entries, downloaded, strict=True)
+    )
     out: list[BytesIO | str] = []
     for f in file_list:
         if not f.startswith(("http://", "https://")):

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -38,17 +38,16 @@ def _redact_secret(url: str) -> str:
 def _is_fake_tls_secret(secret: str) -> bool:
     """Check if secret appears to be a Fake TLS (base64) secret.
 
-    Fake TLS secrets start with '7' (the padding character in base64).
-    When decoded, they typically contain domain names like 'github.com'.
+    Fake TLS secrets start with '7' (the base64 padding character that Telegram uses
+    as a marker for fake TLS secrets) or 'ee' in hex format.
     """
     if not secret:
         return False
     secret = secret.strip()
-    # Fake TLS secrets are often base64 with '7' prefix (padding indicator)
+    # Fake TLS base64 secrets start with '7' (Telegram's marker)
     if secret.startswith("7"):
         return True
     # Also check if it's a hex secret with 'ee' prefix (Fake TLS marker)
-    # Note: 'dd' prefix is standard MTProto randomized intermediate, NOT fake TLS
     if secret.startswith("ee"):
         return True
     return False
@@ -58,11 +57,12 @@ def _process_fake_tls_secret(secret: str) -> str:
     """Process Fake TLS secret for TelethonFakeTLS.
 
     For base64 secrets starting with '7', remove the leading '7'.
-    For hex secrets starting with 'ee' or 'dd', the proxy.py already handles extraction.
+    The '7' is a marker that Telegram adds to indicate fake TLS, but TelethonFakeTLS
+    expects the raw base64 bytes without it.
     """
     secret = secret.strip()
     if secret.startswith("7"):
-        # Remove leading '7' for TelethonFakeTLS
+        # Remove leading '7' marker for TelethonFakeTLS
         return secret[1:]
     return secret
 

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -1,6 +1,10 @@
 """
 MTProto proxy URL parsing utilities.
+
+Supports both standard MTProto proxies and Fake TLS (EE prefix) proxies.
+Fake TLS secrets are converted for use with TelethonFakeTLS package.
 """
+
 import logging
 import urllib.parse
 from typing import NamedTuple
@@ -14,6 +18,7 @@ class MTProtoProxy(NamedTuple):
     server: str
     port: int
     secret: str
+    use_fake_tls: bool = False
 
 
 def _redact_secret(url: str) -> str:
@@ -30,13 +35,46 @@ def _redact_secret(url: str) -> str:
     return "host:port:***"
 
 
+def _is_fake_tls_secret(secret: str) -> bool:
+    """Check if secret appears to be a Fake TLS (base64) secret.
+
+    Fake TLS secrets start with '7' (the padding character in base64).
+    When decoded, they typically contain domain names like 'github.com'.
+    """
+    if not secret:
+        return False
+    secret = secret.strip()
+    # Fake TLS secrets are often base64 with '7' prefix (padding indicator)
+    if secret.startswith("7"):
+        return True
+    # Also check if it's a hex secret with 'ee' prefix (Fake TLS marker)
+    # Note: 'dd' prefix is standard MTProto randomized intermediate, NOT fake TLS
+    if secret.startswith("ee"):
+        return True
+    return False
+
+
+def _process_fake_tls_secret(secret: str) -> str:
+    """Process Fake TLS secret for TelethonFakeTLS.
+
+    For base64 secrets starting with '7', remove the leading '7'.
+    For hex secrets starting with 'ee' or 'dd', the proxy.py already handles extraction.
+    """
+    secret = secret.strip()
+    if secret.startswith("7"):
+        # Remove leading '7' for TelethonFakeTLS
+        return secret[1:]
+    return secret
+
+
 def parse_mtproto_proxy(url: str | None) -> MTProtoProxy | None:
     """
     Parse MTProto proxy URL into components.
 
     Supports formats:
-    - tg://proxy?server=host&port=443&secret=xxx
-    - host:port:secret
+    - tg://proxy?server=host&port=443&secret=xxx (standard or fake TLS)
+    - host:port:secret (standard)
+    - host:port:ee... (fake TLS with ee prefix)
 
     Args:
         url: MTProto proxy URL or None
@@ -82,7 +120,12 @@ def _parse_tg_proxy_format(url: str) -> MTProtoProxy | None:
         except ValueError:
             port = 443
 
-        return MTProtoProxy(server=server, port=port, secret=secret)
+        # Detect fake TLS
+        use_fake_tls = _is_fake_tls_secret(secret)
+        if use_fake_tls:
+            secret = _process_fake_tls_secret(secret)
+
+        return MTProtoProxy(server=server, port=port, secret=secret, use_fake_tls=use_fake_tls)
     except Exception:
         logger.warning("Failed to parse MTProto proxy URL")
         return None
@@ -98,10 +141,18 @@ def _parse_simple_format(url: str) -> MTProtoProxy | None:
     """Parse simple host:port:secret format."""
     try:
         server, port_str, secret = url.split(":")
+        secret = secret.strip()
+
+        # Detect fake TLS by hex prefix
+        use_fake_tls = _is_fake_tls_secret(secret)
+        if use_fake_tls:
+            secret = _process_fake_tls_secret(secret)
+
         return MTProtoProxy(
             server=server.strip(),
             port=int(port_str.strip()),
-            secret=secret.strip(),
+            secret=secret,
+            use_fake_tls=use_fake_tls,
         )
     except Exception:
         logger.warning("Failed to parse simple proxy format")

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -57,13 +57,17 @@ def _process_fake_tls_secret(secret: str) -> str:
     """Process Fake TLS secret for TelethonFakeTLS.
 
     For base64 secrets starting with '7', remove the leading '7'.
-    The '7' is a marker that Telegram adds to indicate fake TLS, but TelethonFakeTLS
-    expects the raw base64 bytes without it.
+    For hex secrets starting with 'ee', remove the 'ee' prefix.
+    The '7' and 'ee' are markers that Telegram adds to indicate fake TLS,
+    but TelethonFakeTLS expects the raw secret bytes without them.
     """
     secret = secret.strip()
     if secret.startswith("7"):
         # Remove leading '7' marker for TelethonFakeTLS
         return secret[1:]
+    if secret.startswith("ee"):
+        # Remove 'ee' prefix for TelethonFakeTLS
+        return secret[2:]
     return secret
 
 
@@ -125,7 +129,9 @@ def _parse_tg_proxy_format(url: str) -> MTProtoProxy | None:
         if use_fake_tls:
             secret = _process_fake_tls_secret(secret)
 
-        return MTProtoProxy(server=server, port=port, secret=secret, use_fake_tls=use_fake_tls)
+        return MTProtoProxy(
+            server=server, port=port, secret=secret, use_fake_tls=use_fake_tls
+        )
     except Exception:
         logger.warning("Failed to parse MTProto proxy URL")
         return None

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -1,0 +1,95 @@
+"""
+MTProto proxy URL parsing utilities.
+"""
+import logging
+from typing import NamedTuple
+
+logger = logging.getLogger(__name__)
+
+
+class MTProtoProxy(NamedTuple):
+    """Parsed MTProto proxy configuration."""
+
+    server: str
+    port: int
+    secret: str
+
+
+def parse_mtproto_proxy(url: str | None) -> MTProtoProxy | None:
+    """
+    Parse MTProto proxy URL into components.
+
+    Supports formats:
+    - tg://proxy?server=host&port=443&secret=xxx
+    - host:port:secret
+
+    Args:
+        url: MTProto proxy URL or None
+
+    Returns:
+        MTProtoProxy tuple or None if invalid/not provided
+    """
+    if not url:
+        return None
+
+    url = url.strip()
+
+    # Try tg:// format first
+    if url.startswith("tg://proxy?"):
+        return _parse_tg_proxy_format(url)
+
+    # Try simple host:port:secret format
+    if _is_simple_format(url):
+        return _parse_simple_format(url)
+
+    logger.warning(f"Invalid MTProto proxy URL format: {url}")
+    return None
+
+
+def _parse_tg_proxy_format(url: str) -> MTProtoProxy | None:
+    """Parse tg://proxy?server=...&port=...&secret=... format."""
+    try:
+        # Extract query parameters
+        if not url.startswith("tg://proxy?"):
+            return None
+
+        query = url[11:]  # Remove "tg://proxy?"
+        params = dict(param.split("=") for param in query.split("&"))
+
+        server = params.get("server", "")
+        port_str = params.get("port", "443")
+        secret = params.get("secret", "")
+
+        if not server or not secret:
+            logger.warning(f"MTProto proxy URL missing server or secret: {url}")
+            return None
+
+        try:
+            port = int(port_str)
+        except ValueError:
+            port = 443
+
+        return MTProtoProxy(server=server, port=port, secret=secret)
+    except Exception as e:
+        logger.warning(f"Failed to parse MTProto proxy URL: {e}")
+        return None
+
+
+def _is_simple_format(url: str) -> bool:
+    """Check if URL is simple host:port:secret format."""
+    parts = url.split(":")
+    return len(parts) == 3 and bool(parts[0]) and bool(parts[1]) and bool(parts[2])
+
+
+def _parse_simple_format(url: str) -> MTProtoProxy | None:
+    """Parse simple host:port:secret format."""
+    try:
+        server, port_str, secret = url.split(":")
+        return MTProtoProxy(
+            server=server.strip(),
+            port=int(port_str.strip()),
+            secret=secret.strip(),
+        )
+    except Exception as e:
+        logger.warning(f"Failed to parse simple proxy format: {e}")
+        return None

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -45,12 +45,7 @@ def _is_fake_tls_secret(secret: str) -> bool:
         return False
     secret = secret.strip()
     # Fake TLS base64 secrets start with '7' (Telegram's marker)
-    if secret.startswith("7"):
-        return True
-    # Also check if it's a hex secret with 'ee' prefix (Fake TLS marker)
-    if secret.startswith("ee"):
-        return True
-    return False
+    return True if secret.startswith("7") else bool(secret.startswith("ee"))
 
 
 def _process_fake_tls_secret(secret: str) -> str:
@@ -65,10 +60,7 @@ def _process_fake_tls_secret(secret: str) -> str:
     if secret.startswith("7"):
         # Remove leading '7' marker for TelethonFakeTLS
         return secret[1:]
-    if secret.startswith("ee"):
-        # Remove 'ee' prefix for TelethonFakeTLS
-        return secret[2:]
-    return secret
+    return secret[2:] if secret.startswith("ee") else secret
 
 
 def parse_mtproto_proxy(url: str | None) -> MTProtoProxy | None:

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -2,6 +2,7 @@
 MTProto proxy URL parsing utilities.
 """
 import logging
+import urllib.parse
 from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,20 @@ class MTProtoProxy(NamedTuple):
     server: str
     port: int
     secret: str
+
+
+def _redact_secret(url: str) -> str:
+    """Return URL with secret replaced by '***' for safe logging."""
+    if url.startswith("tg://proxy?"):
+        try:
+            parsed = urllib.parse.urlparse(url)
+            params = urllib.parse.parse_qs(parsed.query)
+            server = params.get("server", [""])[0]
+            port = params.get("port", ["443"])[0]
+            return f"tg://proxy?server={server}&port={port}&secret=***"
+        except Exception:
+            return "tg://proxy?***"
+    return "host:port:***"
 
 
 def parse_mtproto_proxy(url: str | None) -> MTProtoProxy | None:
@@ -42,26 +57,24 @@ def parse_mtproto_proxy(url: str | None) -> MTProtoProxy | None:
     if _is_simple_format(url):
         return _parse_simple_format(url)
 
-    logger.warning(f"Invalid MTProto proxy URL format: {url}")
+    logger.warning(f"Invalid MTProto proxy URL format: {_redact_secret(url)}")
     return None
 
 
 def _parse_tg_proxy_format(url: str) -> MTProtoProxy | None:
     """Parse tg://proxy?server=...&port=...&secret=... format."""
     try:
-        # Extract query parameters
-        if not url.startswith("tg://proxy?"):
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "tg" or parsed.netloc != "proxy":
             return None
 
-        query = url[11:]  # Remove "tg://proxy?"
-        params = dict(param.split("=") for param in query.split("&"))
-
-        server = params.get("server", "")
-        port_str = params.get("port", "443")
-        secret = params.get("secret", "")
+        params = urllib.parse.parse_qs(parsed.query)
+        server = params.get("server", [""])[0]
+        port_str = params.get("port", ["443"])[0]
+        secret = params.get("secret", [""])[0]
 
         if not server or not secret:
-            logger.warning(f"MTProto proxy URL missing server or secret: {url}")
+            logger.warning("MTProto proxy URL missing server or secret")
             return None
 
         try:
@@ -70,8 +83,8 @@ def _parse_tg_proxy_format(url: str) -> MTProtoProxy | None:
             port = 443
 
         return MTProtoProxy(server=server, port=port, secret=secret)
-    except Exception as e:
-        logger.warning(f"Failed to parse MTProto proxy URL: {e}")
+    except Exception:
+        logger.warning("Failed to parse MTProto proxy URL")
         return None
 
 
@@ -90,6 +103,6 @@ def _parse_simple_format(url: str) -> MTProtoProxy | None:
             port=int(port_str.strip()),
             secret=secret.strip(),
         )
-    except Exception as e:
-        logger.warning(f"Failed to parse simple proxy format: {e}")
+    except Exception:
+        logger.warning("Failed to parse simple proxy format")
         return None

--- a/src/utils/proxy.py
+++ b/src/utils/proxy.py
@@ -5,9 +5,10 @@ Supports both standard MTProto proxies and Fake TLS (EE prefix) proxies.
 Fake TLS secrets are converted for use with TelethonFakeTLS package.
 """
 
+import base64
 import logging
 import urllib.parse
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,16 @@ class MTProtoProxy(NamedTuple):
     port: int
     secret: str
     use_fake_tls: bool = False
+
+
+# TelethonFakeTLS import - single source of truth
+try:
+    from TelethonFakeTLS.Connection import ConnectionTcpMTProxyFakeTLS
+
+    TELETHONFAKETLS_AVAILABLE = True
+except ImportError:
+    ConnectionTcpMTProxyFakeTLS = None
+    TELETHONFAKETLS_AVAILABLE = False
 
 
 def _redact_secret(url: str) -> str:
@@ -36,16 +47,51 @@ def _redact_secret(url: str) -> str:
 
 
 def _is_fake_tls_secret(secret: str) -> bool:
-    """Check if secret appears to be a Fake TLS (base64) secret.
+    """Heuristically check if a secret appears to be a Fake TLS secret.
 
-    Fake TLS secrets start with '7' (the base64 padding character that Telegram uses
-    as a marker for fake TLS secrets) or 'ee' in hex format.
+    Fake TLS secrets can be provided either as base64 (usually starting with '7')
+    or as hex (starting with 'ee'). To avoid misclassifying arbitrary secrets,
+    this function performs stricter validation:
+      * For hex: checks proper hex charset, even length, and 'ee' prefix.
+      * For base64: verifies charset/length and that decoded bytes start with 0xEE.
     """
     if not secret:
         return False
+
     secret = secret.strip()
-    # Fake TLS base64 secrets start with '7' (Telegram's marker)
-    return True if secret.startswith("7") else bool(secret.startswith("ee"))
+
+    # Reject composite values like "host:port:secret"
+    if ":" in secret:
+        return False
+
+    lower = secret.lower()
+
+    # Hex-encoded Fake TLS secret: 16-byte MTProxy secret -> 32 hex chars, prefixed with 0xee.
+    # Require valid hex, even length, and 'ee' prefix.
+    is_hex_candidate = (
+        lower.startswith("ee")
+        and len(lower) % 2 == 0
+        and 16 <= len(lower) <= 64
+        and all(c in "0123456789abcdef" for c in lower)
+    )
+    if is_hex_candidate:
+        return True
+
+    # Base64-encoded Fake TLS secret: Telegram uses a leading '7' marker.
+    if not secret.startswith("7"):
+        return False
+
+    # Basic base64 shape checks to avoid obviously invalid strings.
+    if len(secret) < 8 or len(secret) > 128 or len(secret) % 4 != 0:
+        return False
+
+    try:
+        decoded = base64.b64decode(secret, validate=True)
+    except Exception:
+        return False
+
+    # Fake TLS secrets have a leading 0xEE byte.
+    return bool(decoded) and decoded[0] == 0xEE
 
 
 def _process_fake_tls_secret(secret: str) -> str:
@@ -60,7 +106,7 @@ def _process_fake_tls_secret(secret: str) -> str:
     if secret.startswith("7"):
         # Remove leading '7' marker for TelethonFakeTLS
         return secret[1:]
-    return secret[2:] if secret.startswith("ee") else secret
+    return secret[2:] if secret.lower().startswith("ee") else secret
 
 
 def parse_mtproto_proxy(url: str | None) -> MTProtoProxy | None:
@@ -155,3 +201,46 @@ def _parse_simple_format(url: str) -> MTProtoProxy | None:
     except Exception:
         logger.warning("Failed to parse simple proxy format")
         return None
+
+
+def build_mtproto_client_args(
+    proxy_str: str | None,
+    log_func: Any = None,
+) -> dict[str, Any]:
+    """
+    Build TelegramClient kwargs for MTProto proxy connection.
+
+    Parses the proxy string and returns appropriate connection and proxy
+    arguments. Handles both standard MTProto and Fake TLS proxies.
+
+    Args:
+        proxy_str: MTProto proxy URL (or None)
+        log_func: Optional callable for logging (defaults to logger.info)
+
+    Returns:
+        Dict with 'connection' and 'proxy' keys if proxy configured, else empty dict
+    """
+    from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
+
+    proxy = parse_mtproto_proxy(proxy_str)
+    if not proxy:
+        return {}
+
+    client_kwargs: dict[str, Any] = {}
+    log = log_func if log_func else logger.info
+
+    if proxy.use_fake_tls:
+        if TELETHONFAKETLS_AVAILABLE:
+            client_kwargs["connection"] = ConnectionTcpMTProxyFakeTLS
+            log(f"Using MTProto Fake TLS proxy: {proxy.server}:{proxy.port}")
+        else:
+            log(
+                "Warning: Fake TLS proxy configured but TelethonFakeTLS not installed. "
+                "Install with: pip install TelethonFakeTLS"
+            )
+    else:
+        client_kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+        log(f"Using MTProto proxy: {proxy.server}:{proxy.port}")
+
+    client_kwargs["proxy"] = (proxy.server, proxy.port, proxy.secret)
+    return client_kwargs


### PR DESCRIPTION
- Add mtproto_proxy config field to ServerConfig
- Create src/utils/proxy.py with URL parsing for tg://proxy?... format
- Integrate ConnectionTcpMTProxyRandomizedIntermediate into connection.py,
  web_setup.py, and cli_setup.py
- Update .env.example with new configuration option

Made-with: Cursor

## Summary by Sourcery

Добавлена настраиваемая поддержка MTProto-прокси (включая определение Fake TLS) во все точки входа Telegram‑клиентов и задокументирована новая опция MTPROTO_PROXY.

New Features:
- Добавлено конфигурационное поле `mtproto_proxy` на сервере, связанное с переменной окружения `MTPROTO_PROXY` для использования MTProto‑прокси.
- Обеспечена возможность подключения Telegram‑клиентов (основной сервис, веб‑настройка и CLI‑настройка) через MTProto‑ или Fake TLS‑прокси на основе разобранной конфигурации.
- Добавлены утилиты парсинга прокси, поддерживающие форматы `tg://proxy?...` и `host:port:secret` с автоматической обработкой Fake TLS‑секрета.

Enhancements:
- Добавлено логирование активации поддержки MTProto‑прокси и типа используемого прокси для улучшения наблюдаемости.
- Незначительно упрощено сопоставление URL с контентом в утилитах работы с файлами.

Build:
- Добавлена зависимость `TelethonFakeTLS` для поддержки MTProto Fake TLS (прокси с префиксом `EE/7`).

Documentation:
- Задокументирована конфигурация `MTPROTO_PROXY` и поддерживаемые форматы в руководстве по установке и примере `.env`.
- Подчёркнута поддержка MTProto‑прокси и Fake TLS в `README` и документации по MTProto‑Bridge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable MTProto proxy support (including Fake TLS detection) to all Telegram client entry points and document the new MTPROTO_PROXY option.

New Features:
- Introduce mtproto_proxy configuration field on the server, wired to the MTPROTO_PROXY environment variable for MTProto proxy usage.
- Enable Telegram clients (main service, web setup, and CLI setup) to connect via MTProto or Fake TLS proxies based on parsed configuration.
- Add proxy parsing utilities that support both tg://proxy?... and host:port:secret formats with automatic Fake TLS secret handling.

Enhancements:
- Log activation of MTProto proxy support and the type of proxy being used for better observability.
- Slightly simplify URL-to-content mapping in file handling utilities.

Build:
- Add TelethonFakeTLS as a dependency to support MTProto Fake TLS (EE/7 prefix) proxies.

Documentation:
- Document the MTPROTO_PROXY configuration and supported formats in the installation guide and .env example.
- Highlight MTProto proxy and Fake TLS support in the README and MTProto-Bridge documentation.

</details>

Новые возможности:
- Добавлена конфигурация mtproto_proxy сервера, доступная через переменную окружения MTPROTO_PROXY, для включения использования MTProto-прокси.
- Реализована поддержка обоих форматов конфигурации MTProto-прокси: tg://proxy?... и host:port:secret, включая автоматическое определение Fake TLS секретов (с префиксом EE/7).
- Основной клиент сервиса, веб-мастер установки и CLI-настройка теперь могут подключаться к Telegram через MTProto или Fake TLS прокси при соответствующей конфигурации.

Улучшения:
- Добавлено логирование включения поддержки MTProto-прокси и типа используемого прокси для улучшения наблюдаемости.
- Незначительно упрощено сопоставление URL с содержимым в утилитах работы с файлами.

Сборка:
- Добавлен TelethonFakeTLS в качестве зависимости для поддержки MTProto-прокси с Fake TLS (префикс EE).

Документация:
- Задокументирован параметр конфигурации MTPROTO_PROXY и поддерживаемые форматы в руководстве по установке и примере файла .env.
- Подсвечена поддержка MTProto-прокси и Fake TLS в README и документации MTProto-Bridge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавлена настраиваемая поддержка MTProto-прокси (включая определение Fake TLS) во все точки входа Telegram‑клиентов и задокументирована новая опция MTPROTO_PROXY.

New Features:
- Добавлено конфигурационное поле `mtproto_proxy` на сервере, связанное с переменной окружения `MTPROTO_PROXY` для использования MTProto‑прокси.
- Обеспечена возможность подключения Telegram‑клиентов (основной сервис, веб‑настройка и CLI‑настройка) через MTProto‑ или Fake TLS‑прокси на основе разобранной конфигурации.
- Добавлены утилиты парсинга прокси, поддерживающие форматы `tg://proxy?...` и `host:port:secret` с автоматической обработкой Fake TLS‑секрета.

Enhancements:
- Добавлено логирование активации поддержки MTProto‑прокси и типа используемого прокси для улучшения наблюдаемости.
- Незначительно упрощено сопоставление URL с контентом в утилитах работы с файлами.

Build:
- Добавлена зависимость `TelethonFakeTLS` для поддержки MTProto Fake TLS (прокси с префиксом `EE/7`).

Documentation:
- Задокументирована конфигурация `MTPROTO_PROXY` и поддерживаемые форматы в руководстве по установке и примере `.env`.
- Подчёркнута поддержка MTProto‑прокси и Fake TLS в `README` и документации по MTProto‑Bridge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable MTProto proxy support (including Fake TLS detection) to all Telegram client entry points and document the new MTPROTO_PROXY option.

New Features:
- Introduce mtproto_proxy configuration field on the server, wired to the MTPROTO_PROXY environment variable for MTProto proxy usage.
- Enable Telegram clients (main service, web setup, and CLI setup) to connect via MTProto or Fake TLS proxies based on parsed configuration.
- Add proxy parsing utilities that support both tg://proxy?... and host:port:secret formats with automatic Fake TLS secret handling.

Enhancements:
- Log activation of MTProto proxy support and the type of proxy being used for better observability.
- Slightly simplify URL-to-content mapping in file handling utilities.

Build:
- Add TelethonFakeTLS as a dependency to support MTProto Fake TLS (EE/7 prefix) proxies.

Documentation:
- Document the MTPROTO_PROXY configuration and supported formats in the installation guide and .env example.
- Highlight MTProto proxy and Fake TLS support in the README and MTProto-Bridge documentation.

</details>

</details>

Новые возможности:
- Введена конфигурация MTProto-прокси на сервере через новое поле `mtproto_proxy`, связанное с переменной окружения `MTPROTO_PROXY`.
- Реализован разбор URL MTProto-прокси как из формата `tg://proxy?...`, так и из формата `host:port:secret` с помощью нового модуля утилит для работы с прокси.
- Обеспечено подключение клиентов Telegram в основном сервисе, веб-мастере настройки и CLI-настройке через MTProto-прокси при его наличии в конфигурации.

Улучшения:
- Добавлено логирование факта включения и использования MTProto-прокси для повышения операционной наблюдаемости.

Документация:
- Задокументирован параметр конфигурации `MTPROTO_PROXY` в примере файла окружения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавлена настраиваемая поддержка MTProto-прокси (включая определение Fake TLS) во все точки входа Telegram‑клиентов и задокументирована новая опция MTPROTO_PROXY.

New Features:
- Добавлено конфигурационное поле `mtproto_proxy` на сервере, связанное с переменной окружения `MTPROTO_PROXY` для использования MTProto‑прокси.
- Обеспечена возможность подключения Telegram‑клиентов (основной сервис, веб‑настройка и CLI‑настройка) через MTProto‑ или Fake TLS‑прокси на основе разобранной конфигурации.
- Добавлены утилиты парсинга прокси, поддерживающие форматы `tg://proxy?...` и `host:port:secret` с автоматической обработкой Fake TLS‑секрета.

Enhancements:
- Добавлено логирование активации поддержки MTProto‑прокси и типа используемого прокси для улучшения наблюдаемости.
- Незначительно упрощено сопоставление URL с контентом в утилитах работы с файлами.

Build:
- Добавлена зависимость `TelethonFakeTLS` для поддержки MTProto Fake TLS (прокси с префиксом `EE/7`).

Documentation:
- Задокументирована конфигурация `MTPROTO_PROXY` и поддерживаемые форматы в руководстве по установке и примере `.env`.
- Подчёркнута поддержка MTProto‑прокси и Fake TLS в `README` и документации по MTProto‑Bridge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable MTProto proxy support (including Fake TLS detection) to all Telegram client entry points and document the new MTPROTO_PROXY option.

New Features:
- Introduce mtproto_proxy configuration field on the server, wired to the MTPROTO_PROXY environment variable for MTProto proxy usage.
- Enable Telegram clients (main service, web setup, and CLI setup) to connect via MTProto or Fake TLS proxies based on parsed configuration.
- Add proxy parsing utilities that support both tg://proxy?... and host:port:secret formats with automatic Fake TLS secret handling.

Enhancements:
- Log activation of MTProto proxy support and the type of proxy being used for better observability.
- Slightly simplify URL-to-content mapping in file handling utilities.

Build:
- Add TelethonFakeTLS as a dependency to support MTProto Fake TLS (EE/7 prefix) proxies.

Documentation:
- Document the MTPROTO_PROXY configuration and supported formats in the installation guide and .env example.
- Highlight MTProto proxy and Fake TLS support in the README and MTProto-Bridge documentation.

</details>

Новые возможности:
- Добавлена конфигурация mtproto_proxy сервера, доступная через переменную окружения MTPROTO_PROXY, для включения использования MTProto-прокси.
- Реализована поддержка обоих форматов конфигурации MTProto-прокси: tg://proxy?... и host:port:secret, включая автоматическое определение Fake TLS секретов (с префиксом EE/7).
- Основной клиент сервиса, веб-мастер установки и CLI-настройка теперь могут подключаться к Telegram через MTProto или Fake TLS прокси при соответствующей конфигурации.

Улучшения:
- Добавлено логирование включения поддержки MTProto-прокси и типа используемого прокси для улучшения наблюдаемости.
- Незначительно упрощено сопоставление URL с содержимым в утилитах работы с файлами.

Сборка:
- Добавлен TelethonFakeTLS в качестве зависимости для поддержки MTProto-прокси с Fake TLS (префикс EE).

Документация:
- Задокументирован параметр конфигурации MTPROTO_PROXY и поддерживаемые форматы в руководстве по установке и примере файла .env.
- Подсвечена поддержка MTProto-прокси и Fake TLS в README и документации MTProto-Bridge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавлена настраиваемая поддержка MTProto-прокси (включая определение Fake TLS) во все точки входа Telegram‑клиентов и задокументирована новая опция MTPROTO_PROXY.

New Features:
- Добавлено конфигурационное поле `mtproto_proxy` на сервере, связанное с переменной окружения `MTPROTO_PROXY` для использования MTProto‑прокси.
- Обеспечена возможность подключения Telegram‑клиентов (основной сервис, веб‑настройка и CLI‑настройка) через MTProto‑ или Fake TLS‑прокси на основе разобранной конфигурации.
- Добавлены утилиты парсинга прокси, поддерживающие форматы `tg://proxy?...` и `host:port:secret` с автоматической обработкой Fake TLS‑секрета.

Enhancements:
- Добавлено логирование активации поддержки MTProto‑прокси и типа используемого прокси для улучшения наблюдаемости.
- Незначительно упрощено сопоставление URL с контентом в утилитах работы с файлами.

Build:
- Добавлена зависимость `TelethonFakeTLS` для поддержки MTProto Fake TLS (прокси с префиксом `EE/7`).

Documentation:
- Задокументирована конфигурация `MTPROTO_PROXY` и поддерживаемые форматы в руководстве по установке и примере `.env`.
- Подчёркнута поддержка MTProto‑прокси и Fake TLS в `README` и документации по MTProto‑Bridge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable MTProto proxy support (including Fake TLS detection) to all Telegram client entry points and document the new MTPROTO_PROXY option.

New Features:
- Introduce mtproto_proxy configuration field on the server, wired to the MTPROTO_PROXY environment variable for MTProto proxy usage.
- Enable Telegram clients (main service, web setup, and CLI setup) to connect via MTProto or Fake TLS proxies based on parsed configuration.
- Add proxy parsing utilities that support both tg://proxy?... and host:port:secret formats with automatic Fake TLS secret handling.

Enhancements:
- Log activation of MTProto proxy support and the type of proxy being used for better observability.
- Slightly simplify URL-to-content mapping in file handling utilities.

Build:
- Add TelethonFakeTLS as a dependency to support MTProto Fake TLS (EE/7 prefix) proxies.

Documentation:
- Document the MTPROTO_PROXY configuration and supported formats in the installation guide and .env example.
- Highlight MTProto proxy and Fake TLS support in the README and MTProto-Bridge documentation.

</details>

</details>

</details>