### PR TITLE
fix: add min_date/max_date filtering for per-chat search

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -199,8 +199,8 @@ get_messages(
   message_ids?: number[],        // Specific message IDs to retrieve
   reply_to_id?: number,          // Get replies (post comments, forum topics, message replies)
   limit?: number = 50,           // Max results
-  min_date?: string,             // ISO date filter
-  max_date?: string,             // ISO date filter
+  min_date?: string,             // ISO date filter (search/browse modes only)
+  max_date?: string,             // ISO date filter (search/browse modes only)
   auto_expand_batches?: number = 2,  // Extra batches for filtered searches
   include_total_count?: boolean = false  // Include total count (chat search only)
 )
@@ -209,8 +209,8 @@ get_messages(
 **5 Modes (parameter combinations):**
 1. **Search in chat**: `chat_id` + `query` - Search messages in a specific chat
 2. **Browse chat**: `chat_id` only - Get latest messages
-3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages
-4. **Get replies**: `chat_id` + `reply_to_id` - Get replies to a message (universal)
+3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages *(date filters error)*
+4. **Get replies**: `chat_id` + `reply_to_id` - Get replies to a message *(date filters error)*
 5. **Search replies**: `chat_id` + `reply_to_id` + `query` - Search within replies
 
 **reply_to_id automatically handles:**

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -209,8 +209,8 @@ get_messages(
 **5 Modes (parameter combinations):**
 1. **Search in chat**: `chat_id` + `query` - Search messages in a specific chat
 2. **Browse chat**: `chat_id` only - Get latest messages
-3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages *(date filters error)*
-4. **Get replies**: `chat_id` + `reply_to_id` - Get replies to a message *(date filters error)*
+3. **Read by IDs**: `chat_id` + `message_ids` - Get specific messages *(date filters not supported)*
+4. **Get replies**: `chat_id` + `reply_to_id` - Get replies to a message *(date filters not supported)*
 5. **Search replies**: `chat_id` + `reply_to_id` + `query` - Search within replies
 
 **reply_to_id automatically handles:**

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum, auto
 from typing import Any
 
@@ -278,6 +278,8 @@ async def _collect_messages_in_chat(
     chat_id: str,
     queries: list[str],
     limit: int,
+    min_datetime: datetime | None,
+    max_datetime: datetime | None,
     chat_type: str | None,
     public: bool | None,
     auto_expand_batches: int,
@@ -296,6 +298,8 @@ async def _collect_messages_in_chat(
             entity,
             (q or ""),
             limit,
+            min_datetime,
+            max_datetime,
             chat_type,
             public,
             auto_expand_batches,
@@ -365,8 +369,14 @@ async def _handle_search_mode(
             exception=ValueError("Search query must not be empty for global search"),
         )
 
-    min_datetime = datetime.fromisoformat(min_date) if min_date else None
-    max_datetime = datetime.fromisoformat(max_date) if max_date else None
+    min_datetime = (
+        datetime.fromisoformat(min_date).replace(tzinfo=timezone.utc)
+        if min_date else None
+    )
+    max_datetime = (
+        datetime.fromisoformat(max_date).replace(tzinfo=timezone.utc)
+        if max_date else None
+    )
 
     def _connection_error_or_build(
         exc: Exception, fallback_message: str
@@ -395,6 +405,8 @@ async def _handle_search_mode(
                     chat_id,
                     queries,
                     limit,
+                    min_datetime,
+                    max_datetime,
                     chat_type,
                     public,
                     auto_expand_batches,
@@ -543,6 +555,13 @@ async def search_messages_impl(
                 params=params,
                 exception=ValueError("Missing required params"),
             )
+        if min_date or max_date:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message="min_date and max_date are not supported for message_ids mode",
+                params=params,
+                exception=ValueError("Date filters not supported for message_ids mode"),
+            )
         return await _handle_message_ids_mode(chat_id, message_ids, params)
 
     if mode is MessageRetrievalMode.REPLIES:
@@ -552,6 +571,13 @@ async def search_messages_impl(
                 error_message="chat_id and reply_to_id required for replies mode",
                 params=params,
                 exception=ValueError("Missing required params"),
+            )
+        if min_date or max_date:
+            return log_and_build_error(
+                operation="get_messages",
+                error_message="min_date and max_date are not supported for replies mode",
+                params=params,
+                exception=ValueError("Date filters not supported for replies mode"),
             )
         return await _handle_replies_mode(chat_id, reply_to_id, limit, query, params)
 
@@ -574,6 +600,8 @@ async def _search_chat_messages_generator(
     entity,
     query,
     limit,
+    min_datetime,
+    max_datetime,
     chat_type,
     public,
     auto_expand_batches,
@@ -591,11 +619,21 @@ async def _search_chat_messages_generator(
     while batch_count < max_batches:
         last_id = None
         async for message in client.iter_messages(
-            entity, search=query, offset_id=next_offset_id
+            entity, search=query, offset_id=next_offset_id, offset_date=max_datetime
         ):
             if not message:
                 continue
             last_id = getattr(message, "id", None) or last_id
+
+            # Skip messages newer than max_datetime (offset_date is exclusive,
+            # but Python filter needed for batches 2+ since Telethon clears max_date)
+            if max_datetime and message.date and message.date > max_datetime:
+                continue
+            # Stop when we hit min_datetime boundary - all subsequent messages
+            # will be older since we iterate newest->oldest. return exits the
+            # entire generator, not just the inner loop.
+            if min_datetime and message.date and message.date < min_datetime:
+                return
 
             if not _matches_chat_type(entity, chat_type):
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Pytest configuration and shared fixtures for Telegram MCP Server tests.
 This module provides common fixtures and configuration used across all test files.
 """
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -28,12 +29,12 @@ class MockTelegramClient:
         self.is_connected_value = True
         self.messages = {
             "me": [
-                {"id": 1, "text": "Test message 1", "date": "2024-01-01"},
-                {"id": 2, "text": "Test message 2", "date": "2024-01-02"},
+                {"id": 1, "text": "Test message 1", "date": datetime(2024, 1, 1)},
+                {"id": 2, "text": "Test message 2", "date": datetime(2024, 1, 2)},
             ],
             "@test_channel": [
-                {"id": 10, "text": "Channel message 1", "date": "2024-01-01"},
-                {"id": 11, "text": "Channel message 2", "date": "2024-01-02"},
+                {"id": 10, "text": "Channel message 1", "date": datetime(2024, 1, 1)},
+                {"id": 11, "text": "Channel message 2", "date": datetime(2024, 1, 2)},
             ],
         }
 
@@ -41,7 +42,7 @@ class MockTelegramClient:
         # Telethon's client.is_connected() is synchronous; keep mock signature aligned.
         return self.is_connected_value
 
-    async def iter_messages(self, entity, limit=50, search=None):
+    async def iter_messages(self, entity, limit=50, search=None, offset_date=None):
         """Mock message iteration."""
         chat_id = (
             getattr(entity, "username", str(entity))
@@ -54,6 +55,9 @@ class MockTelegramClient:
             messages = [
                 msg for msg in messages if search.lower() in msg["text"].lower()
             ]
+        # Filter by offset_date (messages older than offset_date)
+        if offset_date:
+            messages = [msg for msg in messages if msg["date"] < offset_date]
 
         for msg in messages[:limit]:
             mock_msg = MagicMock()

--- a/tests/integration/test_date_filtering.py
+++ b/tests/integration/test_date_filtering.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Integration tests for get_messages date filtering.
+
+Run with: uv run python3 tests/integration/test_date_filtering.py
+"""
+import asyncio
+from datetime import datetime, timezone
+from src.client.connection import get_connected_client
+from src.tools.search import search_messages_impl
+
+
+async def run_date_filtering_test():
+    """Test min_date/max_date filtering for per-chat search."""
+    print("\n" + "=" * 60)
+    print("Testing get_messages date filtering")
+    print("=" * 60)
+
+    # Find a chat with some history
+    client = await get_connected_client()
+    me = await client.get_me()
+    print(f"Connected as: {me.first_name} {me.last_name or ''} (@{me.username})")
+
+    # Get recent dialogs to find a chat with messages
+    print("\nFinding a chat with message history...")
+    test_chat_id = None
+    test_chat_title = None
+
+    async for dialog in client.iter_dialogs(limit=50):
+        entity = getattr(dialog, "entity", None)
+        if not entity:
+            continue
+        # Find a chat that has messages (not just a contact)
+        if hasattr(entity, "username") and entity.username:
+            test_chat_id = str(entity.id)
+            test_chat_title = getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown")
+            print(f"Selected chat: {test_chat_title} (id={test_chat_id})")
+            break
+
+    if not test_chat_id:
+        print("ERROR: No suitable chat found for testing")
+        return
+
+    # Test 1: Browse without date filter
+    print("\n--- Test 1: Browse chat (no date filter) ---")
+    result = await search_messages_impl(chat_id=test_chat_id, limit=10)
+    if "error" in result:
+        print(f"ERROR: {result['error']}")
+    else:
+        msgs = result.get("messages", [])
+        print(f"Found {len(msgs)} messages")
+        for m in msgs[:3]:
+            print(f"  [{m.get('id')}] {m.get('date')} - {m.get('text', '')[:50]}")
+        if msgs:
+            latest_date = msgs[0].get("date") if msgs else None
+            oldest_date = msgs[-1].get("date") if msgs else None
+            print(f"  Date range in results: {oldest_date} to {latest_date}")
+
+    # Test 2: Browse with min_date (recent messages only)
+    print("\n--- Test 2: Browse with min_date=2024-01-01 ---")
+    result = await search_messages_impl(
+        chat_id=test_chat_id,
+        min_date="2024-01-01",
+        limit=10
+    )
+    if "error" in result:
+        print(f"ERROR: {result['error']}")
+    else:
+        msgs = result.get("messages", [])
+        print(f"Found {len(msgs)} messages")
+        for m in msgs[:3]:
+            print(f"  [{m.get('id')}] {m.get('date')} - {m.get('text', '')[:50]}")
+        if msgs:
+            latest_date = msgs[0].get("date") if msgs else None
+            oldest_date = msgs[-1].get("date") if msgs else None
+            print(f"  Date range in results: {oldest_date} to {latest_date}")
+
+    # Test 3: Browse with max_date (old messages only)
+    print("\n--- Test 3: Browse with max_date=2023-01-01 ---")
+    result = await search_messages_impl(
+        chat_id=test_chat_id,
+        max_date="2023-01-01",
+        limit=10
+    )
+    if "error" in result:
+        print(f"ERROR: {result['error']}")
+    else:
+        msgs = result.get("messages", [])
+        print(f"Found {len(msgs)} messages")
+        for m in msgs[:3]:
+            print(f"  [{m.get('id')}] {m.get('date')} - {m.get('text', '')[:50]}")
+        if msgs:
+            latest_date = msgs[0].get("date") if msgs else None
+            oldest_date = msgs[-1].get("date") if msgs else None
+            print(f"  Date range in results: {oldest_date} to {latest_date}")
+
+    # Test 4: Search with date filter
+    print("\n--- Test 4: Search with min_date ---")
+    # Try to search for something common that might exist
+    result = await search_messages_impl(
+        chat_id=test_chat_id,
+        query="the",
+        min_date="2024-01-01",
+        limit=10
+    )
+    if "error" in result:
+        print(f"ERROR: {result['error']}")
+    else:
+        msgs = result.get("messages", [])
+        print(f"Found {len(msgs)} messages")
+        for m in msgs[:3]:
+            print(f"  [{m.get('id')}] {m.get('date')} - {m.get('text', '')[:50]}")
+
+    # Test 5: Date filter with message_ids mode (should error)
+    print("\n--- Test 5: message_ids mode with date filter (should error) ---")
+    # Get a message ID first
+    if msgs:
+        msg_id = msgs[0].get("id")
+        result = await search_messages_impl(
+            chat_id=test_chat_id,
+            message_ids=[msg_id],
+            min_date="2024-01-01"
+        )
+        if "error" in result:
+            print(f"CORRECTLY ERRORED: {result['error']}")
+        else:
+            print(f"BUG: Should have errored but got: {result}")
+
+    print("\n" + "=" * 60)
+    print("Date filtering tests completed")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_date_filtering_test())

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -8,8 +8,8 @@ Tests cover:
 - Error handling for all modes
 """
 
-from datetime import datetime
-from unittest.mock import AsyncMock, Mock, patch
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -91,8 +91,8 @@ class TestGetMessagesReadByIds:
 
     @pytest.mark.asyncio
     @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
-    async def test_message_ids_ignores_other_params(self, mock_read):
-        """Should ignore limit/date filters when using message_ids."""
+    async def test_message_ids_rejects_date_filters(self, mock_read):
+        """Should reject date filters when using message_ids."""
         mock_read.return_value = [{"id": 1, "text": "Message"}]
 
         result = await search_messages_impl(
@@ -102,10 +102,8 @@ class TestGetMessagesReadByIds:
             min_date="2024-01-01",
         )
 
-        # Should call with only chat_id and message_ids
-        mock_read.assert_called_once_with("me", [1])
-        assert isinstance(result, dict)
-        assert result["has_more"] is False
+        assert "error" in result
+        assert "not supported for message_ids mode" in result["error"]
 
     @pytest.mark.asyncio
     @patch("src.tools.search.read_messages_by_ids", new_callable=AsyncMock)
@@ -426,3 +424,218 @@ class TestGetMessagesChatFieldIntegration:
         assert "messages" in result
         for msg in result["messages"]:
             assert "chat" not in msg, f"Expected no chat in message_ids mode, got {msg.get('chat')}"
+
+
+class TestGetMessagesDateFiltering:
+    """Test min_date/max_date filtering for per-chat search."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    async def test_search_chat_respects_min_date(self, mock_get_entity, mock_get_client):
+        """Should filter out messages older than min_date."""
+        from tests.conftest import make_mock_message
+
+        # Set up entity mock
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_get_entity.return_value = mock_entity
+
+        # Set up client mock with iter_messages
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+
+        # Create messages with different dates
+        old_msg = make_mock_message(id=1, text="Old message", date=datetime(2023, 1, 1, tzinfo=timezone.utc))
+        recent_msg = make_mock_message(id=2, text="Recent message", date=datetime(2024, 6, 15, tzinfo=timezone.utc))
+        future_msg = make_mock_message(id=3, text="Future message", date=datetime(2025, 1, 1, tzinfo=timezone.utc))
+
+        # Return messages in order (newest to oldest when iterated)
+        # iter_messages is an async iterator, so we need to return an async iterator
+        async def mock_iter_messages_gen():
+            for msg in [future_msg, recent_msg, old_msg]:
+                yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter_messages_gen())
+        mock_get_client.return_value = mock_client
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="message",
+            min_date="2024-01-01",
+            limit=50,
+        )
+
+        assert "messages" in result
+        # Should return 2 messages (2024 and 2025), not 2023
+        assert len(result["messages"]) == 2
+        msg_ids = {msg["id"] for msg in result["messages"]}
+        assert 1 not in msg_ids  # Old message should be filtered
+        assert 2 in msg_ids  # Recent message should be included
+        assert 3 in msg_ids  # Future message should be included
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    async def test_search_chat_respects_max_date(self, mock_get_entity, mock_get_client):
+        """Should filter out messages newer than max_date."""
+        from tests.conftest import make_mock_message
+
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_get_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+
+        old_msg = make_mock_message(id=1, text="Old message", date=datetime(2023, 1, 1, tzinfo=timezone.utc))
+        recent_msg = make_mock_message(id=2, text="Recent message", date=datetime(2024, 6, 15, tzinfo=timezone.utc))
+        future_msg = make_mock_message(id=3, text="Future message", date=datetime(2025, 1, 1, tzinfo=timezone.utc))
+
+        async def mock_iter_messages_gen():
+            for msg in [future_msg, recent_msg, old_msg]:
+                yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter_messages_gen())
+        mock_get_client.return_value = mock_client
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="message",
+            max_date="2024-12-31",
+            limit=50,
+        )
+
+        assert "messages" in result
+        # Should return 2 messages (2023 and 2024), not 2025
+        assert len(result["messages"]) == 2
+        msg_ids = {msg["id"] for msg in result["messages"]}
+        assert 3 not in msg_ids  # Future message should be filtered
+        assert 2 in msg_ids  # Recent message should be included
+        assert 1 in msg_ids  # Old message should be included
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    async def test_search_chat_respects_date_range(self, mock_get_entity, mock_get_client):
+        """Should filter to only messages within min_date and max_date range."""
+        from tests.conftest import make_mock_message
+
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_get_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+
+        old_msg = make_mock_message(id=1, text="Old message", date=datetime(2023, 1, 1, tzinfo=timezone.utc))
+        recent_msg = make_mock_message(id=2, text="Recent message", date=datetime(2024, 6, 15, tzinfo=timezone.utc))
+        future_msg = make_mock_message(id=3, text="Future message", date=datetime(2025, 1, 1, tzinfo=timezone.utc))
+
+        async def mock_iter_messages_gen():
+            for msg in [future_msg, recent_msg, old_msg]:
+                yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter_messages_gen())
+        mock_get_client.return_value = mock_client
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="message",
+            min_date="2024-01-01",
+            max_date="2024-12-31",
+            limit=50,
+        )
+
+        assert "messages" in result
+        # Should return only 1 message (2024-06-15)
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["id"] == 2
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    async def test_search_chat_stops_at_min_date_boundary(
+        self, mock_get_entity, mock_get_client
+    ):
+        """Should stop fetching when hitting min_date boundary (return, not continue)."""
+        from tests.conftest import make_mock_message
+
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_get_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+
+        # Create 5 messages - only 2 should be returned after min_date filter
+        msgs = [
+            make_mock_message(id=5, text="Msg 2025", date=datetime(2025, 1, 1, tzinfo=timezone.utc)),
+            make_mock_message(id=4, text="Msg mid 2024", date=datetime(2024, 6, 15, tzinfo=timezone.utc)),
+            make_mock_message(id=3, text="Msg early 2024", date=datetime(2024, 1, 15, tzinfo=timezone.utc)),  # min boundary
+            make_mock_message(id=2, text="Msg late 2023", date=datetime(2023, 12, 1, tzinfo=timezone.utc)),
+            make_mock_message(id=1, text="Msg 2022", date=datetime(2022, 1, 1, tzinfo=timezone.utc)),
+        ]
+
+        async def mock_iter_messages_gen():
+            for msg in msgs:
+                yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter_messages_gen())
+        mock_get_client.return_value = mock_client
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="Msg",
+            min_date="2024-01-01",
+            limit=10,
+        )
+
+        assert "messages" in result
+        # Should return 3 messages (2025, mid 2024, early 2024)
+        # Should STOP at early 2024 (id=3) and NOT process late 2023 (id=2) or 2022 (id=1)
+        assert len(result["messages"]) == 3
+        msg_ids = {msg["id"] for msg in result["messages"]}
+        assert msg_ids == {5, 4, 3}
+        assert 2 not in msg_ids  # Should not have processed these
+        assert 1 not in msg_ids
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.get_entity_by_id", new_callable=AsyncMock)
+    async def test_search_chat_handles_none_date(self, mock_get_entity, mock_get_client):
+        """Should pass through messages with None date (unknown date = don't filter)."""
+        from tests.conftest import make_mock_message
+
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_get_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+
+        msg_with_date = make_mock_message(id=1, text="Dated message", date=datetime(2024, 6, 15, tzinfo=timezone.utc))
+        msg_no_date = make_mock_message(id=2, text="Unknown date", date=None)
+
+        async def mock_iter_messages_gen():
+            for msg in [msg_with_date, msg_no_date]:
+                yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter_messages_gen())
+        mock_get_client.return_value = mock_client
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="message",
+            min_date="2024-01-01",
+            limit=50,
+        )
+
+        assert "messages" in result
+        # Both messages should pass - None date is not filtered
+        assert len(result["messages"]) == 2


