### PR TITLE
Refactor session token validation (Sourcery follow-up)

### DIFF
--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -16,7 +16,7 @@ from ..config.server_config import PROJECT_ROOT, get_config
 from ..config.settings import SESSION_DIR
 from ..server_components.session_token_validation import (
     InvalidSessionTokenError,
-    session_file_path,
+    validated_session_file_path,
 )
 from ..utils.proxy import build_mtproto_client_args
 
@@ -293,7 +293,7 @@ async def _get_client_by_token(token: str) -> TelegramClient:
             return client
 
         try:
-            session_path = session_file_path(SESSION_DIR, token)
+            session_path = validated_session_file_path(SESSION_DIR, token)
         except InvalidSessionTokenError as e:
             raise SessionNotAuthorizedError("Invalid bearer token") from e
 
@@ -403,7 +403,7 @@ async def ensure_connection(client: TelegramClient, token: str) -> bool:
             )
             # Remove session file immediately to prevent loop
             try:
-                session_path = session_file_path(SESSION_DIR, token)
+                session_path = validated_session_file_path(SESSION_DIR, token)
             except InvalidSessionTokenError:
                 session_path = None
             if session_path is not None and session_path.exists():
@@ -493,7 +493,7 @@ async def cleanup_failed_sessions():
 
             # Remove session file
             try:
-                session_path = session_file_path(SESSION_DIR, token)
+                session_path = validated_session_file_path(SESSION_DIR, token)
             except InvalidSessionTokenError:
                 continue
             if session_path.exists():

--- a/src/server_components/auth.py
+++ b/src/server_components/auth.py
@@ -7,6 +7,7 @@ from src.client.connection import set_request_token
 from src.config.server_config import get_config
 from src.server_components.session_token_validation import (
     RESERVED_SESSION_NAMES,
+    InvalidSessionTokenError,
     validate_session_token,
 )
 
@@ -34,7 +35,10 @@ def _extract_bearer_token_from_headers(headers: dict[str, str]) -> str | None:
     if not token:
         return None
 
-    return validate_session_token(token)
+    try:
+        return validate_session_token(token)
+    except InvalidSessionTokenError:
+        return None
 
 
 def extract_bearer_token() -> str | None:

--- a/src/server_components/auth_middleware.py
+++ b/src/server_components/auth_middleware.py
@@ -28,7 +28,10 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from src.server_components.session_token_validation import validate_session_token
+from src.server_components.session_token_validation import (
+    InvalidSessionTokenError,
+    validate_session_token,
+)
 
 if TYPE_CHECKING:
     from src.config.server_config import ServerConfig
@@ -85,8 +88,9 @@ class UrlTokenMiddleware(BaseHTTPMiddleware):
 
         token = match.group(1)
 
-        validated = validate_session_token(token)
-        if validated is None:
+        try:
+            token = validate_session_token(token)
+        except InvalidSessionTokenError:
             logger.warning("Rejected invalid bearer token from URL path")
             return JSONResponse(
                 {
@@ -94,7 +98,6 @@ class UrlTokenMiddleware(BaseHTTPMiddleware):
                 },
                 status_code=401,
             )
-        token = validated
 
         # Rewrite path: /v1/url_auth/{token}/mcp/{method} -> /v1/mcp/{method}
         # This makes FastMCP receive the request at its normal mount point

--- a/src/server_components/session_token_validation.py
+++ b/src/server_components/session_token_validation.py
@@ -32,10 +32,10 @@ class InvalidSessionTokenError(ValueError):
     """Bearer token failed format or session-directory containment checks."""
 
 
-def validate_session_token(token: str) -> str | None:
-    """Return normalized token if valid, else None."""
+def validate_session_token(token: str) -> str:
+    """Return normalized token if valid, else raise InvalidSessionTokenError."""
     if not token or not token.strip():
-        return None
+        raise InvalidSessionTokenError("Empty or whitespace-only session token")
 
     normalized = token.strip()
 
@@ -44,28 +44,34 @@ def validate_session_token(token: str) -> str | None:
             "Rejected reserved session name '%s' as bearer token",
             normalized,
         )
