### PR TITLE
Fix get_messages reply_to_id for forum topic scoping

### DIFF
--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,15 +1,18 @@
+import itertools
 import logging
 from datetime import datetime
 from enum import Enum, auto
 from typing import Any
 
-from telethon.tl.functions.messages import SearchGlobalRequest
-from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty
+from telethon import utils as tg_utils
+from telethon.tl.functions.messages import SearchGlobalRequest, SearchRequest
+from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty, MessageEmpty
 
 from src.client.connection import get_connected_client
 from src.tools.links import generate_telegram_links
 from src.tools.messages import read_messages_by_ids
 from src.utils.datetime_parse import parse_iso_datetime_utc
+from src.utils.discussion import get_post_discussion_info
 from src.utils.entity import (
     _get_chat_message_count,
     _matches_chat_type,
@@ -27,6 +30,91 @@ from src.utils.message_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Match Telethon's message iterator chunk size for getReplies / search slices.
+_REPLIES_FETCH_CHUNK = 100
+
+
+def _normalized_reply_query(query: str | None) -> str | None:
+    """Strip per-chat query for reply mode; whitespace-only becomes None."""
+    if not query:
+        return None
+    stripped = query.strip()
+    return stripped or None
+
+
+def _belongs_to_forum_thread(message: Any, thread_root_msg_id: int) -> bool:
+    """Return whether a message belongs to a forum thread rooted at ``thread_root_msg_id``.
+
+    Forum threads are keyed by the topic starter / service message id. Thread
+    messages usually set ``reply_to.reply_to_top_id`` to that id, or reference
+    it via ``reply_to_msg_id``.
+    """
+    if getattr(message, "id", None) == thread_root_msg_id:
+        return True
+    reply_to = getattr(message, "reply_to", None)
+    top = getattr(reply_to, "reply_to_top_id", None) if reply_to else None
+    if top is not None and top == thread_root_msg_id:
+        return True
+    rmid = getattr(reply_to, "reply_to_msg_id", None) if reply_to else None
+    if rmid is not None and rmid == thread_root_msg_id:
+        return True
+    outer = getattr(message, "reply_to_msg_id", None)
+    if outer is not None and outer == thread_root_msg_id:
+        return True
+    return False
+
+
+async def _iter_forum_topic_search_messages(
+    client,
+    entity,
+    top_msg_id: int,
+    q: str,
+    limit: int,
+):
+    """Yield messages from ``messages.search`` scoped to one forum topic (``top_msg_id``)."""
+    input_peer = await client.get_input_entity(entity)
+    offset_id = 0
+    yielded = 0
+    want = limit + 1
+
+    while yielded < want:
+        batch = min(_REPLIES_FETCH_CHUNK, want - yielded)
+        r = await client(
+            SearchRequest(
+                peer=input_peer,
+                q=q,
+                filter=InputMessagesFilterEmpty(),
+                min_date=None,
+                max_date=None,
+                offset_id=offset_id,
+                add_offset=0,
+                limit=batch,
+                max_id=0,
+                min_id=0,
+                hash=0,
+                from_id=None,
+                saved_peer_id=None,
+                saved_reaction=None,
+                top_msg_id=top_msg_id,
+            )
+        )
+        if not r.messages:
+            break
+        entities = {
+            tg_utils.get_peer_id(x): x for x in itertools.chain(r.users, r.chats)
+        }
+        for message in r.messages:
+            if isinstance(message, MessageEmpty):
+                continue
+            message._finish_init(client, entities, input_peer)
+            yielded += 1
+            yield message
+            if yielded >= want:
+                return
+        offset_id = r.messages[-1].id
+        if len(r.messages) < batch:
+            break
 
 
 class MessageRetrievalMode(Enum):
@@ -167,22 +255,46 @@ async def _fetch_replies(
         except ValueError:
             logger.debug(f"Channel post {reply_to_id} has no discussion enabled")
 
-    collected = []
-    async for message in client.iter_messages(
-        effective_entity,
-        reply_to=effective_reply_to,
-        search=query or None,
-        limit=limit + 1,
-    ):
-        result = await _build_result_for_message(
-            client, message, effective_entity, include_chat_entity
-        )
-        if not result:
-            continue
+    normalized_query = _normalized_reply_query(query)
+    is_forum = bool(getattr(effective_entity, "forum", False))
 
-        collected.append(result)
-        if len(collected) >= limit + 1:
-            break
+    collected = []
+    if normalized_query and is_forum:
+        async for message in _iter_forum_topic_search_messages(
+            client,
+            effective_entity,
+            effective_reply_to,
+            normalized_query,
+            limit,
+        ):
+            if not _belongs_to_forum_thread(message, effective_reply_to):
+                continue
+            result = await _build_result_for_message(
+                client, message, effective_entity, include_chat_entity
+            )
+            if not result:
+                continue
+            collected.append(result)
+            if len(collected) >= limit + 1:
+                break
+    else:
+        async for message in client.iter_messages(
+            effective_entity,
+            reply_to=effective_reply_to,
+            search=normalized_query,
+            limit=limit + 1,
+        ):
+            if is_forum and not _belongs_to_forum_thread(message, effective_reply_to):
+                continue
+            result = await _build_result_for_message(
+                client, message, effective_entity, include_chat_entity
+            )
+            if not result:
+                continue
+
+            collected.append(result)
+            if len(collected) >= limit + 1:
+                break
 
     await transcribe_voice_messages(collected[:limit], effective_entity)
 
@@ -525,8 +637,10 @@ async def search_messages_impl(
         message_ids: List of specific message IDs to retrieve. Conflicts with query and reply_to_id.
         reply_to_id: Message ID to get replies from. Works for:
             - Channel posts (fetches discussion comments automatically)
-            - Forum topics (fetches topic messages)
+            - Forum topics (fetches topic messages; results are filtered to that topic)
             - Regular messages (fetches direct replies)
+            For forum supergroups, a non-empty ``query`` uses ``messages.search`` with
+            ``top_msg_id`` set to ``reply_to_id`` so search stays inside the topic.
         limit: Maximum number of results to return
         min_date: Minimum date filter (ISO format)
         max_date: Maximum date filter (ISO format)

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -9,6 +9,7 @@ Tests cover:
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -715,3 +716,50 @@ class TestGetMessagesDateFiltering:
         assert len(result["messages"]) == 1
         assert result["messages"][0]["id"] == 99
         assert "[Service: PinMessage]" in (result["messages"][0].get("text") or "")
+
+
+class TestForumThreadReplyHelpers:
+    """Forum thread metadata used to filter get_messages reply_to_id results."""
+
+    def test_belongs_to_forum_thread_matches_reply_to_top_id(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(
+            id=999,
+            reply_to=SimpleNamespace(reply_to_top_id=16160, reply_to_msg_id=50),
+            reply_to_msg_id=None,
+        )
+        assert _belongs_to_forum_thread(msg, 16160) is True
+
+    def test_belongs_to_forum_thread_rejects_other_topic(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(
+            id=1,
+            reply_to=SimpleNamespace(reply_to_top_id=84412, reply_to_msg_id=None),
+            reply_to_msg_id=None,
+        )
+        assert _belongs_to_forum_thread(msg, 16160) is False
+
+    def test_belongs_to_forum_thread_matches_starter_id(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(id=16160, reply_to=None, reply_to_msg_id=None)
+        assert _belongs_to_forum_thread(msg, 16160) is True
+
+    def test_belongs_to_forum_thread_matches_outer_reply_to_msg_id(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(
+            id=500,
+            reply_to=None,
+            reply_to_msg_id=16160,
+        )
+        assert _belongs_to_forum_thread(msg, 16160) is True
+
+    def test_normalized_reply_query_strips_and_empty(self):
+        from src.tools.search import _normalized_reply_query
+
+        assert _normalized_reply_query("  hi  ") == "hi"
+        assert _normalized_reply_query("   ") is None
+        assert _normalized_reply_query(None) is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Confirmation

Yes: `get_messages` with `reply_to_id` could return messages from other forum topics. The handler used `client.iter_messages(..., reply_to=..., search=query or None)`, which maps to `messages.getReplies` when `reply_to` is set, but mixed-topic rows can still appear for large forum groups. A non-empty `query` was passed through while Telethon prioritizes `getReplies` and does not apply text search inside the thread.

## Changes

- After resolving the target peer, **forum** megagroups now **drop** any message whose `reply_to` metadata does not belong to the requested topic root (`reply_to_top_id`, `reply_to_msg_id`, or the starter id).
- When both **forum** and a **non-empty** `query` are present, use **`messages.search` with `top_msg_id`** set to `reply_to_id` so search stays inside that topic (aligned with how Telegram scopes forum search).
- **Whitespace-only** `query` values are treated as omitted for reply mode.
- **Import** `get_post_discussion_info` in `search.py` (was referenced for broadcast + discussion but not imported).
- **Tests** for `_belongs_to_forum_thread` and `_normalized_reply_query`.

Restart the `telegram-dev` MCP server in Cursor after pulling so the updated tool code is loaded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa5bf696-d436-4d8f-9971-62a2db3f2cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa5bf696-d436-4d8f-9971-62a2db3f2cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Убедиться, что ответы `get_messages` в темах форума ограничены правильным тредом и поддерживают поиск по тексту в пределах темы.

Исправления ошибок:
- Фильтровать результаты `reply_to_id` в форумных супергруппах так, чтобы возвращались только сообщения из запрошенной темы/треда.

Улучшения:
- Использовать `topic`-скоупнутый `messages.search` с `top_msg_id` при выборке ответов в форумных супергруппах с непустым поисковым запросом и нормализовать запросы, состоящие только из пробельных символов.
- Добавить вспомогательные утилиты для определения принадлежности к форумному треду и для нормализации поисковых запросов для ответов.

Тесты:
- Добавить модульные тесты для детектирования принадлежности к форумному треду и для вспомогательных функций нормализации поисковых запросов для ответов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure get_messages replies in forum topics are scoped to the correct thread and support topic-local text search.

Bug Fixes:
- Filter reply_to_id results in forum supergroups so only messages from the requested topic/thread are returned.

Enhancements:
- Use topic-scoped messages.search with top_msg_id when querying replies in forum supergroups with a non-empty query, and normalize whitespace-only queries.
- Add helper utilities for determining forum-thread membership and for normalizing reply queries.

Tests:
- Add unit tests for forum thread membership detection and reply query normalization helpers.

</details>