### PR DESCRIPTION
## Summary
- Fix `min_date` and `max_date` being silently ignored for per-chat search (`get_messages` with `chat_id`)
- Date filters now work correctly for search/browse modes
- Date filters return errors for `message_ids` and `replies` modes (unsupported)

## Test plan
- [x] 443 tests pass
- [x] 5 new tests for date filtering: min_date, max_date, date range, boundary stop, None date handling

## Summary by Sourcery

Реализовать корректную обработку `min_date`/`max_date` для поиска `get_messages` в рамках одного чата и жёстко запрещать неподдерживаемые комбинации.

Bug Fixes:
- Применять ограничения `min_date` и `max_date` при поиске или просмотре сообщений в одном чате, обеспечивая корректную фильтрацию результатов по времени.
- Возвращать ошибки при использовании фильтров по дате с режимами `message_ids` или `replies` вместо их тихого игнорирования.

Enhancements:
- Пропускать часовой пояс и фильтры `datetime` через конвейер поиска и `Telethon iter_messages`, включая раннюю остановку при достижении минимальной границы даты.
- Считать сообщения с неизвестными датами нефильтрованными и обновить моки и генераторы для поддержки пагинации на основе `offset_date`.
- Задокументировать режим-зависимую поддержку фильтров по дате в справке по инструменту `get_messages` и добавить интеграционный скрипт для проверки фильтрации по датам с реальным клиентом.

