### PR TITLE
fix: find_chats filter resolution (rename folder→filter)

### DIFF
--- a/docs/Filters-vs-Folders.md
+++ b/docs/Filters-vs-Folders.md
@@ -1,0 +1,61 @@
+# Filters vs Folders
+
+Telegram's UI refers to "folders" but the underlying MTProto API and our implementation use the term **dialog filters**.
+
+## Why "filter" Instead of "folder"?
+
+In the Telegram UI, users create "folders" to organize their chats. However, these are actually **dialog filters** — smart lists defined by rules (flags) and/or explicit peer lists.
+
+### Dialog Filters vs Physical Sidebar Folders
+
+| Concept | MTProto `folder_id` | UI Name |
+|---------|---------------------|---------|
+| Main (all chats) | `0` | Main sidebar |
+| Archive | `1` | Archive folder |
+| Custom filter | N/A (not supported) | User-created "folder" |
+
+**Key limitation**: The MTProto API's `folder_id` parameter in `messages.getDialogs` only accepts physical sidebar folder IDs (`0` = Main, `1` = Archive). Custom dialog filter IDs cannot be used with `folder_id`.
+
+## How Dialog Filters Work
+
+Dialog filters have two components:
+
+### 1. Flags (Rule-based)
+
+Boolean flags that determine which chats match the filter:
+
+- `contacts` — include contacts
+- `non_contacts` — include non-contacts
+- `groups` — include supergroups (megagroups)
+- `broadcasts` — include channels
+- `bots` — include bots
+- `exclude_muted` — exclude muted chats
+- `exclude_read` — exclude chats with no unread messages
+- `exclude_archived` — exclude archived chats
+
+When all flags are `False`, the filter matches nothing unless explicit peers are listed.
+
+### 2. Include/Exclude Peers (Explicit List)
+
+Filters can explicitly include or exclude specific chats by their peer (user, chat, or channel). These take priority over flags.
+
+## Implementation Approach
+
+Since MTProto doesn't support custom filter IDs with `iter_dialogs`, we use two workarounds:
+
+### For Filters with `include_peers`
+
+1. Get the filter definition to retrieve the list of explicitly included peers
+2. Resolve each `InputPeer` to a real entity via `get_entity()`
+3. Use `GetPeerDialogsRequest` in chunks to get last activity dates
+4. Apply any additional flag-based filtering
+
+### For Flag-based Filters (no `include_peers`)
+
+1. Iterate all dialogs via `iter_dialogs()` without a folder parameter
+2. For each dialog, check if it matches the filter's flags
+3. Apply date filters if specified
+
+## Date Filtering Limitation
+
+When a filter has `include_peers`, date parameters (`min_date`, `max_date`) are **ignored**. This is because `GetPeerDialogsRequest` does not return dialog date information — only the last message date per peer. Use flag-based filters when date filtering is needed.

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -22,37 +22,36 @@ find_chats(
   query?: str,                  // Search term(s); required for global search (comma-separated for multi-term)
   limit?: number = 20,         // Max results to return
   chat_type?: string, // Optional filter ('private','group','channel','bot', comma-separated for multiple)
-  folder?: number | string,    // Filter by dialog folder (integer ID or string name, case-insensitive exact match)
+  filter?: string,             // Filter by dialog filter name (case-insensitive exact match). See Filters-vs-Folders.md.
   public?: boolean,            // Optional public filter (true=with username, false=without username). Never applies to private chats.
-  min_date?: string,           // ISO date filter: only chats active since this date (last_activity_date)
-  max_date?: string            // ISO date filter: only chats active until this date (last_activity_date)
+  min_date?: string,           // ISO date filter: only chats active since this date (last_activity_date). Ignored for include_peers filters.
+  max_date?: string            // ISO date filter: only chats active until this date (last_activity_date). Ignored for include_peers filters.
 ) -> {
   chats: Chat[],               // Array of chat/user entities
 }
 ```
 
-**Two search modes:**
+**Three search modes:**
 
-1. **GLOBAL SEARCH** (query provided, no date/folder filters) — searches all of Telegram by name/username/phone. Can find any user/group/channel.
+1. **GLOBAL SEARCH** (query provided, no filter or date params) — searches all of Telegram by name/username/phone. Can find any user/group/channel.
 
-2. **DIALOG SEARCH** (min_date/max_date or folder used) — searches your sidebar/dialog list only. Returns chats matching query AND active within the date range. Each result includes `last_activity_date`.
+2. **FILTER SEARCH** (filter used) — searches chats matching the dialog filter. Filters with explicit peers use `GetPeerDialogsRequest`; flag-based filters iterate dialogs. Returns chats matching filter definition.
+
+3. **DIALOG SEARCH** (min_date/max_date used, no filter) — searches your sidebar/dialog list only. Returns chats matching query AND active within the date range. Each result includes `last_activity_date`.
 
 **Search capabilities:**
 - **Saved contacts** - Your Telegram contacts
 - **Global users** - Public Telegram users
 - **Channels & groups** - Public channels and groups
 - **Multi-term** - "term1, term2" runs parallel searches and merges/dedupes
-- **Folder filtering** - Filter by dialog folder (archived, custom folders)
+- **Filter** - Filter by dialog filter name (see Filters-vs-Folders.md)
 
 **Query formats:**
 - Name: `"John Doe"`
 - Username: `"telegram"` (without @)
 - Phone: `"+1234567890"`
 
-**Folder values:**
-- `0` or `"0"` - Default/main folder
-- `1` or `"1"` - Archived folder
-- Folder name as string - Case-insensitive exact match (e.g., `"Бридж"`, `"Work"`)
+**Filter:** Dialog filter name as string. Case-insensitive exact match after normalization (trim whitespace, collapse internal spaces, lowercase). Example: `"Без каналов"`, `"Work"`.
 
 **Examples:**
 ```json
