### PR TITLE
Fix get_messages reply_to_id for forum topics (scoped search)

### DIFF
--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -46,9 +46,12 @@ def _normalized_reply_query(query: str | None) -> str | None:
 def _belongs_to_forum_thread(message: Any, thread_root_msg_id: int) -> bool:
     """Return whether a message belongs to a forum thread rooted at ``thread_root_msg_id``.
 
-    Forum threads are keyed by the topic starter / service message id. Thread
-    messages usually set ``reply_to.reply_to_top_id`` to that id, or reference
-    it via ``reply_to_msg_id``.
+    In Telegram, each forum message belongs to exactly one topic (one thread
+    root id). This helper does not imply otherwise: it matches reply metadata
+    against the requested thread root so we can drop rows that should not have
+    been returned for that thread (for example when a text ``search`` was not
+    scoped to ``top_msg_id`` and Telethon's ``iter_messages`` mixed in
+    chat-wide matches).
     """
     if getattr(message, "id", None) == thread_root_msg_id:
         return True
@@ -230,6 +233,10 @@ async def _fetch_replies(
     - Channel posts with discussion (detects and uses discussion group)
     - Forum topics (uses reply_to directly)
     - Regular message replies (uses reply_to directly)
+
+    For forum supergroups with a non-empty text query, uses ``messages.search``
+    with ``top_msg_id`` so results stay in the topic; plain ``iter_messages``
+    with ``reply_to`` plus ``search`` is not reliably topic-scoped in Telethon.
 
     Returns tuple of (messages, discussion_metadata_or_none):
     - messages: List of reply message dicts

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,15 +1,18 @@
+import itertools
 import logging
 from datetime import datetime
 from enum import Enum, auto
 from typing import Any
 
-from telethon.tl.functions.messages import SearchGlobalRequest
-from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty
+from telethon import utils as tg_utils
+from telethon.tl.functions.messages import SearchGlobalRequest, SearchRequest
+from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty, MessageEmpty
 
 from src.client.connection import get_connected_client
 from src.tools.links import generate_telegram_links
 from src.tools.messages import read_messages_by_ids
 from src.utils.datetime_parse import parse_iso_datetime_utc
+from src.utils.discussion import get_post_discussion_info
 from src.utils.entity import (
     _get_chat_message_count,
     _matches_chat_type,
@@ -27,6 +30,91 @@ from src.utils.message_format import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Match Telethon's message iterator chunk size for getReplies / search slices.
+_REPLIES_FETCH_CHUNK = 100
+
+
+def _normalized_reply_query(query: str | None) -> str | None:
+    """Strip per-chat query for reply mode; whitespace-only becomes None."""
+    if not query:
+        return None
+    stripped = query.strip()
+    return stripped or None
+
+
+def _belongs_to_forum_thread(message: Any, thread_root_msg_id: int) -> bool:
+    """Return whether a message belongs to a forum thread rooted at ``thread_root_msg_id``.
+
+    Forum threads are keyed by the topic starter / service message id. Thread
+    messages usually set ``reply_to.reply_to_top_id`` to that id, or reference
+    it via ``reply_to_msg_id``.
+    """
+    if getattr(message, "id", None) == thread_root_msg_id:
+        return True
+    reply_to = getattr(message, "reply_to", None)
+    top = getattr(reply_to, "reply_to_top_id", None) if reply_to else None
+    if top is not None and top == thread_root_msg_id:
+        return True
+    rmid = getattr(reply_to, "reply_to_msg_id", None) if reply_to else None
+    if rmid is not None and rmid == thread_root_msg_id:
+        return True
+    outer = getattr(message, "reply_to_msg_id", None)
+    if outer is not None and outer == thread_root_msg_id:
+        return True
+    return False
+
+
+async def _iter_forum_topic_search_messages(
+    client,
+    entity,
+    top_msg_id: int,
+    q: str,
+    limit: int,
+):
+    """Yield messages from ``messages.search`` scoped to one forum topic (``top_msg_id``)."""
+    input_peer = await client.get_input_entity(entity)
+    offset_id = 0
+    yielded = 0
+    want = limit + 1
+
+    while yielded < want:
+        batch = min(_REPLIES_FETCH_CHUNK, want - yielded)
+        r = await client(
+            SearchRequest(
+                peer=input_peer,
+                q=q,
+                filter=InputMessagesFilterEmpty(),
+                min_date=None,
+                max_date=None,
+                offset_id=offset_id,
+                add_offset=0,
+                limit=batch,
+                max_id=0,
+                min_id=0,
+                hash=0,
+                from_id=None,
+                saved_peer_id=None,
+                saved_reaction=None,
+                top_msg_id=top_msg_id,
+            )
+        )
+        if not r.messages:
+            break
+        entities = {
+            tg_utils.get_peer_id(x): x for x in itertools.chain(r.users, r.chats)
+        }
+        for message in r.messages:
+            if isinstance(message, MessageEmpty):
+                continue
+            message._finish_init(client, entities, input_peer)
+            yielded += 1
+            yield message
+            if yielded >= want:
+                return
+        offset_id = r.messages[-1].id
+        if len(r.messages) < batch:
+            break
 
 
 class MessageRetrievalMode(Enum):
@@ -167,22 +255,46 @@ async def _fetch_replies(
         except ValueError:
             logger.debug(f"Channel post {reply_to_id} has no discussion enabled")
 
-    collected = []
-    async for message in client.iter_messages(
-        effective_entity,
-        reply_to=effective_reply_to,
-        search=query or None,
-        limit=limit + 1,
-    ):
-        result = await _build_result_for_message(
-            client, message, effective_entity, include_chat_entity
-        )
-        if not result:
-            continue
+    normalized_query = _normalized_reply_query(query)
+    is_forum = bool(getattr(effective_entity, "forum", False))
 
-        collected.append(result)
-        if len(collected) >= limit + 1:
-            break
+    collected = []
+    if normalized_query and is_forum:
+        async for message in _iter_forum_topic_search_messages(
+            client,
+            effective_entity,
+            effective_reply_to,
+            normalized_query,
+            limit,
+        ):
+            if not _belongs_to_forum_thread(message, effective_reply_to):
+                continue
+            result = await _build_result_for_message(
+                client, message, effective_entity, include_chat_entity
+            )
+            if not result:
+                continue
+            collected.append(result)
+            if len(collected) >= limit + 1:
+                break
+    else:
+        async for message in client.iter_messages(
+            effective_entity,
+            reply_to=effective_reply_to,
+            search=normalized_query,
+            limit=limit + 1,
+        ):
+            if is_forum and not _belongs_to_forum_thread(message, effective_reply_to):
+                continue
+            result = await _build_result_for_message(
+                client, message, effective_entity, include_chat_entity
+            )
+            if not result:
+                continue
+
+            collected.append(result)
+            if len(collected) >= limit + 1:
+                break
 
     await transcribe_voice_messages(collected[:limit], effective_entity)
 
@@ -525,8 +637,10 @@ async def search_messages_impl(
         message_ids: List of specific message IDs to retrieve. Conflicts with query and reply_to_id.
         reply_to_id: Message ID to get replies from. Works for:
             - Channel posts (fetches discussion comments automatically)
-            - Forum topics (fetches topic messages)
+            - Forum topics (fetches topic messages; results are filtered to that topic)
             - Regular messages (fetches direct replies)
+            For forum supergroups, a non-empty ``query`` uses ``messages.search`` with
+            ``top_msg_id`` set to ``reply_to_id`` so search stays inside the topic.
         limit: Maximum number of results to return
         min_date: Minimum date filter (ISO format)
         max_date: Maximum date filter (ISO format)

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -9,6 +9,7 @@ Tests cover:
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -715,3 +716,50 @@ class TestGetMessagesDateFiltering:
         assert len(result["messages"]) == 1
         assert result["messages"][0]["id"] == 99
         assert "[Service: PinMessage]" in (result["messages"][0].get("text") or "")
+
+
+class TestForumThreadReplyHelpers:
+    """Forum thread metadata used to filter get_messages reply_to_id results."""
+
+    def test_belongs_to_forum_thread_matches_reply_to_top_id(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(
+            id=999,
+            reply_to=SimpleNamespace(reply_to_top_id=16160, reply_to_msg_id=50),
+            reply_to_msg_id=None,
+        )
+        assert _belongs_to_forum_thread(msg, 16160) is True
+
+    def test_belongs_to_forum_thread_rejects_other_topic(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(
+            id=1,
+            reply_to=SimpleNamespace(reply_to_top_id=84412, reply_to_msg_id=None),
+            reply_to_msg_id=None,
+        )
+        assert _belongs_to_forum_thread(msg, 16160) is False
+
+    def test_belongs_to_forum_thread_matches_starter_id(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(id=16160, reply_to=None, reply_to_msg_id=None)
+        assert _belongs_to_forum_thread(msg, 16160) is True
+
+    def test_belongs_to_forum_thread_matches_outer_reply_to_msg_id(self):
+        from src.tools.search import _belongs_to_forum_thread
+
+        msg = SimpleNamespace(
+            id=500,
+            reply_to=None,
+            reply_to_msg_id=16160,
+        )
+        assert _belongs_to_forum_thread(msg, 16160) is True
+
+    def test_normalized_reply_query_strips_and_empty(self):
+        from src.tools.search import _normalized_reply_query
+
+        assert _normalized_reply_query("  hi  ") == "hi"
+        assert _normalized_reply_query("   ") is None
+        assert _normalized_reply_query(None) is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `tg_get_messages` when `reply_to_id` targets a forum topic: keep results aligned with that thread, including when a text `query` is present.

## Reviewer question (PR #47)

**“There is no such thing as mixed-topic messages in Telegram. Did you research this?”**

Yes — and that wording in the earlier bot reply was **misleading**. Telegram assigns each forum message to **one** topic (one thread root). The bug is not “Telegram mixing topics”; it is **how we retrieved messages**:

- Passing both `reply_to` and `search` through Telethon’s `iter_messages` does **not** reliably apply topic-scoped search the way `messages.search` with `top_msg_id=reply_to_id` does. That can surface **chat-wide** search hits while the user asked for a **single topic**, which looks like wrong `topic_id` values in the formatted output even though each row still has its own single topic in the MTProto sense.
- For **forum + non-empty query**, this branch uses `messages.search` with `top_msg_id` set to `reply_to_id`, matching the workaround from the issue (`messages.getReplies` / topic-aware search semantics).
- **Forum + no query (or whitespace-only query)**: we still filter with `_belongs_to_forum_thread` as a safety net against any out-of-thread rows from the iterator path.
- Also restores the missing `get_post_discussion_info` import (used for broadcast channel discussion resolution).

Docstrings in `search.py` now describe this as **client/library scoping**, not “mixed topics” from Telegram.

## Tests

- `tests/test_get_messages.py::TestForumThreadReplyHelpers`

After merge, restart the `telegram-dev` MCP server so Cursor picks up the change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-251ee792-0e0c-4cd4-9f19-79f7ed7f66ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-251ee792-0e0c-4cd4-9f19-79f7ed7f66ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Обеспечить, чтобы ответы `get_messages`, привязанные к теме форума, оставались внутри этой темы, включая случаи, когда используется текстовый запрос.

Bug Fixes:
- Не допускать, чтобы ответы в теме форума, полученные через `reply_to_id` и текстовый запрос, возвращали сообщения из других тем, за счёт использования поиска и фильтрации в пределах одной темы.

Enhancements:
- Нормализовать текстовые запросы для режима ответа и добавить вспомогательные функции для определения принадлежности сообщений к ветке форума.

Tests:
- Добавить модульные тесты для проверки принадлежности к ветке форума и нормализации запросов для ответов, используемых при выборке ответных сообщений.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure get_messages replies scoped to a forum topic stay within that thread, including when a text query is used.

Bug Fixes:
- Prevent forum topic replies fetched via reply_to_id and a text query from returning messages from other topics by using topic-scoped search and filtering.

Enhancements:
- Normalize reply text queries for reply mode and add helpers to determine forum thread membership for messages.

Tests:
- Add unit tests for forum thread membership and reply query normalization helpers used when fetching replies.

</details>