Tests:
- Добавить модульные тесты, покрывающие поведение фильтрации по дате в рамках одного чата, включая `min_date`, `max_date`, диапазоны дат, остановку на границах и обработку значений даты `None`.
- Расширить тестовые фикстуры и интеграционные тесты для проверки обработки `offset_date` и для гарантии, что некорректные комбинации фильтров по дате в режиме `message_ids` приводят к возникновению ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement proper min_date/max_date handling for per-chat get_messages search and enforce unsupported combinations.

Bug Fixes:
- Apply min_date and max_date constraints when searching or browsing messages in a single chat, ensuring results are correctly time-filtered.
- Return errors when date filters are used with message_ids or replies modes, instead of silently ignoring them.

Enhancements:
- Pass timezone-aware datetime filters through the search pipeline and Telethon iter_messages, including early stopping when the minimum date boundary is reached.
- Treat messages with unknown dates as unfiltered, and update mocks and generators to support offset_date-based pagination.
- Document mode-specific support for date filters in the get_messages tool reference and add an integration script to exercise date filtering against a real client.

Tests:
- Add unit tests covering per-chat date filtering behaviors, including min_date, max_date, date ranges, boundary stopping, and None-date handling.
- Extend test fixtures and integration tests to verify offset_date handling and to ensure invalid date-filter combinations in message_ids mode surface errors.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Реализовать корректную обработку `min_date`/`max_date` для поиска `get_messages` в рамках одного чата и жёстко запрещать неподдерживаемые комбинации.