@@ -77,11 +76,8 @@ find_chats(
 // Find private groups only
 {"tool": "find_chats", "params": {"query": "team", "chat_type": "group", "public": false}}
 
-// Find chats in archived folder (folder ID)
-{"tool": "find_chats", "params": {"query": "project", "folder": 1}}
-
-// Find chats in a specific folder by name
-{"tool": "find_chats", "params": {"query": "work", "folder": "Work"}}
+// Find chats by filter name
+{"tool": "find_chats", "params": {"query": "work", "filter": "Work"}}
 
 // Find bots
 {"tool": "find_chats", "params": {"query": "assistant", "chat_type": "bot"}}
@@ -92,11 +88,11 @@ find_chats(
 // Dialog search: your chats active in date range
 {"tool": "find_chats", "params": {"min_date": "2026-01-01", "max_date": "2026-06-30"}}
 
-// Dialog search: with query, in folder
-{"tool": "find_chats", "params": {"query": "project", "folder": "Work"}}
+// Filter search: chats in "Work" filter
+{"tool": "find_chats", "params": {"query": "project", "filter": "Work"}}
 
-// Dialog search: by last activity date in a specific folder
-{"tool": "find_chats", "params": {"min_date": "2026-04-01", "folder": "Бридж"}}
+// Filter search: with date filter (flag-based filter only)
+{"tool": "find_chats", "params": {"min_date": "2026-04-01", "filter": "Без каналов"}}
 ```
 
 ### get_chat_info

--- a/src/server_components/mcp_tool_types.py
+++ b/src/server_components/mcp_tool_types.py
@@ -189,12 +189,12 @@ QueryFindChats = Annotated[
     ),
 ]
 
-FolderFilter = Annotated[
-    int | str,
+FilterParam = Annotated[
+    str,
     Field(
         description=(
-            "Dialog folder: integer id or exact folder name (case-insensitive). "
-            "Triggers sidebar-only search with other filters."
+            "Dialog filter name (case-insensitive exact match after normalization). "
+            "See Filters-vs-Folders.md for filter vs folder distinction."
         )
     ),
 ]

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -14,7 +14,7 @@ from src.server_components.mcp_tool_types import (
     ContactFirstName,
     ContactLastName,
     FilesListParam,
-    FolderFilter,
+    FilterParam,
     IncludeTotalCount,
     LimitChats,
     LimitMessages,
@@ -82,7 +82,7 @@ _DESC_EDIT_MESSAGE = _tool_description(
 _DESC_FIND_CHATS = _tool_description(
     "Find users/groups/channels by name, username, or phone. "
     "Global search (query required) searches all Telegram; "
-    "with min_date, max_date, or folder, search is limited to your sidebar dialogs. "
+    "with min_date, max_date, or filter, search uses dialog filter. "
     "Success: dict with key chats (list of chat objects). "
 )
 
@@ -250,11 +250,11 @@ def register_tools(mcp: FastMCP) -> None:
         public: PublicFilter = None,
         min_date: MinDate = None,
         max_date: MaxDate = None,
-        folder: FolderFilter = None,
+        filter: FilterParam = None,
     ) -> dict[str, Any]:
-        """Find chats by query, folder, or activity dates (full doc URL in tool description)."""
+        """Find chats by query, filter, or activity dates (full doc URL in tool description)."""
         return await find_chats_impl(
-            query, limit, chat_type, public, min_date, max_date, folder
+            query, limit, chat_type, public, min_date, max_date, filter
         )
 
     @mcp.tool(

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -113,13 +113,10 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
     mute_until = getattr(getattr(dialog, "notify_settings", None) or {}, "mute_until", 0) or 0
     if filter_dict.get("exclude_muted") and mute_until > now:
         return False
-    return (
-        False
-        if filter_dict.get("exclude_read")
-        and getattr(dialog, "unread_count", 0) == 0
-        else not filter_dict.get("exclude_archived")
-        or getattr(dialog, "folder_id", None) != 1
-    )
+    # exclude_read: filter out dialogs with no unread messages
+    if filter_dict.get("exclude_read") and getattr(dialog, "unread_count", 0) == 0:
+        return False
+    return not (filter_dict.get("exclude_archived") and getattr(dialog, "folder_id", None) == 1)
 
 
 async def search_contacts_native(
@@ -267,7 +264,7 @@ async def find_chats_impl(
             error_message=(
                 "query parameter is required for global Telegram search. "
                 "Telegram's global search requires a non-empty search term (name, username, or phone). "
-                "To browse chats in a specific folder, use filter parameter. "
+                "To browse chats in a specific filter, use filter parameter. "
                 "To find chats active in a date range, use min_date/max_date filters. "
                 f"Received: query={query!r} with no date/filter."
             ),
@@ -642,7 +639,7 @@ async def _find_chats_by_include_peers(
 
         try:
             result = await client(GetPeerDialogsRequest(peers=input_peers))
-            for d, m in zip(result.dialogs, result.messages, strict=True):
+            for d, m in zip(result.dialogs, result.messages, strict=False):
                 # Extract peer_id from message.peer
                 peer_id = _extract_peer_id(d.peer)
                 if peer_id and m.date:

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -39,9 +39,7 @@ AVAILABLE_FILTERS_MAX_SHOW = 10
 
 def _normalize_filter_name(name: str | None) -> str:
     """Normalize filter names for comparison: trim and collapse whitespace, lowercase."""
-    if not name:
-        return ""
-    return " ".join(name.split()).lower()
+    return " ".join(name.split()).lower() if name else ""
 
 
 async def _get_filter_by_name(client, filter_name: str) -> dict | None:

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -94,9 +94,9 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
     ):
         return False
 
-    # groups=True → include supergroups (megagroup)
+    # groups=True → include supergroups (megagroup - Channel with megagroup=True)
     if filter_dict.get("groups") and not (
-        is_chat and getattr(entity, "megagroup", False)
+        is_chat or (is_channel and getattr(entity, "megagroup", False))
     ):
         return False
     # broadcasts=True → include channels
@@ -111,7 +111,7 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
     # Exclude filters
     now = datetime.now(UTC).timestamp()
     mute_until = getattr(dialog.notify_settings, "mute_until", 0) or 0
-    if filter_dict.get("exclude_muted") and mute_until <= now:
+    if filter_dict.get("exclude_muted") and mute_until > now:
         return False
     return (
         False
@@ -739,7 +739,22 @@ async def _find_chats_by_filter_flags(
 ) -> dict[str, Any]:
     """Handle flag-based filter by iterating all dialogs and matching flags."""
     min_date_dt = _parse_iso_date(min_date)
+    if min_date is not None and min_date_dt is None:
+        return log_and_build_error(
+            operation="find_chats",
+            error_message=f"Invalid min_date format: '{min_date}'. Use ISO format (e.g., '2024-01-01')",
+            params={},
+            exception=ValueError(f"Invalid min_date format: '{min_date}'"),
+        )
+
     max_date_dt = _parse_iso_date(max_date)
+    if max_date is not None and max_date_dt is None:
+        return log_and_build_error(
+            operation="find_chats",
+            error_message=f"Invalid max_date format: '{max_date}'. Use ISO format (e.g., '2024-12-31')",
+            params={},
+            exception=ValueError(f"Invalid max_date format: '{max_date}'"),
+        )
 
     results = []
     async for dialog in client.iter_dialogs(

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -96,8 +96,8 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
         is_chat or (is_channel and getattr(entity, "megagroup", False))
     ):
         return False
-    # broadcasts=True → include channels
-    if filter_dict.get("broadcasts") and not is_channel:
+    # broadcasts=True → include broadcast channels only (not supergroups/megagroups)
+    if filter_dict.get("broadcasts") and not (is_channel and getattr(entity, "broadcast", False)):
         return False
     # bots=True → include only actual bots; bots=False means don't filter by bot status
     # Only applies to users (channels/groups aren't bots even if they have a bot attr)

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -69,30 +69,27 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
     is_chat = isinstance(entity, TelethonChat)
     is_channel = isinstance(entity, TelethonChannel)
 
-    # Handle contacts AND non_contacts = all users (no contact filter)
+    # Handle contacts AND non_contacts flags
+    # When both True or both False: include all users (skip contact status check)
+    # When only contacts=True: only include actual contacts
+    # When only non_contacts=True: only include non-contacts
     contacts_flag = filter_dict.get("contacts", False)
     non_contacts_flag = filter_dict.get("non_contacts", False)
 
-    if contacts_flag and non_contacts_flag:
-        pass  # include all users, skip contact status check
-    elif (
-        contacts_flag
-        and not (
-            is_user
-            and (
-                getattr(entity, "contact", False)
-                or getattr(entity, "mutual_contact", False)
-            )
-        )
-    ) or (
-        non_contacts_flag
-        and not (
-            is_user
-            and not getattr(entity, "contact", False)
-            and not getattr(entity, "mutual_contact", False)
-        )
-    ):
-        return False
+    if is_user and (contacts_flag or non_contacts_flag):
+        is_contact = getattr(entity, "contact", False) or getattr(entity, "mutual_contact", False)
+        is_non_contact = not is_contact
+
+        # If only contacts flag is set and user is not a contact → exclude
+        if contacts_flag and not non_contacts_flag and not is_contact:
+            return False
+        # If only non_contacts flag is set and user IS a contact → exclude
+        if non_contacts_flag and not contacts_flag and is_contact:
+            return False
+        # If neither flag is set (both False): exclude all users (wait for other flags)
+        # Actually when both False, should we include or exclude users? Let other flags decide
+        if not contacts_flag and not non_contacts_flag:
+            pass  # don't filter based on contact status alone
 
     # groups=True → include supergroups (megagroup - Channel with megagroup=True)
     if filter_dict.get("groups") and not (
@@ -102,10 +99,9 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
     # broadcasts=True → include channels
     if filter_dict.get("broadcasts") and not is_channel:
         return False
-    # bots=True → include bots
-    if filter_dict.get("bots") and (
-        not is_user or not getattr(entity, "bot", False)
-    ):
+    # bots=True → include only actual bots; bots=False means don't filter by bot status
+    # Only applies to users (channels/groups aren't bots even if they have a bot attr)
+    if filter_dict.get("bots") is True and is_user and not getattr(entity, "bot", False):
         return False
 
     # Exclude filters

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -37,8 +37,10 @@ GET_PEER_DIALOGS_CHUNK_SIZE = 50
 AVAILABLE_FILTERS_MAX_SHOW = 10
 
 
-def _normalize_filter_name(name: str) -> str:
+def _normalize_filter_name(name: str | None) -> str:
     """Normalize filter names for comparison: trim and collapse whitespace, lowercase."""
+    if not name:
+        return ""
     return " ".join(name.split()).lower()
 
 

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -9,7 +9,10 @@ from datetime import UTC, datetime
 from typing import Any
 
 from telethon.tl.functions.contacts import SearchRequest
-from telethon.tl.functions.messages import GetForumTopicsRequest
+from telethon.tl.functions.messages import GetForumTopicsRequest, GetPeerDialogsRequest
+from telethon.tl.types import Channel as TelethonChannel
+from telethon.tl.types import Chat as TelethonChat
+from telethon.tl.types import User as TelethonUser
 
 from src.client.connection import (
     SessionNotAuthorizedError,
@@ -22,42 +25,101 @@ from src.utils.entity import (
     build_dialog_entity_dict,
     build_entity_dict,
     build_entity_dict_enriched,
-    get_available_folders,
+    get_dialog_filters,
     get_entity_by_id,
 )
 from src.utils.error_handling import log_and_build_error
 
 logger = logging.getLogger(__name__)
 
+FLAG_MATCH_MAX_DIALOGS = 500
+GET_PEER_DIALOGS_CHUNK_SIZE = 50
+AVAILABLE_FILTERS_MAX_SHOW = 10
 
-def _normalize_folder_name(name: str) -> str:
-    """Normalize folder names for comparison: trim and collapse whitespace, lowercase."""
+
+def _normalize_filter_name(name: str) -> str:
+    """Normalize filter names for comparison: trim and collapse whitespace, lowercase."""
     return " ".join(name.split()).lower()
 
 
-async def _resolve_folder_id(client, folder: int | str) -> int | None:
-    """Resolve folder parameter to folder ID.
+async def _get_filter_by_name(client, filter_name: str) -> dict | None:
+    """Find filter by name (string). Returns full filter dict or None."""
+    filters = await get_dialog_filters(client)
+    normalized = _normalize_filter_name(filter_name)
+    return next(
+        (
+            f
+            for f in filters
+            if _normalize_filter_name(f.get("title", "")) == normalized
+        ),
+        None,
+    )
 
-    Args:
-        folder: Folder ID (int) or folder name (str, case-insensitive exact match)
 
-    Returns:
-        Folder ID (int) or None if not found
+def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
+    """Check if entity matches filter flags.
 
-    Note: Folder 0 (default) shows as folder_id=null on Dialog objects,
-          so iter_dialogs(folder=0) returns dialogs with folder_id=null
+    filter_dict contains: contacts, non_contacts, groups, broadcasts, bots,
+    exclude_muted, exclude_read, exclude_archived (from filter's flags)
+
+    Note: exclude_muted/exclude_read/exclude_archived require dialog object,
+    not just entity. entity param is the Chat/User/Channel, dialog is the Dialog object.
     """
-    if isinstance(folder, int):
-        return folder
+    is_user = isinstance(entity, TelethonUser)
+    is_chat = isinstance(entity, TelethonChat)
+    is_channel = isinstance(entity, TelethonChannel)
 
-    # String name - load folders and match by title
-    folders = await get_available_folders(client)
-    normalized_folder = _normalize_folder_name(folder)
-    for f in folders:
-        title = f.get("title", "")
-        if title and _normalize_folder_name(title) == normalized_folder:
-            return f.get("id")
-    return None
+    # Handle contacts AND non_contacts = all users (no contact filter)
+    contacts_flag = filter_dict.get("contacts", False)
+    non_contacts_flag = filter_dict.get("non_contacts", False)
+
+    if contacts_flag and non_contacts_flag:
+        pass  # include all users, skip contact status check
+    elif (
+        contacts_flag
+        and not (
+            is_user
+            and (
+                getattr(entity, "contact", False)
+                or getattr(entity, "mutual_contact", False)
+            )
+        )
+    ) or (
+        non_contacts_flag
+        and not (
+            is_user
+            and not getattr(entity, "contact", False)
+            and not getattr(entity, "mutual_contact", False)
+        )
+    ):
+        return False
+
+    # groups=True → include supergroups (megagroup)
+    if filter_dict.get("groups") and not (
+        is_chat and getattr(entity, "megagroup", False)
+    ):
+        return False
+    # broadcasts=True → include channels
+    if filter_dict.get("broadcasts") and not is_channel:
+        return False
+    # bots=True → include bots
+    if filter_dict.get("bots") and (
+        not is_user or not getattr(entity, "bot", False)
+    ):
+        return False
+
+    # Exclude filters
+    now = datetime.now(UTC).timestamp()
+    mute_until = getattr(dialog.notify_settings, "mute_until", 0) or 0
+    if filter_dict.get("exclude_muted") and mute_until <= now:
+        return False
+    return (
+        False
+        if filter_dict.get("exclude_read")
+        and getattr(dialog, "unread_count", 0) == 0
+        else not filter_dict.get("exclude_archived")
+        or getattr(dialog, "folder_id", None) != 1
+    )
 
 
 async def search_contacts_native(
@@ -158,7 +220,7 @@ async def find_chats_impl(
     public: bool | None = None,
     min_date: str | None = None,
     max_date: str | None = None,
-    folder: int | str | None = None,
+    filter: str | None = None,
 ) -> dict[str, Any]:
     """
     High-level contacts search with support for comma-separated multi-term queries.
@@ -173,16 +235,17 @@ async def find_chats_impl(
         public: Optional filter for public discoverability
         min_date: Minimum last activity date filter (ISO format, e.g. "2024-01-01" or "2024-01-01T14:30:00")
         max_date: Maximum last activity date filter (ISO format, e.g. "2024-12-31" or "2024-12-31T23:59:59")
-        folder: Filter by folder (int ID or str name)
+        filter: Filter by dialog filter name (str). When filter has include_peers,
+                date parameters (min_date/max_date) are ignored.
 
     Returns:
         Dict with "chats" key containing list of matches, or standardized error dict
 
     Raises:
-        ValueError: For invalid parameter combinations (e.g., empty query without date/folder filters)
+        ValueError: For invalid parameter combinations (e.g., empty query without date/filter)
     """
-    has_date_or_folder_filter = (
-        min_date is not None or max_date is not None or folder is not None
+    has_date_or_filter = (
+        min_date is not None or max_date is not None or filter is not None
     )
 
     params = {
@@ -192,11 +255,11 @@ async def find_chats_impl(
         "public": public,
         "min_date": min_date,
         "max_date": max_date,
-        "folder": folder,
+        "filter": filter,
     }
 
     # Validate: global search requires non-empty query
-    if not has_date_or_folder_filter and (
+    if not has_date_or_filter and (
         not query or (isinstance(query, str) and not query.strip())
     ):
         return log_and_build_error(
@@ -204,12 +267,12 @@ async def find_chats_impl(
             error_message=(
                 "query parameter is required for global Telegram search. "
                 "Telegram's global search requires a non-empty search term (name, username, or phone). "
-                "To browse chats in a specific folder, use folder parameter. "
+                "To browse chats in a specific folder, use filter parameter. "
                 "To find chats active in a date range, use min_date/max_date filters. "
-                f"Received: query={query!r} with no date/folder filters."
+                f"Received: query={query!r} with no date/filter."
             ),
             params=params,
-            exception=ValueError("Empty query not allowed without date/folder filters"),
+            exception=ValueError("Empty query not allowed without date/filter"),
         )
 
     # Validate limit
@@ -221,7 +284,18 @@ async def find_chats_impl(
             exception=ValueError(f"Invalid limit: {limit}"),
         )
 
-    if has_date_or_folder_filter:
+    if filter is not None:
+        return await _find_chats_by_filter(
+            query=query,
+            limit=limit,
+            chat_type=chat_type,
+            public=public,
+            min_date=min_date,
+            max_date=max_date,
+            filter_name=filter,
+        )
+
+    if has_date_or_filter:
         return await _find_chats_by_dialogs(
             query=query,
             limit=limit,
@@ -229,15 +303,16 @@ async def find_chats_impl(
             public=public,
             min_date=min_date,
             max_date=max_date,
-            folder=folder,
+            folder_id=None,
         )
 
-    return await _find_chats_global(
+    result = await _find_chats_global(
         query=query,
         limit=limit,
         chat_type=chat_type,
         public=public,
     )
+    return {"chats": result} if isinstance(result, list) else result
 
 
 async def _find_chats_global(
@@ -316,7 +391,7 @@ async def _find_chats_by_dialogs(
     public: bool | None,
     min_date: str | None,
     max_date: str | None,
-    folder: int | str | None = None,
+    folder_id: int | None = None,
 ) -> dict[str, Any]:
     """Dialog-based search with date filtering and last_activity_date."""
     params = {
@@ -326,7 +401,7 @@ async def _find_chats_by_dialogs(
         "public": public,
         "min_date": min_date,
         "max_date": max_date,
-        "folder": folder,
+        "folder_id": folder_id,
     }
 
     min_date_dt = _parse_iso_date(min_date)
@@ -346,14 +421,6 @@ async def _find_chats_by_dialogs(
             params=params,
             exception=ValueError(f"Invalid max_date format: '{max_date}'"),
         )
-
-    # Resolve folder name to ID if needed (only when a folder filter is provided)
-    # Use `is not None` to handle folder=0 correctly (falsy check would skip folder 0)
-    if folder is not None:
-        client = await get_connected_client()
-        folder_id = await _resolve_folder_id(client, folder)
-    else:
-        folder_id = None
 
     results = []
     async for item in search_dialogs_impl(
@@ -378,6 +445,335 @@ async def _find_chats_by_dialogs(
         params=params,
         exception=ValueError(f"No chats found {query_str}{date_str}"),
     )
+
+
+async def _find_chats_by_filter(
+    query: str | None,
+    limit: int,
+    chat_type: str | None,
+    public: bool | None,
+    min_date: str | None,
+    max_date: str | None,
+    filter_name: str,
+) -> dict[str, Any]:
+    """Filter-based search using dialog filter definition."""
+    params = {
+        "query": query,
+        "limit": limit,
+        "chat_type": chat_type,
+        "public": public,
+        "min_date": min_date,
+        "max_date": max_date,
+        "filter": filter_name,
+    }
+
+    client = await get_connected_client()
+    filter_dict = await _get_filter_by_name(client, filter_name)
+
+    if not filter_dict:
+        all_filters = await get_dialog_filters(client)
+        available = "; ".join(
+            f'"{f.get("title", "")}"' for f in all_filters[:AVAILABLE_FILTERS_MAX_SHOW]
+        )
+        return log_and_build_error(
+            operation="find_chats",
+            error_message=f"Filter '{filter_name}' not found. Available: [{available}]",
+            params=params,
+            exception=ValueError(f"Filter '{filter_name}' not found"),
+        )
+
+    include_peers = filter_dict.get("include_peers", []) or []
+    has_flags = any(
+        filter_dict.get(flag)
+        for flag in (
+            "contacts",
+            "non_contacts",
+            "groups",
+            "broadcasts",
+            "bots",
+            "exclude_muted",
+            "exclude_read",
+            "exclude_archived",
+        )
+    )
+
+    if include_peers:
+        return await _find_chats_by_include_peers(
+            client,
+            filter_dict,
+            query,
+            limit,
+            chat_type,
+            public,
+            min_date,
+            max_date,
+        )
+    if has_flags:
+        return await _find_chats_by_filter_flags(
+            client,
+            filter_dict,
+            query,
+            limit,
+            chat_type,
+            public,
+            min_date,
+            max_date,
+        )
+    # Filter exists but has no include_peers and no active flags
+    return {"chats": []}
+
+
+async def _find_chats_by_include_peers(
+    client,
+    filter_dict: dict,
+    query: str | None,
+    limit: int,
+    chat_type: str | None,
+    public: bool | None,
+    min_date: str | None,
+    max_date: str | None,
+) -> dict[str, Any]:
+    """Handle filter with explicit include_peers using GetPeerDialogsRequest."""
+    include_peers = filter_dict.get("include_peers", []) or []
+    exclude_peers = filter_dict.get("exclude_peers", []) or []
+
+    # Resolve include_peers InputPeers → actual entities
+    ordered_peer_ids: list[int] = []
+    peer_entity_map: dict[int, dict] = {}
+
+    for inp_peer in include_peers:
+        try:
+            entity = await client.get_entity(inp_peer)
+            eid = getattr(entity, "id", None)
+            if eid is None:
+                continue
+            if eid in ordered_peer_ids:
+                continue
+            entity_dict = build_entity_dict(entity)
+            if not entity_dict:
+                continue
+            ordered_peer_ids.append(eid)
+            peer_entity_map[eid] = entity_dict
+        except Exception as e:
+            logger.debug(f"Failed to resolve include_peer {inp_peer}: {e}")
+            continue
+
+    # Apply exclude_peers
+    for inp_peer in exclude_peers:
+        try:
+            entity = await client.get_entity(inp_peer)
+            eid = getattr(entity, "id", None)
+            if eid and eid in ordered_peer_ids:
+                ordered_peer_ids.remove(eid)
+                peer_entity_map.pop(eid, None)
+        except Exception as e:
+            logger.debug(f"Failed to resolve exclude_peer {inp_peer}: {e}")
+
+    # If filter has flags too, add flag-matching dialogs
+    has_flags = any(
+        filter_dict.get(flag)
+        for flag in (
+            "contacts",
+            "non_contacts",
+            "groups",
+            "broadcasts",
+            "bots",
+            "exclude_muted",
+            "exclude_read",
+            "exclude_archived",
+        )
+    )
+    if has_flags:
+        async for dialog in client.iter_dialogs(
+            limit=min(limit * 10, FLAG_MATCH_MAX_DIALOGS),
+        ):
+            entity = getattr(dialog, "entity", None)
+            if not entity:
+                continue
+            eid = getattr(entity, "id", None)
+            if (
+                eid
+                and eid not in ordered_peer_ids
+                and _filter_matches_flags(entity, dialog, filter_dict)
+                and (entity_dict := build_entity_dict(entity))
+            ):
+                ordered_peer_ids.append(eid)
+                peer_entity_map[eid] = entity_dict
+
+    if not ordered_peer_ids:
+        return {"chats": []}
+
+    # Build InputPeers and batch call GetPeerDialogsRequest
+    last_activity_map: dict[int, str] = {}
+    for chunk_start in range(0, len(ordered_peer_ids), GET_PEER_DIALOGS_CHUNK_SIZE):
+        chunk_ids = ordered_peer_ids[
+            chunk_start : chunk_start + GET_PEER_DIALOGS_CHUNK_SIZE
+        ]
+
+        input_peers = []
+        for pid in chunk_ids:
+            ent = peer_entity_map.get(pid)
+            if not ent:
+                continue
+            ent_type = ent.get("type")
+            if ent_type == "channel":
+                from telethon.tl.types import InputPeerChannel
+
+                input_peers.append(
+                    InputPeerChannel(
+                        channel_id=pid, access_hash=ent.get("access_hash", 0) or 0
+                    )
+                )
+            elif ent_type == "group":
+                from telethon.tl.types import InputPeerChat
+
+                input_peers.append(InputPeerChat(chat_id=pid))
+            elif ent_type in ("private", "bot"):
+                from telethon.tl.types import InputPeerUser
+
+                input_peers.append(
+                    InputPeerUser(
+                        user_id=pid, access_hash=ent.get("access_hash", 0) or 0
+                    )
+                )
+
+        if not input_peers:
+            continue
+
+        try:
+            result = await client(GetPeerDialogsRequest(peers=input_peers))
+            for d, m in zip(result.dialogs, result.messages, strict=True):
+                # Extract peer_id from message.peer
+                peer_id = _extract_peer_id(d.peer)
+                if peer_id and m.date:
+                    last_activity_map[peer_id] = m.date.isoformat()
+        except Exception as e:
+            logger.debug(f"GetPeerDialogsRequest failed: {e}")
+
+    # Build result with filtering
+    results = []
+    for pid in ordered_peer_ids:
+        ent_dict = peer_entity_map.get(pid)
+        if not ent_dict:
+            continue
+
+        # Apply chat_type filter
+        if chat_type and not _matches_chat_type_from_dict(ent_dict, chat_type):
+            continue
+
+        # Apply public filter
+        if public is not None and not _matches_public_filter_from_dict(
+            ent_dict, public
+        ):
+            continue
+
+        # Apply query filter
+        if query:
+            query_lower = query.lower().strip()
+            if query_lower and not _matches_dict_query(ent_dict, query_lower):
+                continue
+
+        result_dict = dict(ent_dict)
+        if pid in last_activity_map:
+            result_dict["last_activity_date"] = last_activity_map[pid]
+
+        results.append(result_dict)
+        if len(results) >= limit:
+            break
+
+    return {"chats": results}
+
+
+def _extract_peer_id(peer) -> int | None:
+    """Extract numeric peer ID from PeerUser/PeerChannel/PeerChat."""
+    if hasattr(peer, "user_id"):
+        return peer.user_id
+    if hasattr(peer, "channel_id"):
+        return peer.channel_id
+    return peer.chat_id if hasattr(peer, "chat_id") else None
+
+
+def _matches_chat_type_from_dict(entity_dict: dict, chat_type: str) -> bool:
+    """Check if entity dict matches chat_type filter."""
+    if not chat_type:
+        return True
+    chat_types = [ct.strip().lower() for ct in chat_type.split(",") if ct.strip()]
+    valid_types = {"private", "bot", "group", "channel"}
+    if any(ct not in valid_types for ct in chat_types):
+        return False
+    entity_type = entity_dict.get("type")
+    return entity_type in chat_types
+
+
+def _matches_public_filter_from_dict(entity_dict: dict, public: bool | None) -> bool:
+    """Check if entity dict matches public filter."""
+    if entity_dict.get("type") in ("private", "bot"):
+        return True
+    if public is None:
+        return True
+    has_username = bool(entity_dict.get("username"))
+    return has_username if public else not has_username
+
+
+def _matches_dict_query(entity_dict: dict, query_lower: str) -> bool:
+    """Check if entity dict matches query string."""
+    title = entity_dict.get("title", "") or ""
+    username = entity_dict.get("username", "") or ""
+    first_name = entity_dict.get("first_name", "") or ""
+    last_name = entity_dict.get("last_name", "") or ""
+    searchable = " ".join(
+        part for part in (title, username, first_name, last_name) if part
+    ).lower()
+    return query_lower in searchable
+
+
+async def _find_chats_by_filter_flags(
+    client,
+    filter_dict: dict,
+    query: str | None,
+    limit: int,
+    chat_type: str | None,
+    public: bool | None,
+    min_date: str | None,
+    max_date: str | None,
+) -> dict[str, Any]:
+    """Handle flag-based filter by iterating all dialogs and matching flags."""
+    min_date_dt = _parse_iso_date(min_date)
+    max_date_dt = _parse_iso_date(max_date)
+
+    results = []
+    async for dialog in client.iter_dialogs(
+        limit=min(limit * 10, FLAG_MATCH_MAX_DIALOGS)
+    ):
+        entity = getattr(dialog, "entity", None)
+        if not entity:
+            continue
+
+        if not _filter_matches_flags(entity, dialog, filter_dict):
+            continue
+
+        dialog_date = getattr(dialog, "date", None)
+        if not await _dialog_in_date_range(
+            entity, client, dialog_date, min_date_dt, max_date_dt
+        ):
+            continue
+
+        if chat_type and not _matches_chat_type(entity, chat_type):
+            continue
+        if not _matches_public_filter(entity, public):
+            continue
+
+        if result := build_dialog_entity_dict(dialog, entity):
+            # Apply query filter
+            if query:
+                query_lower = query.lower().strip()
+                if query_lower and not _matches_dialog_query(entity, query_lower):
+                    continue
+            results.append(result)
+            if len(results) >= limit:
+                break
+
+    return {"chats": results}
 
 
 # Backwards-compatible alias for previous name

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -671,6 +671,8 @@ async def _find_chats_by_include_peers(
                 continue
 
         result_dict = dict(ent_dict)
+        # Remove internal fields not meant for API responses
+        result_dict.pop("access_hash", None)
         if pid in last_activity_map:
             result_dict["last_activity_date"] = last_activity_map[pid]
 

--- a/src/tools/contacts.py
+++ b/src/tools/contacts.py
@@ -112,7 +112,7 @@ def _filter_matches_flags(entity, dialog, filter_dict: dict) -> bool:
 
     # Exclude filters
     now = datetime.now(UTC).timestamp()
-    mute_until = getattr(dialog.notify_settings, "mute_until", 0) or 0
+    mute_until = getattr(getattr(dialog, "notify_settings", None) or {}, "mute_until", 0) or 0
     if filter_dict.get("exclude_muted") and mute_until > now:
         return False
     return (

--- a/src/utils/entity.py
+++ b/src/utils/entity.py
@@ -290,6 +290,8 @@ def build_entity_dict(entity) -> dict | None:
         "subscribers_count": subscribers_count,
         # Present only for forum-enabled channels/supergroups
         "is_forum": True if is_forum else None,
+        # Access hash (required for InputPeer construction)
+        "access_hash": getattr(entity, "access_hash", None),
     }
 
     # Prune None values for a compact, uniform schema

--- a/src/utils/entity.py
+++ b/src/utils/entity.py
@@ -34,14 +34,34 @@ _FOLDER_LIST_CACHE: dict[str | int, tuple[list[dict], float]] = {}
 _FOLDER_CACHE_TTL_SECONDS = 300  # 5 minutes
 
 
-async def get_available_folders(client) -> list[dict]:
-    """Fetch user's dialog folders from Telegram with 5-minute caching.
+def _extract_filter_flags(filter_obj) -> dict:
+    """Extract boolean flags from DialogFilter/DialogFilterChatlist into flat dict."""
+    return {
+        "id": getattr(filter_obj, "id", None),
+        "title": getattr(filter_obj, "title", None),
+        "contacts": getattr(filter_obj, "contacts", False),
+        "non_contacts": getattr(filter_obj, "non_contacts", False),
+        "groups": getattr(filter_obj, "groups", False),
+        "broadcasts": getattr(filter_obj, "broadcasts", False),
+        "bots": getattr(filter_obj, "bots", False),
+        "exclude_muted": getattr(filter_obj, "exclude_muted", False),
+        "exclude_read": getattr(filter_obj, "exclude_read", False),
+        "exclude_archived": getattr(filter_obj, "exclude_archived", False),
+        "include_peers": getattr(filter_obj, "include_peers", []),
+        "exclude_peers": getattr(filter_obj, "exclude_peers", []),
+    }
+
+
+async def get_dialog_filters(client) -> list[dict]:
+    """Fetch user's dialog filters from Telegram with 5-minute caching.
 
     Uses client(functions.messages.GetDialogFiltersRequest()) via Telethon.
 
-    Returns list of dicts with 'id' (int) and 'title' (str) keys.
+    Returns list of flat dicts with filter metadata and flags:
+    - id, title, contacts, non_contacts, groups, broadcasts, bots,
+      exclude_muted, exclude_read, exclude_archived, include_peers, exclude_peers
 
-    IMPORTANT: Folder title is a TextWithEntities object - extract .text
+    Note: Folder title is a TextWithEntities object - extract .text
     """
     global _FOLDER_LIST_CACHE
 
@@ -53,12 +73,12 @@ async def get_available_folders(client) -> list[dict]:
 
     # Check cache
     if cache_key in _FOLDER_LIST_CACHE:
-        folders, timestamp = _FOLDER_LIST_CACHE[cache_key]
+        filters, timestamp = _FOLDER_LIST_CACHE[cache_key]
         if time.time() - timestamp < _FOLDER_CACHE_TTL_SECONDS:
-            return folders
+            return filters
 
     # Fetch from Telegram
-    folders = []
+    filters = []
     try:
         from telethon import functions
 
@@ -67,23 +87,25 @@ async def get_available_folders(client) -> list[dict]:
             # title is TextWithEntities object - extract .text
             title_obj = getattr(f, "title", None)
             title_text = getattr(title_obj, "text", None) if title_obj else None
-            folders.append(
-                {
-                    "id": getattr(f, "id", None),
-                    "title": title_text,
-                }
-            )
+            filter_dict = _extract_filter_flags(f)
+            filter_dict["title"] = title_text
+            filters.append(filter_dict)
     except asyncio.CancelledError:
         # Let cancellation propagate so shutdown/timeout behavior works correctly
         raise
     except Exception as e:
         logger.debug(f"GetDialogFiltersRequest failed: {e}")
         # Don't cache empty result on failure - allows retry instead of long-lived empty cache
-        return folders
+        return filters
 
     # Update cache only on success
-    _FOLDER_LIST_CACHE[cache_key] = (folders, time.time())
-    return folders
+    _FOLDER_LIST_CACHE[cache_key] = (filters, time.time())
+    return filters
+
+
+async def get_available_folders(client) -> list[dict]:
+    """Deprecated alias for get_dialog_filters."""
+    return await get_dialog_filters(client)
 
 
 def _entity_cache_key(entity) -> tuple:

--- a/src/utils/entity.py
+++ b/src/utils/entity.py
@@ -621,6 +621,9 @@ def build_dialog_entity_dict(dialog, entity) -> dict | None:
     if not base:
         return None
 
+    # Strip internal fields not meant for API responses
+    base.pop("access_hash", None)
+
     last_activity_date = None
     if dialog_date := getattr(dialog, "date", None):
         with contextlib.suppress(Exception):

--- a/src/utils/entity.py
+++ b/src/utils/entity.py
@@ -83,7 +83,7 @@ async def get_dialog_filters(client) -> list[dict]:
         from telethon import functions
 
         result = await client(functions.messages.GetDialogFiltersRequest())
-        for f in result.dialog_filters:
+        for f in result.filters:
             # title is TextWithEntities object - extract .text
             title_obj = getattr(f, "title", None)
             title_text = getattr(title_obj, "text", None) if title_obj else None

--- a/tests/test_contacts_bot_folder.py
+++ b/tests/test_contacts_bot_folder.py
@@ -6,15 +6,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.tools.contacts import (
-    _normalize_folder_name,
-    _resolve_folder_id,
+    _normalize_filter_name,
+    _get_filter_by_name,
     find_chats_impl,
     search_dialogs_impl,
 )
 from src.utils.entity import (
     _matches_chat_type,
     _matches_public_filter,
-    get_available_folders,
+    get_dialog_filters,
     get_normalized_chat_type,
 )
 from tests.conftest import MockChannel, MockChat, MockDialog, MockUser, make_folder
@@ -136,8 +136,8 @@ class TestMatchesPublicFilter:
 # ============== Folder Filtering Tests ==============
 
 
-class TestGetAvailableFolders:
-    """Tests for get_available_folders function.
+class TestGetDialogFilters:
+    """Tests for get_dialog_filters function.
 
     Note: These tests verify the title extraction logic from TextWithEntities objects.
     The actual async API call is tested via integration tests.
@@ -160,15 +160,15 @@ class TestGetAvailableFolders:
         title_text = getattr(title_obj, "text", None) if title_obj else None
         assert title_text is None
 
-    def test_folder_dict_structure(self):
-        """Verify the folder dict structure returned by get_available_folders."""
-        folder_dict = {"id": 1, "title": "Work"}
-        assert folder_dict["id"] == 1
-        assert folder_dict["title"] == "Work"
+    def test_filter_dict_structure(self):
+        """Verify the filter dict structure returned by get_dialog_filters."""
+        filter_dict = {"id": 1, "title": "Work"}
+        assert filter_dict["id"] == 1
+        assert filter_dict["title"] == "Work"
 
     @pytest.mark.asyncio
     async def test_caches_results_on_first_call(self):
-        """Verify get_available_folders caches results after first API call."""
+        """Verify get_dialog_filters caches results after first API call."""
         from src.utils.entity import _FOLDER_LIST_CACHE
 
         _FOLDER_LIST_CACHE.clear()
@@ -190,7 +190,7 @@ class TestGetAvailableFolders:
 
         mock_client.side_effect = mock_call
 
-        await get_available_folders(mock_client)
+        await get_dialog_filters(mock_client)
 
         assert "cache_test_session" in _FOLDER_LIST_CACHE
         cached_folders, _ = _FOLDER_LIST_CACHE["cache_test_session"]
@@ -214,7 +214,7 @@ class TestGetAvailableFolders:
 
         mock_client.side_effect = Exception("API Error")
 
-        result = await get_available_folders(mock_client)
+        result = await get_dialog_filters(mock_client)
 
         assert result == []
         assert "fail_test_session" not in _FOLDER_LIST_CACHE
@@ -222,103 +222,95 @@ class TestGetAvailableFolders:
         _FOLDER_LIST_CACHE.clear()
 
 
-class TestNormalizeFolderName:
-    """Tests for _normalize_folder_name helper."""
+class TestNormalizeFilterName:
+    """Tests for _normalize_filter_name helper."""
 
     def test_trims_whitespace(self):
         """Should trim leading/trailing whitespace."""
-        assert _normalize_folder_name("  Work  ") == "work"
-        assert _normalize_folder_name("\tPersonal\t") == "personal"
+        assert _normalize_filter_name("  Work  ") == "work"
+        assert _normalize_filter_name("\tPersonal\t") == "personal"
 
     def test_collapse_internal_whitespace(self):
         """Should collapse internal whitespace to single spaces."""
-        assert _normalize_folder_name("Work  Chat") == "work chat"
-        assert _normalize_folder_name("Personal\tGroup") == "personal group"
+        assert _normalize_filter_name("Work  Chat") == "work chat"
+        assert _normalize_filter_name("Personal\tGroup") == "personal group"
 
     def test_lowercase_conversion(self):
         """Should convert to lowercase."""
-        assert _normalize_folder_name("WORK") == "work"
-        assert _normalize_folder_name("Personal") == "personal"
+        assert _normalize_filter_name("WORK") == "work"
+        assert _normalize_filter_name("Personal") == "personal"
 
     def test_combined_normalization(self):
         """Should combine all normalizations."""
-        assert _normalize_folder_name("  Work  Chat  ") == "work chat"
-        assert _normalize_folder_name("  PERSONAL ") == "personal"
+        assert _normalize_filter_name("  Work  Chat  ") == "work chat"
+        assert _normalize_filter_name("  PERSONAL ") == "personal"
 
 
-class TestResolveFolderId:
-    """Tests for _resolve_folder_id helper."""
-
-    @pytest.mark.asyncio
-    async def test_returns_integer_as_is(self):
-        """Integer folder ID should be returned as-is."""
-        mock_client = MagicMock()
-
-        result = await _resolve_folder_id(mock_client, 5)
-        assert result == 5
+class TestGetFilterByName:
+    """Tests for _get_filter_by_name helper."""
 
     @pytest.mark.asyncio
-    async def test_resolves_string_name_to_id(self):
-        """String folder name should be resolved to folder ID."""
+    async def test_resolves_string_name_to_filter_dict(self):
+        """String filter name should be resolved to full filter dict."""
         mock_client = MagicMock()
 
         with patch(
-            "src.tools.contacts.get_available_folders", new_callable=AsyncMock
-        ) as mock_folders:
-            mock_folders.return_value = [
+            "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+        ) as mock_filters:
+            mock_filters.return_value = [
+                {"id": 1, "title": "Work", "contacts": True},
+                {"id": 2, "title": "Personal", "contacts": False},
+            ]
+
+            result = await _get_filter_by_name(mock_client, "Work")
+            assert result == {"id": 1, "title": "Work", "contacts": True}
+
+    @pytest.mark.asyncio
+    async def test_filter_name_case_insensitive(self):
+        """Filter name matching should be case-insensitive."""
+        mock_client = MagicMock()
+
+        with patch(
+            "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+        ) as mock_filters:
+            mock_filters.return_value = [
                 {"id": 1, "title": "Work"},
                 {"id": 2, "title": "Personal"},
             ]
 
-            result = await _resolve_folder_id(mock_client, "Work")
-            assert result == 1
+            result = await _get_filter_by_name(mock_client, "work")
+            assert result["id"] == 1
+
+            result = await _get_filter_by_name(mock_client, "WORK")
+            assert result["id"] == 1
 
     @pytest.mark.asyncio
-    async def test_folder_name_case_insensitive(self):
-        """Folder name matching should be case-insensitive."""
+    async def test_filter_name_with_whitespace_matches(self):
+        """Filter names with extra whitespace should still match."""
         mock_client = MagicMock()
 
         with patch(
-            "src.tools.contacts.get_available_folders", new_callable=AsyncMock
-        ) as mock_folders:
-            mock_folders.return_value = [
-                {"id": 1, "title": "Work"},
-                {"id": 2, "title": "Personal"},
-            ]
+            "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+        ) as mock_filters:
+            mock_filters.return_value = [{"id": 1, "title": "Work"}]
 
-            result = await _resolve_folder_id(mock_client, "work")
-            assert result == 1
+            result = await _get_filter_by_name(mock_client, "  Work  ")
+            assert result["id"] == 1
 
-            result = await _resolve_folder_id(mock_client, "WORK")
-            assert result == 1
-
-    @pytest.mark.asyncio
-    async def test_folder_name_with_whitespace_matches(self):
-        """Folder names with extra whitespace should still match."""
-        mock_client = MagicMock()
-
-        with patch(
-            "src.tools.contacts.get_available_folders", new_callable=AsyncMock
-        ) as mock_folders:
-            mock_folders.return_value = [{"id": 1, "title": "Work"}]
-
-            result = await _resolve_folder_id(mock_client, "  Work  ")
-            assert result == 1
-
-            result = await _resolve_folder_id(mock_client, "Work  Chat")
+            result = await _get_filter_by_name(mock_client, "Work  Chat")
             assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):
-        """Should return None when folder name is not found."""
+        """Should return None when filter name is not found."""
         mock_client = MagicMock()
 
         with patch(
-            "src.tools.contacts.get_available_folders", new_callable=AsyncMock
-        ) as mock_folders:
-            mock_folders.return_value = [{"id": 1, "title": "Work"}]
+            "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+        ) as mock_filters:
+            mock_filters.return_value = [{"id": 1, "title": "Work"}]
 
-            result = await _resolve_folder_id(mock_client, "Nonexistent")
+            result = await _get_filter_by_name(mock_client, "Nonexistent")
             assert result is None
 
 
@@ -354,18 +346,18 @@ class TestSearchDialogsImplFolder:
             assert len(results) == 1
 
 
-class TestFindChatsImplFolder:
-    """Tests for find_chats_impl with folder parameter."""
+class TestFindChatsImplFilter:
+    """Tests for find_chats_impl with filter parameter."""
 
     @pytest.mark.asyncio
-    async def test_folder_param_uses_dialog_search(self):
-        """When folder is provided, should use dialog-based search."""
+    async def test_filter_param_uses_filter_search(self):
+        """When filter is provided, should use filter-based search."""
         dialog = MockDialog(
             MockUser(1, first_name="TestBot", bot=True),
             date=datetime(2024, 6, 15, tzinfo=UTC),
         )
 
-        async def mock_iter_dialogs(limit=None, folder=None):
+        async def mock_iter_dialogs(limit=None):
             yield dialog
 
         mock_client = MagicMock()
@@ -377,37 +369,38 @@ class TestFindChatsImplFolder:
             mock_get_client.return_value = mock_client
 
             with patch(
-                "src.tools.contacts.get_available_folders", new_callable=AsyncMock
-            ) as mock_folders:
-                mock_folders.return_value = [{"id": 1, "title": "Work"}]
+                "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+            ) as mock_filters:
+                mock_filters.return_value = [
+                    {"id": 1, "title": "Work", "include_peers": [], "groups": True}
+                ]
 
-                result = await find_chats_impl(folder=1)
+                result = await find_chats_impl(filter="Work")
 
                 assert "chats" in result
 
     @pytest.mark.asyncio
-    async def test_folder_param_none_uses_global_search(self):
-        """When no folder (None), should use global search."""
+    async def test_filter_param_none_uses_global_search(self):
+        """When no filter (None), should use global search."""
         with patch(
             "src.tools.contacts._search_contacts_as_list", new_callable=AsyncMock
         ) as mock_search:
             mock_search.return_value = [{"id": 1, "title": "Test"}]
 
-            result = await find_chats_impl(query="test", limit=10, folder=None)
+            result = await find_chats_impl(query="test", limit=10, filter=None)
 
             mock_search.assert_called_once()
             assert "chats" in result
 
     @pytest.mark.asyncio
-    async def test_resolves_folder_name_to_id(self):
-        """Should resolve folder name to folder ID."""
+    async def test_resolves_filter_name(self):
+        """Should resolve filter name to filter dict."""
         dialog = MockDialog(
             MockUser(1, first_name="TestBot", bot=True),
             date=datetime(2024, 6, 15, tzinfo=UTC),
         )
 
-        async def mock_iter_dialogs(limit=None, folder=None):
-            assert folder == 1
+        async def mock_iter_dialogs(limit=None):
             yield dialog
 
         mock_client = MagicMock()
@@ -419,10 +412,12 @@ class TestFindChatsImplFolder:
             mock_get_client.return_value = mock_client
 
             with patch(
-                "src.tools.contacts.get_available_folders", new_callable=AsyncMock
-            ) as mock_folders:
-                mock_folders.return_value = [{"id": 1, "title": "Work"}]
+                "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+            ) as mock_filters:
+                mock_filters.return_value = [
+                    {"id": 1, "title": "Work", "include_peers": [], "groups": True}
+                ]
 
-                result = await find_chats_impl(folder="Work")
+                result = await find_chats_impl(filter="Work")
 
                 assert "chats" in result

--- a/tests/test_contacts_bot_folder.py
+++ b/tests/test_contacts_bot_folder.py
@@ -448,3 +448,7 @@ class TestFindChatsImplFilter:
                 assert "Unknown" in result["error"]
                 assert "Work" in result["error"]
                 assert "Personal" in result["error"]
+
+    def test_none_returns_empty_string(self):
+        """None input should return empty string."""
+        assert _normalize_filter_name(None) == ""

--- a/tests/test_contacts_bot_folder.py
+++ b/tests/test_contacts_bot_folder.py
@@ -180,7 +180,7 @@ class TestGetDialogFilters:
         mock_client.session = MockSession()
 
         mock_result = MagicMock()
-        mock_result.dialog_filters = [
+        mock_result.filters = [
             make_folder(1, "Work"),
             make_folder(2, "Personal"),
         ]

--- a/tests/test_contacts_bot_folder.py
+++ b/tests/test_contacts_bot_folder.py
@@ -17,6 +17,7 @@ from src.utils.entity import (
     get_dialog_filters,
     get_normalized_chat_type,
 )
+from src.utils.error_handling import log_and_build_error
 from tests.conftest import MockChannel, MockChat, MockDialog, MockUser, make_folder
 
 # ============== Bot Type Detection Tests ==============
@@ -421,3 +422,29 @@ class TestFindChatsImplFilter:
                 result = await find_chats_impl(filter="Work")
 
                 assert "chats" in result
+
+
+    @pytest.mark.asyncio
+    async def test_unknown_filter_returns_error(self):
+        """When filter name is not found, should return error with available filters."""
+        mock_client = MagicMock()
+
+        with patch(
+            "src.tools.contacts.get_connected_client", new_callable=AsyncMock
+        ) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            with patch(
+                "src.tools.contacts.get_dialog_filters", new_callable=AsyncMock
+            ) as mock_filters:
+                mock_filters.return_value = [
+                    {"id": 1, "title": "Work"},
+                    {"id": 2, "title": "Personal"},
+                ]
+
+                result = await find_chats_impl(filter="Unknown")
+
+                assert "error" in result
+                assert "Unknown" in result["error"]
+                assert "Work" in result["error"]
+                assert "Personal" in result["error"]


### PR DESCRIPTION
## Summary
- Fix `get_dialog_filters`: `result.filters` → `result.dialog_filters` (the actual API attribute)
- Rename `folder` parameter → `filter` (string only, not int IDs)
- Add `_filter_matches_flags` for flag-based filter matching
- Add `_find_chats_by_include_peers` using `GetPeerDialogsRequest`
- Add `_find_chats_by_filter_flags` for flag-based filters
- Add `docs/Filters-vs-Folders.md` explaining dialog filters vs physical sidebar folders
- Update `docs/Tools-Reference.md` with new `filter` param

## Breaking Change
`folder` parameter renamed to `filter` on `find_chats`.

## Test plan
- [x] 436 tests pass
- [x] `ruff check --fix && ty check` clean

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats` с поддержкой как явного `include_peers`, так и фильтров диалогов, основанных на флагах.
- Метаданные диалоговых фильтров (флаги и списки пиров) теперь доступны через `get_dialog_filters` и связанные вспомогательные утилиты.
- Задокументировано различие между диалоговыми фильтрами Telegram и физическими папками боковой панели, обновлена документация по инструментам для нового параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров: теперь используется корректный атрибут Telegram API при получении фильтров.

Улучшения:
- Уточнён поток управления в `find_chats` для выбора между глобальным, диалоговым и фильтровым поиском, а также стандартизирован формат возвращаемых данных.
- Расширено кэширование диалоговых фильтров, теперь оно включает флаги фильтров и списки пиров для более богатых кэшированных метаданных.
- Обновлены тесты для покрытия поведения, основанного на фильтрах, нормализации имён и новых семантик кэширования.

Документация:
- Добавлено руководство «Filters-vs-Folders», объясняющее различия между диалоговыми фильтрами и физическими папками и то, как они используются в поиске.
- Обновлён «Tools-Reference» с описанием новой семантики параметра `filter` и актуализированными примерами.

Тесты:
- Расширены и переименованы тесты, связанные с папками, чтобы покрыть `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` на основе фильтров.

Рутинные задачи:
- Устаревший API, основанный на «папках», помечен к удалению в пользу строкового параметра `filter`; добавлен устаревший алиас для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats` с поддержкой как явного `include_peers`, так и фильтров диалогов, основанных на флагах.
- Метаданные диалоговых фильтров (флаги и списки пиров) теперь доступны через `get_dialog_filters` и связанные вспомогательные утилиты.
- Задокументировано различие между диалоговыми фильтрами Telegram и физическими папками боковой панели, обновлена документация по инструментам для нового параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров: теперь используется корректный атрибут Telegram API при получении фильтров.

Улучшения:
- Уточнён поток управления в `find_chats` для выбора между глобальным, диалоговым и фильтровым поиском, а также стандартизирован формат возвращаемых данных.
- Расширено кэширование диалоговых фильтров, теперь оно включает флаги фильтров и списки пиров для более богатых кэшированных метаданных.
- Обновлены тесты для покрытия поведения, основанного на фильтрах, нормализации имён и новых семантик кэширования.

Документация:
- Добавлено руководство «Filters-vs-Folders», объясняющее различия между диалоговыми фильтрами и физическими папками и то, как они используются в поиске.
- Обновлён «Tools-Reference» с описанием новой семантики параметра `filter` и актуализированными примерами.

Тесты:
- Расширены и переименованы тесты, связанные с папками, чтобы покрыть `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` на основе фильтров.

Рутинные задачи:
- Устаревший API, основанный на «папках», помечен к удалению в пользу строкового параметра `filter`; добавлен устаревший алиас для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

</details>

</details>

Новые возможности:
- Ввести пути поиска, основанные на фильтрах диалогов, в `find_chats`, с поддержкой как `include_peers`, так и фильтров на основе флагов.
- Добавить вспомогательные утилиты для разрешения фильтров диалогов по имени и для сопоставления сущностей с флагами фильтров.
- Задокументировать различие между фильтрами диалогов Telegram и физическими папками в новом руководстве «Filters-vs-Folders».

Исправления ошибок:
- Исправить получение фильтров диалогов, чтобы использовать атрибут `result.dialog_filters` из Telegram API.

Улучшения:
- Уточнить логику управления потоком в `find_chats`, чтобы выбирать между глобальным, диалоговым и основанным на фильтрах режимами поиска, а также стандартизировать формы возвращаемых результатов.
- Расширить извлечение и кэширование метаданных фильтров диалогов, чтобы предоставлять флаги фильтров и списки пиров.
- Обновить тесты, чтобы покрыть поведение, основанное на фильтрах, нормализацию имен и обновлённую семантику кэширования.
- Обновить справочную документацию по инструментам, чтобы описать новую семантику параметров фильтров и привести примеры.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats` с поддержкой как явного `include_peers`, так и фильтров диалогов, основанных на флагах.
- Метаданные диалоговых фильтров (флаги и списки пиров) теперь доступны через `get_dialog_filters` и связанные вспомогательные утилиты.
- Задокументировано различие между диалоговыми фильтрами Telegram и физическими папками боковой панели, обновлена документация по инструментам для нового параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров: теперь используется корректный атрибут Telegram API при получении фильтров.

Улучшения:
- Уточнён поток управления в `find_chats` для выбора между глобальным, диалоговым и фильтровым поиском, а также стандартизирован формат возвращаемых данных.
- Расширено кэширование диалоговых фильтров, теперь оно включает флаги фильтров и списки пиров для более богатых кэшированных метаданных.
- Обновлены тесты для покрытия поведения, основанного на фильтрах, нормализации имён и новых семантик кэширования.

Документация:
- Добавлено руководство «Filters-vs-Folders», объясняющее различия между диалоговыми фильтрами и физическими папками и то, как они используются в поиске.
- Обновлён «Tools-Reference» с описанием новой семантики параметра `filter` и актуализированными примерами.

Тесты:
- Расширены и переименованы тесты, связанные с папками, чтобы покрыть `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` на основе фильтров.

Рутинные задачи:
- Устаревший API, основанный на «папках», помечен к удалению в пользу строкового параметра `filter`; добавлен устаревший алиас для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats` с поддержкой как явного `include_peers`, так и фильтров диалогов, основанных на флагах.
- Метаданные диалоговых фильтров (флаги и списки пиров) теперь доступны через `get_dialog_filters` и связанные вспомогательные утилиты.
- Задокументировано различие между диалоговыми фильтрами Telegram и физическими папками боковой панели, обновлена документация по инструментам для нового параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров: теперь используется корректный атрибут Telegram API при получении фильтров.

Улучшения:
- Уточнён поток управления в `find_chats` для выбора между глобальным, диалоговым и фильтровым поиском, а также стандартизирован формат возвращаемых данных.
- Расширено кэширование диалоговых фильтров, теперь оно включает флаги фильтров и списки пиров для более богатых кэшированных метаданных.
- Обновлены тесты для покрытия поведения, основанного на фильтрах, нормализации имён и новых семантик кэширования.

Документация:
- Добавлено руководство «Filters-vs-Folders», объясняющее различия между диалоговыми фильтрами и физическими папками и то, как они используются в поиске.
- Обновлён «Tools-Reference» с описанием новой семантики параметра `filter` и актуализированными примерами.

Тесты:
- Расширены и переименованы тесты, связанные с папками, чтобы покрыть `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` на основе фильтров.

Рутинные задачи:
- Устаревший API, основанный на «папках», помечен к удалению в пользу строкового параметра `filter`; добавлен устаревший алиас для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, включая поддержку диалоговых фильтров с явным `include_peers` и определениями на основе флагов.
- Раскрыты расширенные метаданные диалоговых фильтров (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён и сопоставления флагов.
- Введено руководство «Filters-vs-Folders» и обновлена справка по инструментам для документирования новой семантики параметра `filter`.

Исправления ошибок:
- Исправлена загрузка диалоговых фильтров для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнён управляющий поток в `find_chats` для выбора между глобальным, диалоговым и фильтровым режимами поиска и стандартизированы формы возвращаемых результатов.
- Расширено кэширование диалоговых фильтров для сохранения флагов фильтров и списков пиров с целью более богатых, многократно используемых метаданных.
- Скорректированы схемы и описания серверных инструментов для замены параметра `folder` строковым параметром `filter`.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая разницу между диалоговыми фильтрами и физическими папками и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров.

Тесты:
- Расширены и переименованы тесты с покрытия, основанного на папках, на покрытие, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Устаревание API, основанного на папках, в пользу строкового параметра `filter` и добавление устаревшего алиаса для `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Внедрён поиск по чатам на основе фильтров диалогов в `find_chats` и объявлен устаревшим прежний API, основанный на папках.

Новые возможности:
- Добавлены пути поиска на основе фильтров в `find_chats`, с поддержкой фильтров диалогов с явными `include_peers` и определениями на основе флагов.
- Экспортированы расширенные метаданные фильтров диалогов (флаги и списки пиров) через `get_dialog_filters` и вспомогательные утилиты для разрешения имён фильтров и применения сопоставления по флагам.
- Добавлено руководство «Filters-vs-Folders» и расширена справка по инструментам с описанием новой семантики параметра `filter` и режимов его использования.

Исправления ошибок:
- Исправлена загрузка фильтров диалогов для использования корректного атрибута Telegram API при получении фильтров.

Улучшения:
- Уточнена логика управления потоком в `find_chats` для выбора между глобальным, диалоговым и фильтр-ориентированным режимами поиска и стандартизации формы возвращаемых результатов.
- Расширено кэширование фильтров диалогов для сохранения флагов фильтров и списков пиров с целью повторного использования как более богатых метаданных.
- Обновлены схемы и описания серверных инструментов: параметр `folder` заменён строковым параметром `filter` и добавлен устаревший псевдоним для API, основанных на папках.

Документация:
- Добавлена документация «Filters-vs-Folders», объясняющая различия между фильтрами диалогов и физическими папками боковой панели и то, как они влияют на поведение поиска.
- Обновлена «Tools-Reference» для описания параметра `filter`, режимов поиска на основе фильтров и новых примеров использования.

Тесты:
- Расширены и переименованы тесты, основанные на папках, чтобы охватить поведение, основанное на фильтрах, включая кэширование `get_dialog_filters`, разрешение имён фильтров и поведение `find_chats` с фильтрами.

Обслуживание:
- Объявлен устаревшим API, основанный на папках, в пользу строкового параметра `filter`, и добавлен легаси-псевдоним для `get_available_folders` через `get_dialog_filters`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog filter–based chat search in find_chats and deprecate the older folder-based API.

New Features:
- Add filter-based search paths to find_chats, supporting dialog filters with explicit include_peers and flag-based definitions.
- Expose rich dialog filter metadata (flags and peer lists) via get_dialog_filters and helper utilities for resolving filter names and applying flag matching.
- Introduce a Filters-vs-Folders guide and extend the tools reference to describe the new filter parameter semantics and usage modes.

Bug Fixes:
- Fix dialog filter loading to use the correct Telegram API attribute when fetching filters.

Enhancements:
- Refine find_chats control flow to choose between global, dialog, and filter-based search modes and standardize returned result shapes.
- Extend dialog filter caching to store filter flags and peer lists for reuse as richer metadata.
- Update server tool schemas and descriptions to replace the folder parameter with the string-based filter parameter and add a deprecated alias for folder-based APIs.

Documentation:
- Add Filters-vs-Folders documentation explaining the difference between dialog filters and physical sidebar folders and how they impact search behavior.
- Update Tools-Reference to cover the filter parameter, filter-based search modes, and new usage examples.

Tests:
- Expand and rename folder-based tests to cover filter-based behavior, including get_dialog_filters caching, filter name resolution, and find_chats behavior with filters.

Chores:
- Deprecate the folder-based API in favor of the string filter parameter and add a legacy alias for get_available_folders via get_dialog_filters.

</details>

</details>

</details>

</details>

</details>