-        return None
+        raise InvalidSessionTokenError(
+            "Reserved session name is not a valid bearer token"
+        )
 
     if not BEARER_TOKEN_RE.fullmatch(normalized):
         logger.warning(
             "Rejected bearer token with invalid format (length=%s)",
             len(normalized),
         )
-        return None
+        raise InvalidSessionTokenError("Bearer token has invalid format")
 
     return normalized
 
 
 def session_file_path(session_dir: Path, token: str) -> Path:
-    """Resolve {session_dir}/{token}.session and ensure it stays under session_dir."""
-    validated = validate_session_token(token)
-    if validated is None:
-        raise InvalidSessionTokenError("Invalid session token")
+    """Resolve {session_dir}/{token}.session and ensure it stays under session_dir.
 
+    Expects ``token`` to already be validated via ``validate_session_token``.
+    """
     base = session_dir.resolve()
-    resolved = (base / f"{validated}.session").resolve()
+    resolved = (base / f"{token}.session").resolve()
     if not resolved.is_relative_to(base):
         raise InvalidSessionTokenError(
             "Session file path escapes configured session directory"
         )
     return resolved
+
+
+def validated_session_file_path(session_dir: Path, raw_token: str) -> Path:
+    """Validate ``raw_token`` and return its confined session file path."""
+    return session_file_path(session_dir, validate_session_token(raw_token))

--- a/src/server_components/session_token_verifier.py
+++ b/src/server_components/session_token_verifier.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from fastmcp.server.auth import AccessToken, TokenVerifier
 
 from src.server_components.session_token_validation import (
+    InvalidSessionTokenError,
     session_file_path,
     validate_session_token,
 )
@@ -62,13 +63,10 @@ class SessionFileTokenVerifier(TokenVerifier):
 
         token = token.strip()
 
-        validated = validate_session_token(token)
-        if validated is None:
-            return None
-
         try:
+            validated = validate_session_token(token)
             session_path = session_file_path(self._session_directory, validated)
-        except Exception:
+        except InvalidSessionTokenError:
             return None
 
         if not session_path.is_file():

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -22,7 +22,6 @@ from src.server_components.session_token_validation import (
     InvalidSessionTokenError,
     session_file_path,
     validate_session_token,
-    validated_session_file_path,
 )
 from src.server_components.auth_middleware import generate_url_based_config
 from src.utils.mcp_config import generate_mcp_config_json