Bug Fixes:
- Применять ограничения `min_date` и `max_date` при поиске или просмотре сообщений в одном чате, обеспечивая корректную фильтрацию результатов по времени.
- Возвращать ошибки при использовании фильтров по дате с режимами `message_ids` или `replies` вместо их тихого игнорирования.

Enhancements:
- Пропускать часовой пояс и фильтры `datetime` через конвейер поиска и `Telethon iter_messages`, включая раннюю остановку при достижении минимальной границы даты.
- Считать сообщения с неизвестными датами нефильтрованными и обновить моки и генераторы для поддержки пагинации на основе `offset_date`.
- Задокументировать режим-зависимую поддержку фильтров по дате в справке по инструменту `get_messages` и добавить интеграционный скрипт для проверки фильтрации по датам с реальным клиентом.

Tests:
- Добавить модульные тесты, покрывающие поведение фильтрации по дате в рамках одного чата, включая `min_date`, `max_date`, диапазоны дат, остановку на границах и обработку значений даты `None`.
- Расширить тестовые фикстуры и интеграционные тесты для проверки обработки `offset_date` и для гарантии, что некорректные комбинации фильтров по дате в режиме `message_ids` приводят к возникновению ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement proper min_date/max_date handling for per-chat get_messages search and enforce unsupported combinations.

Bug Fixes:
- Apply min_date and max_date constraints when searching or browsing messages in a single chat, ensuring results are correctly time-filtered.
- Return errors when date filters are used with message_ids or replies modes, instead of silently ignoring them.

Enhancements:
- Pass timezone-aware datetime filters through the search pipeline and Telethon iter_messages, including early stopping when the minimum date boundary is reached.
- Treat messages with unknown dates as unfiltered, and update mocks and generators to support offset_date-based pagination.
- Document mode-specific support for date filters in the get_messages tool reference and add an integration script to exercise date filtering against a real client.

Tests:
- Add unit tests covering per-chat date filtering behaviors, including min_date, max_date, date ranges, boundary stopping, and None-date handling.
- Extend test fixtures and integration tests to verify offset_date handling and to ensure invalid date-filter combinations in message_ids mode surface errors.

</details>

</details>