@@ -64,6 +63,9 @@ BEARER_TOKEN_REQUIRED_MESSAGE = "Bearer token is required."
 INVALID_TOKEN_MESSAGE = "Invalid token."
 INVALID_BEARER_TOKEN_FORMAT_MESSAGE = (
     "Invalid bearer token. Use the token from setup or a URL-safe token from the CLI."
+)
+SESSION_PATH_ACCESS_ERROR_MESSAGE = (
+    "Unable to access the session directory. Please contact the administrator."
 )
 SESSION_NOT_FOUND_MESSAGE = "Session not found. Please check your bearer token."
 REAUTH_COMPLETE_FAILED_MESSAGE = (
@@ -131,6 +133,26 @@ def _fragment(request: Request, template: str, context: dict[str, Any] | None = 
 def _setup_error_fragment(request: Request, error: str):
     """Return HTML error fragment for setup flow."""
     return _fragment(request, "fragments/error.html", {"error": error})
+
+
+def _bearer_token_and_session_path(session_dir: Path, raw_token: str) -> tuple[str, Path]:
+    """Validate bearer token and return confined session file path."""
+    token = validate_session_token(raw_token)
+    return token, session_file_path(session_dir, token)
+
+
+def _setup_token_path_error_fragment(
+    request: Request,
+    template: str,
+    exc: BaseException,
+) -> Any:
+    """Map token/path resolution errors to setup HTML fragments."""
+    if isinstance(exc, InvalidSessionTokenError):
+        return _fragment(request, template, {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE})
+    if isinstance(exc, OSError):
+        logger.warning("Session path access failed: %s", exc)
+        return _fragment(request, template, {"error": SESSION_PATH_ACCESS_ERROR_MESSAGE})
+    raise exc
 
 
 def _2fa_form_context(
@@ -271,13 +293,14 @@ async def setup_generate(request: Request):
 
     try:
         if desired_token:
-            token = validate_session_token(str(desired_token))
-            dst = session_file_path(session_dir, token)
+            token, dst = _bearer_token_and_session_path(session_dir, str(desired_token))
         else:
             token = generate_bearer_token()
             dst = session_file_path(session_dir, token)
-    except InvalidSessionTokenError:
-        return _setup_error_fragment(request, INVALID_BEARER_TOKEN_FORMAT_MESSAGE)
+    except (InvalidSessionTokenError, OSError) as e:
+        return _setup_token_path_error_fragment(
+            request, "fragments/error.html", e
+        )
 
     # Check if session already exists (only when using desired token)
     if desired_token and dst.exists():
@@ -496,14 +519,12 @@ def register_web_setup_routes(mcp_app):
             )
 
         try:
-            session_path = validated_session_file_path(
+            _, session_path = _bearer_token_and_session_path(
                 get_config().session_directory, existing_token
             )
-        except InvalidSessionTokenError:
-            return _fragment(
-                request,
-                "fragments/reauthorize_token_form.html",
-                {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE},
+        except (InvalidSessionTokenError, OSError) as e:
+            return _setup_token_path_error_fragment(
+                request, "fragments/reauthorize_token_form.html", e
             )
         if not session_path.exists():
             return _fragment(
@@ -642,15 +663,12 @@ def register_web_setup_routes(mcp_app):
             )
 
         try:
-            token = validate_session_token(token)
-            session_path = session_file_path(
+            token, session_path = _bearer_token_and_session_path(
                 get_config().session_directory, token
             )
-        except InvalidSessionTokenError:
-            return _fragment(
-                request,
-                "fragments/delete_session_form.html",
-                {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE},
+        except (InvalidSessionTokenError, OSError) as e:
+            return _setup_token_path_error_fragment(
+                request, "fragments/delete_session_form.html", e
             )
         if not session_path.exists():
             return _fragment(

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -19,8 +19,10 @@ from src.client.connection import _cache_lock, _session_cache, generate_bearer_t
 from src.config.server_config import ServerMode, get_config
 from src.config.settings import API_HASH, API_ID
 from src.server_components.session_token_validation import (
+    InvalidSessionTokenError,
     session_file_path,
     validate_session_token,
+    validated_session_file_path,
 )
 from src.server_components.auth_middleware import generate_url_based_config
 from src.utils.mcp_config import generate_mcp_config_json
@@ -264,20 +266,17 @@ async def setup_generate(request: Request):
         return _setup_error_fragment(request, INVALID_SETUP_STATE_MESSAGE)
 
     desired_token = state.get("desired_token")
-    if desired_token:
-        token = validate_session_token(str(desired_token))
-        if token is None:
-            return _setup_error_fragment(
-                request, INVALID_BEARER_TOKEN_FORMAT_MESSAGE
-            )
-    else:
-        token = generate_bearer_token()
-
-    src = Path(temp_session_path)
     session_dir = get_config().session_directory
+    src = Path(temp_session_path)
+
     try:
-        dst = session_file_path(session_dir, token)
-    except Exception:
+        if desired_token:
+            token = validate_session_token(str(desired_token))
+            dst = session_file_path(session_dir, token)
+        else:
+            token = generate_bearer_token()
+            dst = session_file_path(session_dir, token)
+    except InvalidSessionTokenError:
         return _setup_error_fragment(request, INVALID_BEARER_TOKEN_FORMAT_MESSAGE)
 
     # Check if session already exists (only when using desired token)
@@ -496,18 +495,11 @@ def register_web_setup_routes(mcp_app):
                 {"error": BEARER_TOKEN_REQUIRED_MESSAGE},
             )
 
-        if validate_session_token(existing_token) is None:
-            return _fragment(
-                request,
-                "fragments/reauthorize_token_form.html",
-                {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE},
-            )
-
         try:
-            session_path = session_file_path(
+            session_path = validated_session_file_path(
                 get_config().session_directory, existing_token
             )
-        except Exception:
+        except InvalidSessionTokenError:
             return _fragment(
                 request,
                 "fragments/reauthorize_token_form.html",
@@ -649,26 +641,17 @@ def register_web_setup_routes(mcp_app):
                 {"error": BEARER_TOKEN_REQUIRED_MESSAGE},
             )
 
-        validated_token = validate_session_token(token)
-        if validated_token is None:
-            return _fragment(
-                request,
-                "fragments/delete_session_form.html",
-                {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE},
-            )
-
         try:
+            token = validate_session_token(token)
             session_path = session_file_path(
-                get_config().session_directory, validated_token
+                get_config().session_directory, token
             )
-        except Exception:
+        except InvalidSessionTokenError:
             return _fragment(
                 request,
                 "fragments/delete_session_form.html",
                 {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE},
             )
-
-        token = validated_token
         if not session_path.exists():
             return _fragment(
                 request,

--- a/tests/test_bearer_token_determination.py
+++ b/tests/test_bearer_token_determination.py
@@ -28,7 +28,7 @@ from src.server_components.auth import (
 )
 from src.server_components.session_token_validation import (
     InvalidSessionTokenError,
-    validate_session_token as validate_session_token_strict,
+    validate_session_token,
 )
 from tests.conftest import VALID_TEST_BEARER_TOKEN, make_access_token
 
@@ -628,7 +628,7 @@ class TestErrorHandling:
 
     def test_validate_session_token_raises_on_invalid(self):
         with pytest.raises(InvalidSessionTokenError):
-            validate_session_token_strict("not-a-valid-token")
+            validate_session_token("not-a-valid-token")
 
     def test_extract_bearer_token_from_request_reserved_names_rejected(
         self, http_auth_config

--- a/tests/test_bearer_token_determination.py
+++ b/tests/test_bearer_token_determination.py
@@ -26,6 +26,10 @@ from src.server_components.auth import (
     extract_bearer_token_from_request,
     with_auth_context,
 )
+from src.server_components.session_token_validation import (
+    InvalidSessionTokenError,
+    validate_session_token as validate_session_token_strict,
+)
 from tests.conftest import VALID_TEST_BEARER_TOKEN, make_access_token
 
 
@@ -621,6 +625,10 @@ class TestErrorHandling:
                 return_value=mock_headers,
             ):
                 assert extract_bearer_token() is None
+
+    def test_validate_session_token_raises_on_invalid(self):
+        with pytest.raises(InvalidSessionTokenError):
+            validate_session_token_strict("not-a-valid-token")
 
     def test_extract_bearer_token_from_request_reserved_names_rejected(
         self, http_auth_config

--- a/tests/test_session_token_path_security.py
+++ b/tests/test_session_token_path_security.py
@@ -9,6 +9,7 @@ from src.server_components.session_token_validation import (
     InvalidSessionTokenError,
     session_file_path,
     validate_session_token,
+    validated_session_file_path,
 )
 from tests.conftest import VALID_TEST_BEARER_TOKEN
 
@@ -35,7 +36,8 @@ class TestValidateSessionToken:
         ],
     )
     def test_rejects_unsafe_tokens(self, token: str):
-        assert validate_session_token(token) is None
+        with pytest.raises(InvalidSessionTokenError):
+            validate_session_token(token)
 
 
 class TestSessionFilePath:
@@ -45,13 +47,13 @@ class TestSessionFilePath:
         assert path.is_relative_to(tmp_path.resolve())
         assert path.name == f"{token}.session"
 
-    def test_traversal_token_raises(self, tmp_path: Path):
+    def test_traversal_token_raises_on_validated_path_build(self, tmp_path: Path):
         with pytest.raises(InvalidSessionTokenError):
-            session_file_path(tmp_path, "../outside")
+            validated_session_file_path(tmp_path, "../outside")
 
     def test_resolved_path_cannot_escape(self, tmp_path: Path):
         """Even if a file exists outside session_dir, path builder must reject token."""
         outside = tmp_path.parent / "other.session"
         outside.write_text("x")
         with pytest.raises(InvalidSessionTokenError):
-            session_file_path(tmp_path, f"../{outside.stem}")
+            validated_session_file_path(tmp_path, f"../{outside.stem}")

--- a/tests/test_web_setup.py
+++ b/tests/test_web_setup.py
@@ -126,6 +126,29 @@ async def test_setup_reauthorize_phone_invalid_setup_returns_token_form(
 
 
 @pytest.mark.asyncio
+async def test_setup_delete_session_path_os_error_returns_access_message(
+    monkeypatch, setup_routes, tmp_path
+):
+    web_setup._setup_sessions.clear()
+    cfg = ServerConfig()
+    cfg.session_dir = str(tmp_path)
+    set_config(cfg)
+
+    def _raise_os_error(_session_dir, _raw_token):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(web_setup, "_bearer_token_and_session_path", _raise_os_error)
+
+    _patch_template_response(monkeypatch)
+
+    handler = setup_routes[("/setup/delete", ("POST",))]
+    response = await handler(_FakeRequest({"token": VALID_TEST_BEARER_TOKEN}))
+
+    assert response.template == "fragments/delete_session_form.html"
+    assert web_setup.SESSION_PATH_ACCESS_ERROR_MESSAGE in response.context["error"]
+
+
+@pytest.mark.asyncio
 async def test_setup_delete_rejects_path_traversal_token(
     monkeypatch, setup_routes, tmp_path
 ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #53 / 0.19.1 addressing [Sourcery PR review](https://github.com/leshchenko1979/fast-mcp-telegram/pull/53) complexity comments.

## Changes

- `validate_session_token()` now **raises** `InvalidSessionTokenError` instead of returning `None`
- `session_file_path()` only enforces path containment (expects pre-validated token)
- New `validated_session_file_path()` for routes that need validate + path in one step
- `web_setup` delete/reauth/generate: no double validation, no `except Exception`
- `SessionFileTokenVerifier`: catches only `InvalidSessionTokenError`
- Auth header extraction: maps `InvalidSessionTokenError` → `None` for existing API

No security behavior change; clarity and error-handling only.

## Verification

- `pytest`: 515 passed, 7 skipped

@sourcery-ai review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58455769-66d9-4372-b7f6-49c40d16e8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58455769-66d9-4372-b7f6-49c40d16e8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Уточнена проверка токена сессии на основе выбрасываемых исключений и упрощена обработка путей к файловым сессиям на стороне сервера, клиента и в компонентах middleware.

Исправления ошибок:
- Обеспечить, чтобы недействительные или небезопасные bearer-токены последовательно отклонялись без использования широких блоков обработки исключений при определении путей к файлам сессий.

Улучшения:
- Изменить проверку токена сессии так, чтобы при недействительных токенах выбрасывался `InvalidSessionTokenError` вместо возвращения `None`, и скорректировать вызывающий код для явной обработки этого случая.
- Ввести `validated_session_file_path()` для совмещения проверки токена с определением пути к сессии, оставив `session_file_path()` сфокусированной на проверке вхождения пути.
- Ужесточить конфигурацию веб-сервера, auth middleware и потоки верификации сессий, чтобы избежать двойной проверки, устранить обобщённую обработку исключений и сопоставлять ошибки валидации с понятными ответами для пользователя или API.

Тесты:
- Обновить и расширить тесты безопасности токенов/путей и определения bearer-токенов, чтобы проверять выбрасывание `InvalidSessionTokenError` для недействительных токенов и покрывать новое поведение строгой валидации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine session token validation to be exception-based and streamline session file path handling across server, client, and middleware components.

Bug Fixes:
- Ensure invalid or unsafe bearer tokens are consistently rejected without relying on broad exception handling when resolving session file paths.

Enhancements:
- Change session token validation to raise InvalidSessionTokenError on invalid tokens instead of returning None, and adjust callers to handle this explicitly.
- Introduce validated_session_file_path() to combine token validation with session path resolution while keeping session_file_path() focused on path containment.
- Tighten web setup, auth middleware, and session verification flows to avoid double validation, eliminate generic exception handling, and map validation failures to clear user or API responses.

Tests:
- Update and extend token/path security and bearer token determination tests to assert InvalidSessionTokenError is raised for invalid tokens and to cover the new strict validation behavior.

</details>