### PR TITLE
Session ACL Phase 1: http-auth agent guardrails

### DIFF
--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,9 +1,10 @@
 ## Current Work Focus
 
-**Branch `feature/acl` — Trust lane (2026-05-27):** opt-in session ACL for http-auth. Full lane model: [docs/Roadmap.md](../docs/Roadmap.md).
+**Branch `feature/acl` — Trust lane (2026-05-27):** Phase 1 merge blockers implemented (empty-lane deny, startup validation, SECURITY.md runbook). Dev harness: `telegram-dev` stdio + `telegram-dev-acl` http-auth (`acl.dev.yaml.example`, CONTRIBUTING). Phase 1.5 next: sensitive peer denylist. [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md).
 
-- **Implementation:** [session_acl.py](../src/server_components/session_acl.py), `ACL_ENABLED`, [acl.yaml.example](../acl.yaml.example)
-- **Design:** [acl-design-brief.md](../docs/research/acl-design-brief.md), [acl-operator-research.md](../docs/research/acl-operator-research.md)
+- **Implementation:** [session_acl.py](../src/server_components/session_acl.py), `ACL_ENABLED`, [acl.yaml.example](../acl.yaml.example), [SECURITY.md](../SECURITY.md)
+- **Design:** [acl-design-brief.md](../docs/research/acl-design-brief.md) (Phases 1–3)
+- **Phase 2 (deferred):** `ACL_DEFAULT`, `allow_mtproto`, enforcement registry
 - **Other lanes:** Telemetry `feature/telemetry` *(planned)*; QA / Gategrid `feature/evals`
 
 **Shipped (2026-05-25):** Session token validation refactor — PR #54 merged to `master` (no release).

--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,12 +1,12 @@
 ## Current Work Focus
 
-**Roadmap on `master` (2026-05-27):** product docs and Gemini research — [docs/Roadmap.md](../docs/Roadmap.md).
+**Roadmap lanes (2026-05-27):** Trust (`feature/acl`), **Telemetry** (`feature/telemetry` planned), **QA / Gategrid** (`feature/evals`) — see [docs/Roadmap.md](../docs/Roadmap.md).
 
-- **Strategic positioning:** [Strategic-Market-Positioning.md](../docs/Strategic-Market-Positioning.md), [docs/research/](../docs/research/) (Gemini)
-- **Session ACL:** branch `feature/acl` (not merged)
-- **Gategrid evals:** branch `feature/evals` (not merged)
+- **Telemetry lane:** production signals → QA triage → informs GG case design *(planned)*
+- **QA lane:** GG benchmark matrices + GG gating on PR *(WIP on `feature/evals`)*
+- **Trust lane:** opt-in session ACL *(WIP on `feature/acl`)*
 
-**Shipped (2026-05-25):** Session token validation refactor — PR #54 merged to `master` (no release). Raising API, `_bearer_token_and_session_path`, OSError handling in web setup.
+**Shipped (2026-05-25):** Session token validation refactor — PR #54 merged to `master` (no release).
 
 **Shipped (2026-05-25):** GHSA bearer token path traversal fix — PR #53 merged; release [`0.19.1`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.19.1). Credit: [DavidCarliez](https://github.com/DavidCarliez). `session_token_validation.py` enforces URL-safe tokens + session dir containment.
 

--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,12 +1,13 @@
 ## Current Work Focus
 
-**Roadmap on `master` (2026-05-27):** product docs and Gemini research — [docs/Roadmap.md](../docs/Roadmap.md).
+**Branch `feature/acl` (2026-05-27):** opt-in session ACL for http-auth.
 
-- **Strategic positioning:** [Strategic-Market-Positioning.md](../docs/Strategic-Market-Positioning.md), [docs/research/](../docs/research/) (Gemini)
-- **Session ACL:** branch `feature/acl` (not merged)
-- **Gategrid evals:** branch `feature/evals` (not merged)
+- **Implementation:** [session_acl.py](../src/server_components/session_acl.py), `ACL_ENABLED`, [acl.yaml.example](../acl.yaml.example)
+- **Design:** [acl-design-brief.md](../docs/research/acl-design-brief.md), [acl-operator-research.md](../docs/research/acl-operator-research.md)
+- **Docs:** [SECURITY.md](../SECURITY.md) ACL section
+- **Base:** `master` roadmap docs; merge via PR when ready
 
-**Shipped (2026-05-25):** Session token validation refactor — PR #54 merged to `master` (no release). Raising API, `_bearer_token_and_session_path`, OSError handling in web setup.
+**Shipped (2026-05-25):** Session token validation refactor — PR #54 merged to `master` (no release).
 
 **Shipped (2026-05-25):** GHSA bearer token path traversal fix — PR #53 merged; release [`0.19.1`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.19.1). Credit: [DavidCarliez](https://github.com/DavidCarliez). `session_token_validation.py` enforces URL-safe tokens + session dir containment.
 

--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,4 +1,11 @@
 ## Current Work Focus
+
+**Roadmap on `master` (2026-05-27):** product docs and Gemini research — [docs/Roadmap.md](../docs/Roadmap.md).
+
+- **Strategic positioning:** [Strategic-Market-Positioning.md](../docs/Strategic-Market-Positioning.md), [docs/research/](../docs/research/) (Gemini)
+- **Session ACL:** branch `feature/acl` (not merged)
+- **Gategrid evals:** branch `feature/evals` (not merged)
+
 **Shipped (2026-05-25):** Session token validation refactor — PR #54 merged to `master` (no release). Raising API, `_bearer_token_and_session_path`, OSError handling in web setup.
 
 **Shipped (2026-05-25):** GHSA bearer token path traversal fix — PR #53 merged; release [`0.19.1`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.19.1). Credit: [DavidCarliez](https://github.com/DavidCarliez). `session_token_validation.py` enforces URL-safe tokens + session dir containment.

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,3 +1,6 @@
+### 2026-05-27
+- **Roadmap on `master`:** [docs/Roadmap.md](../docs/Roadmap.md), Gemini research under `docs/research/`, [Strategic-Market-Positioning.md](../docs/Strategic-Market-Positioning.md). Session ACL on `feature/acl`; Gategrid evals on `feature/evals`.
+
 ### 2026-05-25
 - **0.19.1 — bearer token path traversal fix:** PR #53 merged. Reject non–URL-safe bearer tokens; resolve session files under `session_directory` only (`session_token_validation.py`). GitHub release `0.19.1`; PyPI via publish workflow. Reporter credit: [DavidCarliez](https://github.com/DavidCarliez). 514 tests pass.
 

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,5 +1,5 @@
 ### 2026-05-27
-- **Roadmap on `master`:** [docs/Roadmap.md](../docs/Roadmap.md), Gemini research under `docs/research/`, [Strategic-Market-Positioning.md](../docs/Strategic-Market-Positioning.md). Session ACL on `feature/acl`; Gategrid evals on `feature/evals`.
+- **Session ACL (`feature/acl`):** Opt-in `ACL_ENABLED`, static `acl.yaml`, enforcement in MCP tools and MTProto bridge; design docs and 9 tests. Merge to `master` via PR.
 
 ### 2026-05-25
 - **0.19.1 — bearer token path traversal fix:** PR #53 merged. Reject non–URL-safe bearer tokens; resolve session files under `session_directory` only (`session_token_validation.py`). GitHub release `0.19.1`; PyPI via publish workflow. Reporter credit: [DavidCarliez](https://github.com/DavidCarliez). 514 tests pass.

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,5 +1,5 @@
 ### 2026-05-27
-- **Roadmap on `master`:** [docs/Roadmap.md](../docs/Roadmap.md), Gemini research under `docs/research/`, [Strategic-Market-Positioning.md](../docs/Strategic-Market-Positioning.md). Session ACL on `feature/acl`; Gategrid evals on `feature/evals`.
+- **Roadmap lanes on `master`:** Trust / Telemetry / QA-Gategrid model; telemetry informs QA triage, GG benchmark validates decisions, GG gating enforces on PR. Branches: `feature/acl`, `feature/evals`, `feature/telemetry` planned.
 
 ### 2026-05-25
 - **0.19.1 — bearer token path traversal fix:** PR #53 merged. Reject non–URL-safe bearer tokens; resolve session files under `session_directory` only (`session_token_validation.py`). GitHub release `0.19.1`; PyPI via publish workflow. Reporter credit: [DavidCarliez](https://github.com/DavidCarliez). 514 tests pass.

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,6 +1,7 @@
 ### 2026-05-27
+- **Session ACL Phase 1 (`feature/acl`):** Empty-lane hard deny (pre-check + post-filter), listed-token MTProto block, startup validation (`read_only` requires `chats`, malformed token entries), SECURITY.md operator runbook, integration tests. 26 ACL tests pass.
 - **Roadmap lanes (`master`):** Trust / Telemetry / QA-Gategrid — telemetry informs QA triage, GG benchmark validates, GG gating enforces on PR.
-- **Session ACL (`feature/acl`):** Opt-in `ACL_ENABLED`, static `acl.yaml`, MCP + MTProto enforcement; 9 tests.
+- **Session ACL MVP (`feature/acl`):** opt-in `ACL_ENABLED`, static `acl.yaml`, MCP + MTProto enforcement. Direction: agent guardrails — [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md); Phase 1.5 sensitive peer denylist next.
 
 ### 2026-05-25
 - **0.19.1 — bearer token path traversal fix:** PR #53 merged. Reject non–URL-safe bearer tokens; resolve session files under `session_directory` only (`session_token_validation.py`). GitHub release `0.19.1`; PyPI via publish workflow. Reporter credit: [DavidCarliez](https://github.com/DavidCarliez). 514 tests pass.

--- a/.gategrid-ci/baselines/main.json
+++ b/.gategrid-ci/baselines/main.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": 1,
+  "profile_id": "main",
+  "updated_at": "2026-05-26T21:24:21.987852+00:00",
+  "source_report_path": ".gategrid-ci/reports/2026-05-26T212417.8_matrix.json",
+  "fingerprint": {
+    "matrix_name": "gate",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_gate",
+      "get_chat_info_gate",
+      "get_messages_browse_mode",
+      "get_messages_readonly",
+      "search_global_single_result",
+      "search_messages_global"
+    ]
+  },
+  "overall": {
+    "pass_rate": 1.0,
+    "duration_ms_mean": 0.013944508585458001,
+    "cell_count": 6,
+    "metrics": {}
+  },
+  "cells": {
+    "find_chats_gate\u0000main\u0000mock": {
+      "key": {
+        "case_id": "find_chats_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.03749999450519681,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "search_messages_global\u0000main\u0000mock": {
+      "key": {
+        "case_id": "search_messages_global",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.012917036656290293,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "get_messages_readonly\u0000main\u0000mock": {
+      "key": {
+        "case_id": "get_messages_readonly",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.009333016350865364,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "get_chat_info_gate\u0000main\u0000mock": {
+      "key": {
+        "case_id": "get_chat_info_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.008750008419156075,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "get_messages_browse_mode\u0000main\u0000mock": {
+      "key": {
+        "case_id": "get_messages_browse_mode",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.00825000461190939,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "search_global_single_result\u0000main\u0000mock": {
+      "key": {
+        "case_id": "search_global_single_result",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.006916990969330072,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    }
+  }
+}

--- a/.gategrid-ci/reports/2026-05-26T212417.8_matrix.json
+++ b/.gategrid-ci/reports/2026-05-26T212417.8_matrix.json
@@ -1,0 +1,437 @@
+{
+  "schema_version": 1,
+  "commit_sha": "local",
+  "timestamp": "2026-05-26T21:24:17.868313+00:00",
+  "matrix_path": "/Users/leshchenko/coding_projects/vds/deployed_projects/fast-mcp-telegram/evals/matrices/gate.yaml",
+  "matrix_name": "gate",
+  "fingerprint": {
+    "matrix_name": "gate",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_gate",
+      "get_chat_info_gate",
+      "get_messages_browse_mode",
+      "get_messages_readonly",
+      "search_global_single_result",
+      "search_messages_global"
+    ]
+  },
+  "sampling": {
+    "sampled": false,
+    "seed": null,
+    "max_cells": null,
+    "share": null,
+    "always_include_tags": [],
+    "planned_cells": 6,
+    "executed_cells": 6,
+    "skipped_cells": []
+  },
+  "run_max_retries": 0,
+  "cells": [
+    {
+      "key": {
+        "case_id": "find_chats_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "List some of my recent chats \u2014 five is fine. How many chats did you get?",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "find_chats",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "find_chats": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.03749999450519681
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.03749999450519681,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "search_messages_global",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Search my messages for the word \u201ctest\u201d and show me up to three hits. Did you find anything?",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "search_messages_globally",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "search_messages_globally": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.012917036656290293
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.012917036656290293,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "get_messages_readonly",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Open Saved Messages and read the last couple of messages there. If you cannot find Saved Messages, pick one chat and read two messages.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "get_messages",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "get_messages": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.009333016350865364
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.009333016350865364,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "get_chat_info_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "What can you tell me about Saved Messages as a chat? Use get_chat_info if you need metadata.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "get_chat_info",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "get_chat_info": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.008750008419156075
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.008750008419156075,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "get_messages_browse_mode",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "In Saved Messages, fetch exactly two recent messages by browsing \u2014 do not search globally and do not send anything.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "get_messages",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "get_messages": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.00825000461190939
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.00825000461190939,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "search_global_single_result",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Search globally for the word \u201chello\u201d but only show one result. Do not send or edit any messages.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "search_messages_globally",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "search_messages_globally": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.006916990969330072
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.006916990969330072,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    }
+  ],
+  "overall": {
+    "pass_rate": 1.0,
+    "duration_ms_mean": 0.013944508585458001,
+    "cell_count": 6,
+    "metrics": {}
+  },
+  "pass_rate": 1.0
+}

--- a/.gategrid/baselines/main.json
+++ b/.gategrid/baselines/main.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "profile_id": "main",
+  "updated_at": "2026-05-25T13:36:14.244653+00:00",
+  "source_report_path": ".gategrid/reports/2026-05-25T133603.0_matrix.json",
+  "fingerprint": {
+    "matrix_name": "gate",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_gate",
+      "get_messages_readonly",
+      "search_messages_global"
+    ]
+  },
+  "overall": {
+    "pass_rate": 1.0,
+    "duration_ms_mean": 0.02047233283519745,
+    "cell_count": 3,
+    "metrics": {}
+  },
+  "cells": {
+    "find_chats_gate\u0000main\u0000mock": {
+      "key": {
+        "case_id": "find_chats_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.038416997995227575,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "search_messages_global\u0000main\u0000mock": {
+      "key": {
+        "case_id": "search_messages_global",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.013208016753196716,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    },
+    "get_messages_readonly\u0000main\u0000mock": {
+      "key": {
+        "case_id": "get_messages_readonly",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "duration_ms": 0.009791983757168055,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      }
+    }
+  }
+}

--- a/.gategrid/reports/2026-05-25T133602.7_matrix.json
+++ b/.gategrid/reports/2026-05-25T133602.7_matrix.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "commit_sha": "local",
+  "timestamp": "2026-05-25T13:36:02.777830+00:00",
+  "matrix_path": "/Users/leshchenko/coding_projects/vds/deployed_projects/fast-mcp-telegram/evals/matrices/smoke.yaml",
+  "matrix_name": "smoke",
+  "fingerprint": {
+    "matrix_name": "smoke",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_smoke"
+    ]
+  },
+  "sampling": {
+    "sampled": false,
+    "seed": null,
+    "max_cells": null,
+    "share": null,
+    "always_include_tags": [],
+    "planned_cells": 1,
+    "executed_cells": 1,
+    "skipped_cells": []
+  },
+  "run_max_retries": 0,
+  "cells": [
+    {
+      "key": {
+        "case_id": "find_chats_smoke",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "smoke"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Call find_chats with query 'Saved' and limit 3. Summarize how many chats were returned.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "find_chats",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "find_chats": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_tooling_ok": true,
+              "no_destructive_tools": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.03495905548334122
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.03495905548334122,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    }
+  ],
+  "overall": {
+    "pass_rate": 1.0,
+    "duration_ms_mean": 0.03495905548334122,
+    "cell_count": 1,
+    "metrics": {}
+  },
+  "pass_rate": 1.0
+}

--- a/.gategrid/reports/2026-05-25T133603.0_matrix.json
+++ b/.gategrid/reports/2026-05-25T133603.0_matrix.json
@@ -1,0 +1,236 @@
+{
+  "schema_version": 1,
+  "commit_sha": "local",
+  "timestamp": "2026-05-25T13:36:03.039505+00:00",
+  "matrix_path": "/Users/leshchenko/coding_projects/vds/deployed_projects/fast-mcp-telegram/evals/matrices/gate.yaml",
+  "matrix_name": "gate",
+  "fingerprint": {
+    "matrix_name": "gate",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_gate",
+      "get_messages_readonly",
+      "search_messages_global"
+    ]
+  },
+  "sampling": {
+    "sampled": false,
+    "seed": null,
+    "max_cells": null,
+    "share": null,
+    "always_include_tags": [],
+    "planned_cells": 3,
+    "executed_cells": 3,
+    "skipped_cells": []
+  },
+  "run_max_retries": 0,
+  "cells": [
+    {
+      "key": {
+        "case_id": "find_chats_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": false,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Use find_chats with limit 5 and no query filter. Reply with the number of chats in the result.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "find_chats",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "find_chats": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_tooling_ok": true,
+              "no_destructive_tools": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.038416997995227575
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.038416997995227575,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "search_messages_global",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": false,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Use search_messages_globally with query 'test' and limit 3. Summarize whether any messages were found.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "search_messages_globally",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "search_messages_globally": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_tooling_ok": true,
+              "no_destructive_tools": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.013208016753196716
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.013208016753196716,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "get_messages_readonly",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": false,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "If you have a Saved Messages chat, use get_messages on that chat_id with limit 2 and no query. Otherwise use find_chats limit 1 first.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "get_messages",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "get_messages": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_tooling_ok": true,
+              "no_destructive_tools": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.009791983757168055
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.009791983757168055,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    }
+  ],
+  "overall": {
+    "pass_rate": 0.0,
+    "duration_ms_mean": 0.02047233283519745,
+    "cell_count": 3,
+    "metrics": {}
+  },
+  "pass_rate": 1.0
+}

--- a/.gategrid/reports/2026-05-25T140252.3_matrix.json
+++ b/.gategrid/reports/2026-05-25T140252.3_matrix.json
@@ -1,0 +1,230 @@
+{
+  "schema_version": 1,
+  "commit_sha": "local",
+  "timestamp": "2026-05-25T14:02:52.347104+00:00",
+  "matrix_path": "/Users/leshchenko/coding_projects/vds/deployed_projects/fast-mcp-telegram/evals/matrices/gate.yaml",
+  "matrix_name": "gate",
+  "fingerprint": {
+    "matrix_name": "gate",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_gate",
+      "get_messages_readonly",
+      "search_messages_global"
+    ]
+  },
+  "sampling": {
+    "sampled": false,
+    "seed": null,
+    "max_cells": null,
+    "share": null,
+    "always_include_tags": [],
+    "planned_cells": 3,
+    "executed_cells": 3,
+    "skipped_cells": []
+  },
+  "run_max_retries": 0,
+  "cells": [
+    {
+      "key": {
+        "case_id": "find_chats_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "List some of my recent chats \u2014 five is fine. How many chats did you get?",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "find_chats",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "find_chats": 1
+            },
+            "evaluators": {
+              "file_content_match": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.037458958104252815
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.037458958104252815,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "search_messages_global",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Search my messages for the word \u201ctest\u201d and show me up to three hits. Did you find anything?",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "search_messages_globally",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "search_messages_globally": 1
+            },
+            "evaluators": {
+              "file_content_match": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.010541989468038082
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.010541989468038082,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "get_messages_readonly",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Open Saved Messages and read the last couple of messages there. If you cannot find Saved Messages, pick one chat and read two messages.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{\"chats\": []}",
+                "name": "get_messages",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "get_messages": 1
+            },
+            "evaluators": {
+              "file_content_match": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.006916990969330072
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.006916990969330072,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    }
+  ],
+  "overall": {
+    "pass_rate": 1.0,
+    "duration_ms_mean": 0.018305979513873655,
+    "cell_count": 3,
+    "metrics": {}
+  },
+  "pass_rate": 1.0
+}

--- a/.gategrid/reports/2026-05-25T140656.2_matrix.json
+++ b/.gategrid/reports/2026-05-25T140656.2_matrix.json
@@ -1,0 +1,236 @@
+{
+  "schema_version": 1,
+  "commit_sha": "local",
+  "timestamp": "2026-05-25T14:06:56.235216+00:00",
+  "matrix_path": "/Users/leshchenko/coding_projects/vds/deployed_projects/fast-mcp-telegram/evals/matrices/gate.yaml",
+  "matrix_name": "gate",
+  "fingerprint": {
+    "matrix_name": "gate",
+    "profile_ids": [
+      "main"
+    ],
+    "case_ids": [
+      "find_chats_gate",
+      "get_messages_readonly",
+      "search_messages_global"
+    ]
+  },
+  "sampling": {
+    "sampled": false,
+    "seed": null,
+    "max_cells": null,
+    "share": null,
+    "always_include_tags": [],
+    "planned_cells": 3,
+    "executed_cells": 3,
+    "skipped_cells": []
+  },
+  "run_max_retries": 0,
+  "cells": [
+    {
+      "key": {
+        "case_id": "find_chats_gate",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "List some of my recent chats \u2014 five is fine. How many chats did you get?",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "find_chats",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "find_chats": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.04754203837364912
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.04754203837364912,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "search_messages_global",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Search my messages for the word \u201ctest\u201d and show me up to three hits. Did you find anything?",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "search_messages_globally",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "search_messages_globally": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.016958045307546854
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.016958045307546854,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    },
+    {
+      "key": {
+        "case_id": "get_messages_readonly",
+        "profile_id": "main",
+        "model_id": "mock"
+      },
+      "passed": true,
+      "tags": [
+        "mcp",
+        "gate"
+      ],
+      "attempts": [
+        {
+          "attempt_index": 0,
+          "passed": true,
+          "artifact": {
+            "messages": [
+              {
+                "role": "user",
+                "content": "Open Saved Messages and read the last couple of messages there. If you cannot find Saved Messages, pick one chat and read two messages.",
+                "name": null,
+                "tool_call_id": null
+              },
+              {
+                "role": "tool",
+                "content": "{}",
+                "name": "get_messages",
+                "tool_call_id": null
+              },
+              {
+                "role": "assistant",
+                "content": "ok",
+                "name": null,
+                "tool_call_id": null
+              }
+            ],
+            "metrics": {
+              "mcp_errors": 0,
+              "tool_call_count": 1,
+              "turns": 0,
+              "tokens_spent": 0
+            },
+            "tools_called": {
+              "get_messages": 1
+            },
+            "evaluators": {
+              "file_content_match": true,
+              "mcp_no_destructive_tools": true,
+              "mcp_tooling_ok": true
+            },
+            "error": null
+          },
+          "error": null,
+          "duration_ms": 0.012459000572562218
+        }
+      ],
+      "flaky_suspect": false,
+      "duration_ms": 0.012459000572562218,
+      "metrics": {
+        "mcp_errors": 0,
+        "tool_call_count": 1,
+        "turns": 0,
+        "tokens_spent": 0
+      },
+      "error": null
+    }
+  ],
+  "overall": {
+    "pass_rate": 1.0,
+    "duration_ms_mean": 0.025653028084586065,
+    "cell_count": 3,
+    "metrics": {}
+  },
+  "pass_rate": 1.0
+}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 
 # MCP specific
 .cursorrules
+acl.dev.yaml
 
 # OS specific
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ python -m src.cli_setup
 
 ### Development with telegram-dev MCP (Cursor IDE)
 
-This project uses a `telegram-dev` MCP server for development:
+Use **telegram-dev** in [`.cursor/mcp.json`](.cursor/mcp.json) for day-to-day stdio development (no ACL):
 
 ```json
 {
@@ -128,25 +128,87 @@ This project uses a `telegram-dev` MCP server for development:
 }
 ```
 
-**Usage:**
+- Auth disabled; default session name `telegram` maps to `config.session_path` (not bearer-token rules).
+- Restart **telegram-dev** in Cursor's MCP panel after code changes.
+- Credentials from project-root `.env` (see `.env.example`). The server loads `.env` automatically when started via `python3 -m src.server` from the project root.
+- **Do not** `source .env.local` in zsh before starting the server — zsh treats `#` comments and special characters in env values differently than Python's dotenv loader and can corrupt `API_HASH`, proxy URLs, or tokens. Use `python3 -m src.server` from the repo root instead.
+- `MTPROTO_PROXY` in `.env` / `.env.local` applies when the server is started from the project root (via Python dotenv, not shell sourcing).
 
-- Start the server and make code changes
-- When you want to test changes, restart the `telegram-dev` MCP server in Cursor's MCP panel
-- Uses credentials from `.env` file
+An optional **telegram-dev-acl** URL entry in `.cursor/mcp.json` (http-auth + fixed `Authorization` header) is **not recommended for ACL testing** — see below.
 
-**Setup:**
+### ACL development and testing (not via Cursor MCP)
 
-1. Copy `.env.example` to `.env` (or create it manually with your credentials)
-2. The MCP server automatically loads credentials from `.env`
-3. Ensure `cwd` points to the project root
+ACL applies only in **http-auth** mode with `ACL_ENABLED=true`. Cursor MCP is a poor fit for exercising the ACL matrix:
 
-**Testing Tools:**
-The MCP server exposes Telegram tools (find_chats, get_messages, send_message, etc.) directly to the AI agent - use them in conversation to test functionality.
+- **stdio has no ACL** — `telegram-dev` bypasses bearer tokens and ACL entirely.
+- **Fixed Authorization header** — a URL MCP entry binds one Bearer token; switching profiles means editing `mcp.json` and reconnecting.
+- **URL MCP limitations** — local http-auth MCP connections can be unreliable; the server must already be running separately.
+- **Session per bearer** — each ACL profile needs its own `{token}.session` via `/setup`, not the stdio `telegram.session`.
+- **Restart and cache issues** — code changes and session/env fixes require restarting both the HTTP server and the MCP client; stale MCP processes are easy to miss.
 
-**Credentials:**
+Use these methods instead:
 
-- Credentials are stored in `.env` (gitignored)
-- `mcp.json` contains only the launch command
+#### 1. pytest (primary regression)
+
+```bash
+pytest tests/test_session_acl.py tests/test_mcp_tool_acl_integration.py -q
+```
+
+Full suite: `pytest tests/ -q`.
+
+#### 2. Manual HTTP server + curl (live matrix)
+
+1. Copy [`acl.dev.yaml.example`](acl.dev.yaml.example) to `acl.dev.yaml` (gitignored — **never commit real tokens or production ACL**).
+2. Start the server from the project root:
+
+```bash
+SERVER_MODE=http-auth HOST=127.0.0.1 PORT=8765 \
+  ACL_ENABLED=true ACL_CONFIG_PATH=acl.dev.yaml \
+  python3 -m src.server
+```
+
+3. Create one session per profile token at `http://127.0.0.1:8765/setup` (session files must match bearer names in `acl.dev.yaml`).
+4. Call tools with curl, swapping the Bearer token per profile:
+
+```bash
+TOKEN="dev_acl_readonly_abcdefghijklmnopqrstuvwxz0"  # from acl.dev.yaml
+
+curl -sS -X POST "http://127.0.0.1:8765/v1/mcp" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "get_messages",
+      "arguments": {"chat_id": "me", "limit": 1}
+    }
+  }'
+```
+
+Repeat with `dev_acl_empty_lane_…` and `dev_acl_team_lane__…` tokens. Expect denials as in the matrix below.
+
+Optional wrapper: [`scripts/acl_mcp_smoke.sh`](scripts/acl_mcp_smoke.sh) runs the same curl pattern for all three profiles. It reads bearer names from `acl.dev.yaml` (override path with `ACL_CONFIG_PATH`); set `BEARER_TOKEN_FOR_TESTING` to override the readonly profile when your yaml uses a custom token key.
+
+**Live ACL test matrix**
+
+| Profile | Bearer token (example file) | Expect |
+| ------- | --------------------------- | ------ |
+| readonly | `dev_acl_readonly_…` | `send_message` denied; `get_messages` on `me` allowed |
+| empty-lane | `dev_acl_empty_lane_…` | `find_chats` denied (empty lane) |
+| team | `dev_acl_team_lane__…` | Whitelisted chat only; other chats denied |
+
+#### 3. Session setup (`/setup`)
+
+Per-token sessions for http-auth (including ACL profiles) are created at `http://127.0.0.1:8765/setup` while the server above is running. Each bearer name in `acl.dev.yaml` needs a matching `{token}.session` under `~/.config/fast-mcp-telegram/`.
+
+**Credentials**
+
+- API keys: `.env` (gitignored)
+- ACL rules: `acl.dev.yaml` (gitignored); example template only in git
+- `mcp.json`: stdio launch command for **telegram-dev** only; no secrets in committed files
 
 ### 4. Start Using!
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,19 @@
 - **Session Separation**: Each user gets their own authenticated session file
 - **Token Privacy**: Bearer tokens should be treated as passwords and kept secure
 - **Session Files**: Contain complete Telegram access for the associated token
-- **Account Access**: Anyone with a valid Bearer token can perform **ANY action** on that associated Telegram account
+- **Account Access**: Anyone with a valid Bearer token can perform **ANY action** on that associated Telegram account **unless** opt-in session ACL applies to that token
+
+## Opt-in session ACL (http-auth)
+
+When **`ACL_ENABLED=true`**, operators can restrict **specific Bearer tokens** via a server-side config file (default `{session_directory}/acl.yaml`, override with **`ACL_CONFIG_PATH`**). See **`acl.yaml.example`** and [docs/research/acl-design-brief.md](docs/research/acl-design-brief.md).
+
+- **Backward compatible**: tokens **not** listed in the ACL file keep full account access
+- **Per-token rules**: `chats` whitelist, optional `read_only`, optional `allow_global_search`
+- **Enforcement**: MCP tools and the HTTP MTProto bridge (`/mtproto-api/*`) in http-auth mode
+- **Not enabled** for stdio or http-no-auth
+- **No MCP tool** to change ACL in v1 — edit the file on the server and restart (or future reload)
+
+Treat the ACL file like a secret (contains bearer token strings). Restrict file permissions (e.g. `0600`).
 
 ## Production Security Recommendations
 
@@ -62,11 +74,9 @@ When **`DOMAIN`** is set to a non-placeholder public host and the server runs ov
 
 ## Token Validation Security
 
-- **Format**: HTTP_AUTH bearer tokens must be 43-character URL-safe base64 strings (same as setup/CLI generation: `[A-Za-z0-9_-]{43}`). Tokens containing `/`, `\`, or path segments are rejected.
-- **Path containment**: Session files are resolved as `{session_directory}/{token}.session` and must stay under `session_directory` after `resolve()`.
 - **Reserved Name Blocking**: Prevents common session names from being used as bearer tokens
 - **Blocked Names**: `telegram`, `default`, `session`, `bot`, `user`, `main`, `primary`, `test`, `dev`, `prod`
-- **Case Insensitive**: Reserved-name checks ignore case differences
+- **Case Insensitive**: Validation ignores case differences
 - **Session Conflict Prevention**: Blocks tokens that could create file conflicts with STDIO/HTTP_NO_AUTH sessions
 - **Logging**: Rejected tokens are logged with warning messages for security monitoring
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,15 +31,72 @@
 
 ## Opt-in session ACL (http-auth)
 
-When **`ACL_ENABLED=true`**, operators can restrict **specific Bearer tokens** via a server-side config file (default `{session_directory}/acl.yaml`, override with **`ACL_CONFIG_PATH`**). See **`acl.yaml.example`** and [docs/research/acl-design-brief.md](docs/research/acl-design-brief.md).
+When **`ACL_ENABLED=true`**, operators can restrict **specific Bearer tokens** via a server-side config file (default `{session_directory}/acl.yaml`, override with **`ACL_CONFIG_PATH`**). See **`acl.yaml.example`**, [ADR 0001](docs/adr/0001-agent-scoped-session-acl.md), and [acl-design-brief.md](docs/research/acl-design-brief.md).
 
-- **Backward compatible**: tokens **not** listed in the ACL file keep full account access
-- **Per-token rules**: `chats` whitelist, optional `read_only`, optional `allow_global_search`
-- **Enforcement**: MCP tools and the HTTP MTProto bridge (`/mtproto-api/*`) in http-auth mode
-- **Not enabled** for stdio or http-no-auth
-- **No MCP tool** to change ACL in v1 — edit the file on the server and restart (or future reload)
+**Framing:** ACL is **agent guardrails** (workspace lanes + capability profiles), not account lockdown. Humans continue using Telegram in official clients; guardrails limit what **connected agents** can do via MCP tools on this server.
+
+### Enablement
+
+1. Set `ACL_ENABLED=true` in the server environment (http-auth only; not stdio or http-no-auth).
+2. Create the ACL file at the default path or set `ACL_CONFIG_PATH`.
+3. Restart the server (or redeploy). Startup **fails closed** if ACL is enabled but the file is missing or invalid.
+4. List only the Bearer tokens you want to restrict. **Unlisted tokens keep full tool access.**
 
 Treat the ACL file like a secret (contains bearer token strings). Restrict file permissions (e.g. `0600`).
+
+### Agent profiles (operator vocabulary)
+
+| Profile | Typical use | `chats` | `read_only` | `allow_global_search` |
+| --- | --- | --- | --- | --- |
+| **full_access** *(default, unlisted token)* | Personal / demo | — | false | true |
+| **analyst** | Read-only lane | non-empty list | true | true |
+| **team_lane** | Work chats, send allowed | non-empty list | false | true |
+| **bot** | Channel automation | channel ids | false | false |
+
+`read_only: true` **requires** a non-empty `chats` list (startup validation rejects analyst entries without a lane).
+
+### Lane rules
+
+- **`chats`**: allowlist of chat ids, `@username`, or `me` (Saved Messages) for this token’s workspace lane.
+- **Listed token with empty `chats`** (`chats: []` or `chats` omitted): **deny all chat-scoped operations** — hard deny on `find_chats` and `search_messages_globally` (not an empty result list), block reads/writes to any chat, block `send_message_to_phone`.
+- **`read_only`**: blocks send, edit, `invoke_mtproto`, and the HTTP MTProto bridge.
+- **`allow_global_search`**: when false, blocks `search_messages_globally` pre-check.
+
+### What is blocked for listed tokens
+
+| Surface | Behavior |
+| --- | --- |
+| MCP tools (`get_messages`, `send_message`, …) | Pre-check `chat_id` against lane; post-filter list results |
+| `find_chats` / `search_messages_globally` | Post-filter to lane; **empty lane → hard deny** |
+| `invoke_mtproto` | Blocked for **any listed token** (Phase 2 will add `allow_mtproto`) |
+| HTTP MTProto bridge (`/mtproto-api/*`) | Same as `invoke_mtproto` for listed tokens |
+
+Denials return MCP `ok: false` with actionable text (token, chat id, lane). HTTP bridge returns 403.
+
+### Shared-token limits
+
+ACL lanes reduce **accidental** cross-chat access and **in-server** tool abuse when teammates share one Bearer token on an http-auth host. ACL does **not**:
+
+- Stop someone with the raw Bearer token from calling Telegram outside this MCP server
+- Replace Telegram account security (2FA, session revocation in official clients)
+- Apply to stdio or http-no-auth deployments
+
+Phase 1.5 (planned) adds a **sensitive peer denylist** (e.g. login-code user `777000`, BotFather) for shared-team blast radius — see [acl-design-brief.md](docs/research/acl-design-brief.md).
+
+### Troubleshooting denials
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| “empty chat lane” | Token listed with `chats: []` or no `chats` key | Add at least one chat to the token entry |
+| “not in the allowed list” | Tool targets a chat outside the lane | Add chat id / `@username` to `chats` or use an unlisted token |
+| “read-only” | `read_only: true` on the token | Set `read_only: false` or use a write-capable profile |
+| “global message search” | `allow_global_search: false` | Set `allow_global_search: true` or use `get_messages` in-lane |
+| “listed in the ACL config” on MTProto | Listed tokens cannot use raw MTProto in Phase 1 | Remove token from ACL for full access, or wait for Phase 2 `allow_mtproto` |
+| Server refuses to start | Missing ACL file or invalid YAML | Create file; fix malformed token entries; ensure `read_only` has `chats` |
+
+No MCP tool mutates ACL in v1 — edit the file on the server and restart.
+
+**Development and testing:** ACL behavior is validated with **pytest** and a local **http-auth** server exercised via **curl** (Bearer header per profile), not via Cursor MCP — stdio mode has no ACL, and URL MCP entries bind a single fixed token. See [CONTRIBUTING.md — ACL development and testing](CONTRIBUTING.md#acl-development-and-testing-not-via-cursor-mcp).
 
 ## Production Security Recommendations
 
@@ -74,6 +131,8 @@ When **`DOMAIN`** is set to a non-placeholder public host and the server runs ov
 
 ## Token Validation Security
 
+- **Format**: HTTP_AUTH bearer tokens must be 43-character URL-safe base64 strings (same as setup/CLI generation: `[A-Za-z0-9_-]{43}`). Tokens containing `/`, `\`, or path segments are rejected.
+- **Path containment**: Session files are resolved as `{session_directory}/{token}.session` and must stay under `session_directory` after `resolve()`.
 - **Reserved Name Blocking**: Prevents common session names from being used as bearer tokens
 - **Blocked Names**: `telegram`, `default`, `session`, `bot`, `user`, `main`, `primary`, `test`, `dev`, `prod`
 - **Case Insensitive**: Validation ignores case differences

--- a/acl.dev.yaml.example
+++ b/acl.dev.yaml.example
@@ -1,0 +1,31 @@
+# Local ACL harness (http-auth). Copy to acl.dev.yaml (gitignored).
+# Live testing: start http-auth server + curl with Bearer header — not Cursor MCP (see CONTRIBUTING.md).
+# Each token below must have a matching session file: {session_directory}/{token}.session
+# Create sessions via http://127.0.0.1:8765/setup after starting the ACL dev server.
+#
+#   cp acl.dev.yaml.example acl.dev.yaml
+#   # Edit tokens only if you regenerate sessions with new bearer names.
+#
+# ACL_CONFIG_PATH=acl.dev.yaml  (relative to project root when starting the server)
+
+tokens:
+  # Profile: readonly — Saved Messages only, no send
+  # In acl.dev.yaml you may use BEARER_TOKEN_FOR_TESTING from .env instead of this placeholder.
+  "dev_acl_readonly_abcdefghijklmnopqrstuvwxz0":
+    chats:
+      - me
+    read_only: true
+    allow_global_search: true
+
+  # Profile: empty_lane — hard deny on chat-scoped tools (ACL matrix testing)
+  "dev_acl_empty_lane_abcdefghijklmnopqrstuvwx":
+    chats: []
+    read_only: false
+    allow_global_search: false
+
+  # Profile: team — single work chat, send allowed (replace id with your supergroup/channel)
+  "dev_acl_team_lane__abcdefghijklmnopqrstuvwx":
+    chats:
+      - -1001234567890
+    read_only: false
+    allow_global_search: false

--- a/acl.yaml.example
+++ b/acl.yaml.example
@@ -1,0 +1,26 @@
+# Tokens omitted from this file retain full account access when ACL is enabled.
+# Set ACL_ENABLED=true and place this file at {session_directory}/acl.yaml
+# or set ACL_CONFIG_PATH to an absolute path.
+
+tokens:
+  # Read-only analyst: Saved Messages only
+  "REPLACE_WITH_BEARER_TOKEN":
+    chats:
+      - me
+    read_only: true
+    allow_global_search: true
+
+  # Team shared: specific work chats, full messaging
+  # "another-token":
+  #   chats:
+  #     - -1001234567890
+  #     - "@myteam"
+  #   read_only: false
+  #   allow_global_search: true
+
+  # Automation: post to channels only, no global search
+  # "automation-token":
+  #   chats:
+  #     - -100999888777
+  #   read_only: false
+  #   allow_global_search: false

--- a/acl.yaml.example
+++ b/acl.yaml.example
@@ -1,16 +1,26 @@
-# Tokens omitted from this file retain full account access when ACL is enabled.
-# Set ACL_ENABLED=true and place this file at {session_directory}/acl.yaml
-# or set ACL_CONFIG_PATH to an absolute path.
+# Agent guardrails (http-auth): per-token workspace lane + profile — not account lockdown.
+# Tokens omitted from this file keep full tool access when ACL is enabled.
+# Set ACL_ENABLED=true; default path {session_directory}/acl.yaml or ACL_CONFIG_PATH.
+# See docs/adr/0001-agent-scoped-session-acl.md and docs/research/acl-design-brief.md.
+#
+# Sensitive peers (Phase 1.5, planned): when ACL is enabled, the server always blocks MCP
+# access to built-in security peers (e.g. 777000 login codes, BotFather) — even if listed
+# under a token's chats. Operators cannot disable those defaults; optional deployment-wide
+# extension only:
+#
+# blocked_peers:
+#   extend:
+#     - 1234567890
 
 tokens:
-  # Read-only analyst: Saved Messages only
+  # Agent profile: analyst (read-only lane — Saved Messages only)
   "REPLACE_WITH_BEARER_TOKEN":
     chats:
       - me
     read_only: true
     allow_global_search: true
 
-  # Team shared: specific work chats, full messaging
+  # Agent profile: team_lane — work chats, send allowed
   # "another-token":
   #   chats:
   #     - -1001234567890
@@ -18,7 +28,7 @@ tokens:
   #   read_only: false
   #   allow_global_search: true
 
-  # Automation: post to channels only, no global search
+  # Agent profile: bot — channels only, no global search
   # "automation-token":
   #   chats:
   #     - -100999888777

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -4,61 +4,141 @@ Official priorities for fast-mcp-telegram. Capability facts live in [Strategic-M
 
 Last updated: 2026-05-27.
 
-## Branches
-
-| Branch | Contents |
-| --- | --- |
-| `master` | Roadmap, strategic positioning index, Gemini research |
-| `feature/acl` | Opt-in session ACL implementation and design docs |
-| `feature/evals` | Gategrid eval harness, CI workflow, gate cases |
-
 ## North star
 
 **Shared `http-auth` multi-user hosting** — one gateway, many Bearer tokens, one Telegram account per token. Optimize tenant isolation, blast-radius control, stability, and agent correctness.
+
+## Roadmap lanes
+
+Work is organized in parallel **lanes**. Each lane has its own branch until merge-ready.
+
+| Lane | Branch | Purpose |
+| --- | --- | --- |
+| **Trust** | `feature/acl` | Opt-in session ACL for http-auth blast-radius control |
+| **Telemetry** | `feature/telemetry` *(planned)* | Production signals that tell QA where agents and users struggle |
+| **QA / Gategrid** | `feature/evals` | Benchmark tool behavior with [Gategrid](https://github.com/leshchenko1979/gategrid) — **GG** — and enforce regressions via **GG gating** |
+| **Docs / strategy** | `master` | Roadmap, capability index, Gemini research reference |
+
+### QA loop: telemetry → benchmark → gate
+
+Telemetry and Gategrid serve different steps of the same **QA function**. Telemetry observes real usage; Gategrid proves fixes and blocks regressions.
+
+```mermaid
+flowchart LR
+  subgraph prod [Production]
+    users[Agents and users]
+    server[MCP server]
+    users --> server
+  end
+  subgraph telemetry_lane [Telemetry lane]
+    signals[Usage signals]
+    triage[Problem triage]
+    server --> signals
+    signals --> triage
+  end
+  subgraph qa_lane [QA / Gategrid lane]
+    cases[Case design]
+    bench[GG benchmark]
+    gate[GG gating]
+    triage --> cases
+    cases --> bench
+    bench --> gate
+  end
+  ship[Merge and deploy]
+  gate --> ship
+  ship --> server
+```
+
+| Step | Lane | What happens |
+| --- | --- | --- |
+| **1. Observe** | Telemetry | Collect structured signals from production: tool errors, `FLOOD_WAIT`, latency outliers, auth failures, repeated tool-selection mistakes. Surfaces *where* quality breaks in the wild. |
+| **2. Decide** | QA | Turn telemetry findings into hypotheses and **GG case** candidates — new prompts, matrices, or baseline updates. Prioritize cases that match real failure modes. |
+| **3. Benchmark** | QA / Gategrid | Run **GG** matrices (`smoke`, `gate`, optional live model) to measure pass rate, tool choice, and regressions vs baselines. Informs whether a tool or doc change actually helps agents. |
+| **4. Assure** | QA / Gategrid | **GG gating** on PRs: `gategrid gate` against [evals/ci/baselines/main.json](../evals/ci/baselines/main.json) blocks merges when pass rate or like-for-like cells regress. |
+| **5. Ship** | All lanes | Merge when trust, telemetry hooks, and gate are aligned for the change scope. |
+
+**Today:** step 3–4 are scaffolded on `feature/evals`. Step 1–2 are planned on `feature/telemetry` (no implementation on `master` yet).
+
+## Branches
+
+| Branch | Lane | Contents |
+| --- | --- | --- |
+| `master` | Docs / strategy | [Roadmap.md](Roadmap.md), [Strategic-Market-Positioning.md](Strategic-Market-Positioning.md), Gemini [research/](research/) |
+| `feature/acl` | Trust | Session ACL implementation and design docs |
+| `feature/evals` | QA / Gategrid | [evals/](../evals/), [gategrid-eval.yml](../.github/workflows/gategrid-eval.yml) |
+| `feature/telemetry` | Telemetry | *Planned* — production observability for QA triage |
 
 ## Decisions (2026-05-26)
 
 | Topic | Decision |
 | --- | --- |
-| ACL | Opt-in via `ACL_ENABLED`; per-token rules in static file — implementation on `feature/acl` |
-| ACL config | Static `acl.yaml` only; no MCP configure tool in v1 |
-| ACL scope | `chats`, `read_only`, `allow_global_search` — see [research/acl-design-brief.md](research/acl-design-brief.md) on `feature/acl` |
-| Evals | Gategrid on `feature/evals` |
-| Post-ACL focus | Eval expansion before rate limits / SQLite |
+| ACL | Opt-in via `ACL_ENABLED`; per-token rules in static file — `feature/acl` |
+| QA model | Telemetry informs case design; **GG benchmark** validates; **GG gating** enforces on PR |
+| Evals | Gategrid harness on `feature/evals`; not merged until gate is stable |
+| Telemetry | Separate lane; must feed QA triage before cases are added blindly |
+| Post-ACL focus | Telemetry spike + eval expansion before rate limits / SQLite |
 
 ## Current sequence
 
-| Step | Status | Branch | Deliverable |
-| --- | --- | --- | --- |
-| 1. Roadmap & research | Done | `master` | [Roadmap.md](Roadmap.md), Gemini docs under [research/](research/) |
-| 2. ACL competitor audit | Done | `feature/acl` | [research/acl-operator-research.md](research/acl-operator-research.md) |
-| 3. ACL design brief | Done | `feature/acl` | [research/acl-design-brief.md](research/acl-design-brief.md) |
-| 4. ACL MVP | Done | `feature/acl` | [session_acl.py](../src/server_components/session_acl.py), [acl.yaml.example](../acl.yaml.example) |
-| 5. Eval expansion + CI | In progress | `feature/evals` | PR gate when baseline stable |
-| 6. Merge feature branches | Pending | — | PRs: `feature/acl`, then `feature/evals` |
+| Step | Status | Lane | Branch | Deliverable |
+| --- | --- | --- | --- | --- |
+| 1. Roadmap and research | Done | Docs | `master` | This doc, Gemini under [research/](research/) |
+| 2. ACL audit and design | Done | Trust | `feature/acl` | [acl-operator-research.md](research/acl-operator-research.md), [acl-design-brief.md](research/acl-design-brief.md) |
+| 3. ACL MVP | Done | Trust | `feature/acl` | [session_acl.py](../src/server_components/session_acl.py) |
+| 4. GG scaffold | In progress | QA | `feature/evals` | Six gate cases, mock baseline, PR workflow |
+| 5. Telemetry for QA | Planned | Telemetry | `feature/telemetry` | Tool/error/latency signals → case backlog |
+| 6. GG depth + live eval | Planned | QA | `feature/evals` | Cases driven by telemetry; optional VDS live matrix |
+| 7. Merge feature branches | Pending | — | — | PRs: `feature/acl`, `feature/telemetry`, `feature/evals` |
 
 ## Shipped on `master`
 
 - [Strategic-Market-Positioning.md](Strategic-Market-Positioning.md) capability index
-- Gemini research split under [research/](research/) (third-party reference)
+- Gemini research under [research/](research/) (third-party reference)
+- Roadmap lane model (this document)
 
-Session ACL and Gategrid evals: merge from `feature/acl` and `feature/evals` when ready.
+Trust, telemetry, and Gategrid evals merge from their feature branches when each lane is ready.
+
+## Telemetry lane — planned scope
+
+Candidate signals for QA triage (not implemented):
+
+| Signal | QA use |
+| --- | --- |
+| Tool error rate by tool name | New or tightened GG cases for that tool |
+| `FLOOD_WAIT` / connection errors | Rate-limit and caching decisions; stress cases |
+| P95 tool latency | Performance regressions; matrix timing budgets |
+| Wrong-tool patterns | Case prompts that require disambiguation |
+| Auth / ACL denials | Security docs and negative-path cases |
+
+Implementation choices (OpenTelemetry, Logfire, structured logs → query) belong on `feature/telemetry`.
+
+## QA / Gategrid lane — current scope
+
+See [evals/README.md](../evals/README.md) on branch `feature/evals`.
+
+| Artifact | Role in QA loop |
+| --- | --- |
+| [evals/cases/](../evals/cases/) | User-language prompts → **benchmark** scenarios |
+| [evals/matrices/](../evals/matrices/) | `smoke` vs `gate` run profiles |
+| [evals/ci/baselines/main.json](../evals/ci/baselines/main.json) | Regression baseline for **GG gating** |
+| [.github/workflows/gategrid-eval.yml](../.github/workflows/gategrid-eval.yml) | PR mock gate + manual live dispatch |
 
 ## Backlog (not sequenced)
 
-| Item | Notes |
-| --- | --- |
-| Per-token rate limits | Host + account protection |
-| SQLite read cache | kfastov-style; pairs with ACL whitelists |
-| ACL v2 permission matrix | Prgebish-style read/send per chat |
-| Prompt-injection scanner | After ACL + evals |
-| OAuth2 / IdP | Enterprise federation |
-| Stdio path sandbox | Local stdio users |
-| Multi-replica attachment tickets | Redis or shared store |
-| Media OCR pipeline | Beyond voice transcription |
+| Item | Lane | Notes |
+| --- | --- | --- |
+| Per-token rate limits | Trust / ops | Complements telemetry FLOOD_WAIT signals |
+| SQLite read cache | Performance | Pairs with ACL whitelists |
+| ACL v2 permission matrix | Trust | Prgebish-style read/send per chat |
+| Prompt-injection scanner | Trust | After ACL + QA coverage |
+| OAuth2 / IdP | Enterprise | Federation path |
+| Stdio path sandbox | Trust | Local stdio users |
+| Multi-replica attachment tickets | Ops | Shared ticket store |
+| Media OCR pipeline | Features | Beyond voice transcription |
 
 ## References
 
 - [Strategic-Market-Positioning.md](Strategic-Market-Positioning.md)
 - [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md)
 - [Installation.md](Installation.md)
+- [Gategrid](https://github.com/leshchenko1979/gategrid) — external eval and gating harness

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -14,7 +14,7 @@ Work is organized in parallel **lanes**. Each lane has its own branch until merg
 
 | Lane | Branch | Purpose |
 | --- | --- | --- |
-| **Trust** | `feature/acl` | Opt-in session ACL for http-auth blast-radius control |
+| **Trust** | `feature/acl` | Agent guardrails per Bearer token (lanes/profiles), not account lockdown — see [ADR 0001](adr/0001-agent-scoped-session-acl.md) |
 | **Telemetry** | `feature/telemetry` *(planned)* | Production signals that tell QA where agents and users struggle |
 | **QA / Gategrid** | `feature/evals` | Benchmark tool behavior with [Gategrid](https://github.com/leshchenko1979/gategrid) — **GG** — and enforce regressions via **GG gating** |
 | **Docs / strategy** | `master` | Roadmap, capability index, Gemini research reference |
@@ -98,6 +98,17 @@ flowchart LR
 
 Trust, telemetry, and Gategrid evals merge from their feature branches when each lane is ready.
 
+## Trust lane — planned scope
+
+Operator-facing enhancements beyond ACL enforcement (not implemented):
+
+| Item | Purpose |
+| --- | --- |
+| **Sensitive peer denylist (Phase 1.5)** | Server-enforced block on security-sensitive peers (`777000` login codes, BotFather, etc.) for **all** tokens when `ACL_ENABLED` — independent of `chats` allowlist. Addresses **shared-team human threat** (same Bearer token) reading PINs or managing bots via MCP. Optional `blocked_peers.extend` in `acl.yaml`. See [ADR 0001](adr/0001-agent-scoped-session-acl.md), [acl-design-brief.md](research/acl-design-brief.md). |
+| **Chat metadata registry** | Operator-curated metadata for whitelisted/shared chats so team agents can navigate `find_chats` results — human titles, descriptions, tags, and “look here for X” hints. Complements ACL **workspace lanes** (which chats a token may use) with **navigation hints** (what each chat is for); does not replace lane allowlists. Likely config alongside `acl.yaml` or a sibling file; enrichment at the tool boundary (e.g. post-filter on `find_chats`). |
+
+See [acl-design-brief.md](research/acl-design-brief.md) Phase 1.5 and Phase 3 for related ACL work.
+
 ## Telemetry lane — planned scope
 
 Candidate signals for QA triage (not implemented):
@@ -127,6 +138,7 @@ See [evals/README.md](../evals/README.md) on branch `feature/evals`.
 
 | Item | Lane | Notes |
 | --- | --- | --- |
+| Sensitive peer denylist | Trust | Phase 1.5 — server defaults + `blocked_peers.extend`; see Trust lane planned scope |
 | Per-token rate limits | Trust / ops | Complements telemetry FLOOD_WAIT signals |
 | SQLite read cache | Performance | Pairs with ACL whitelists |
 | ACL v2 permission matrix | Trust | Prgebish-style read/send per chat |
@@ -135,6 +147,18 @@ See [evals/README.md](../evals/README.md) on branch `feature/evals`.
 | Stdio path sandbox | Trust | Local stdio users |
 | Multi-replica attachment tickets | Ops | Shared ticket store |
 | Media OCR pipeline | Features | Beyond voice transcription |
+
+## Where to record future work
+
+| Kind of item | Where to write it |
+| --- | --- |
+| Prioritized capability, lane, or backlog item | **This doc** — lane sections (`Trust`, `Telemetry`, `QA`) or [Backlog](#backlog-not-sequenced) |
+| Design detail for an approved lane (phases, enforcement, config shape) | `docs/research/*-design-brief.md` (e.g. [acl-design-brief.md](research/acl-design-brief.md)) |
+| Architectural decision with tradeoffs and consequences | `docs/adr/NNNN-*.md` (new ADR when the decision is settled) |
+| Competitor notes, spikes, third-party research | `docs/research/` (reference only; link from Roadmap) |
+| Current sprint focus and immediate next steps | `.cursor/memory-bank/activeContext.md` (3–5 items; not a substitute for Roadmap) |
+
+**Rule of thumb:** Roadmap names *what* and *which lane*; research briefs spell *how*; ADRs record *why* a direction was chosen.
 
 ## References
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,64 @@
+# Product Roadmap
+
+Official priorities for fast-mcp-telegram. Capability facts live in [Strategic-Market-Positioning.md](Strategic-Market-Positioning.md). Third-party Gemini research is under [research/](research/).
+
+Last updated: 2026-05-27.
+
+## Branches
+
+| Branch | Contents |
+| --- | --- |
+| `master` | Roadmap, strategic positioning index, Gemini research |
+| `feature/acl` | Opt-in session ACL implementation and design docs |
+| `feature/evals` | Gategrid eval harness, CI workflow, gate cases |
+
+## North star
+
+**Shared `http-auth` multi-user hosting** — one gateway, many Bearer tokens, one Telegram account per token. Optimize tenant isolation, blast-radius control, stability, and agent correctness.
+
+## Decisions (2026-05-26)
+
+| Topic | Decision |
+| --- | --- |
+| ACL | Opt-in via `ACL_ENABLED`; per-token rules in static file — implementation on `feature/acl` |
+| ACL config | Static `acl.yaml` only; no MCP configure tool in v1 |
+| ACL scope | `chats`, `read_only`, `allow_global_search` — see [research/acl-design-brief.md](research/acl-design-brief.md) on `feature/acl` |
+| Evals | Gategrid on `feature/evals` |
+| Post-ACL focus | Eval expansion before rate limits / SQLite |
+
+## Current sequence
+
+| Step | Status | Branch | Deliverable |
+| --- | --- | --- | --- |
+| 1. Roadmap & research | Done | `master` | [Roadmap.md](Roadmap.md), Gemini docs under [research/](research/) |
+| 2. ACL competitor audit | Done | `feature/acl` | [research/acl-operator-research.md](research/acl-operator-research.md) |
+| 3. ACL design brief | Done | `feature/acl` | [research/acl-design-brief.md](research/acl-design-brief.md) |
+| 4. ACL MVP | Done | `feature/acl` | [session_acl.py](../src/server_components/session_acl.py), [acl.yaml.example](../acl.yaml.example) |
+| 5. Eval expansion + CI | In progress | `feature/evals` | PR gate when baseline stable |
+| 6. Merge feature branches | Pending | — | PRs: `feature/acl`, then `feature/evals` |
+
+## Shipped on `master`
+
+- [Strategic-Market-Positioning.md](Strategic-Market-Positioning.md) capability index
+- Gemini research split under [research/](research/) (third-party reference)
+
+Session ACL and Gategrid evals: merge from `feature/acl` and `feature/evals` when ready.
+
+## Backlog (not sequenced)
+
+| Item | Notes |
+| --- | --- |
+| Per-token rate limits | Host + account protection |
+| SQLite read cache | kfastov-style; pairs with ACL whitelists |
+| ACL v2 permission matrix | Prgebish-style read/send per chat |
+| Prompt-injection scanner | After ACL + evals |
+| OAuth2 / IdP | Enterprise federation |
+| Stdio path sandbox | Local stdio users |
+| Multi-replica attachment tickets | Redis or shared store |
+| Media OCR pipeline | Beyond voice transcription |
+
+## References
+
+- [Strategic-Market-Positioning.md](Strategic-Market-Positioning.md)
+- [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md)
+- [Installation.md](Installation.md)

--- a/docs/Strategic-Market-Positioning.md
+++ b/docs/Strategic-Market-Positioning.md
@@ -1,0 +1,90 @@
+# Strategic Market Positioning
+
+This page is the **project-maintained index** for market and architecture research about fast-mcp-telegram. It separates verified product facts from third-party analysis.
+
+> **Third-party research:** Documents under [docs/research/](research/) are saved Gemini Deep Research output ([original share link](https://gemini.google.com/share/b1d8cb8b23c2), 2026-05-26). They are **not** official roadmaps, security audits, or legal/financial advice. Cross-check claims against [README.md](../README.md), [SECURITY.md](../SECURITY.md), and [docs/Tools-Reference.md](Tools-Reference.md).
+
+## Verified current capabilities (2026-05-26)
+
+Facts below match the repository at the time of the documentation review.
+
+### MCP tools (8)
+
+| Tool | Purpose |
+| --- | --- |
+| `search_messages_globally` | Cross-chat message search |
+| `get_messages` | Browse, search, fetch by IDs, or load replies in one chat |
+| `send_message` | Send text or media to a chat |
+| `edit_message` | Edit an existing message |
+| `find_chats` | Find chats by query, folder, or activity dates |
+| `get_chat_info` | Profile and metadata for one chat or user |
+| `send_message_to_phone` | Send to a phone number with optional contact auto-create |
+| `invoke_mtproto` | Raw MTProto with dangerous-method guardrails |
+
+See [Tools-Reference.md](Tools-Reference.md) for parameters and behavior.
+
+### Server modes (3)
+
+| Mode | Auth | Use case |
+| --- | --- | --- |
+| `stdio` | None | Local MCP clients (Cursor, Claude Desktop) |
+| `http-no-auth` | None | Local HTTP development |
+| `http-auth` | Bearer token | Production multi-user remote hosting |
+
+Configured in [src/config/server_config.py](../src/config/server_config.py). Documented in [Installation.md](Installation.md).
+
+### Authentication and sessions
+
+- Per-user Bearer tokens (256-bit) with browser web setup ([Installation.md](Installation.md#web-setup-interface))
+- Session files at `~/.config/fast-mcp-telegram/{token}.session`
+- LRU session cache (`MAX_ACTIVE_SESSIONS`) in [src/client/connection.py](../src/client/connection.py)
+- URL-based auth for headerless clients: `/v1/url_auth/{token}/mcp/...` ([SECURITY.md](../SECURITY.md))
+- **Scope:** a valid Bearer token grants **full access** to that Telegram account — no per-chat ACL on `master` (see branch `feature/acl`)
+
+### Security (shipped)
+
+| Area | Behavior |
+| --- | --- |
+| Local file paths | Allowed only in **stdio** mode |
+| HTTP modes | All local paths rejected; URL downloads only |
+| URL downloads | SSRF protection, size limits, redirect blocking ([SECURITY.md](../SECURITY.md), [src/tools/messages/security.py](../src/tools/messages/security.py)) |
+| Attachments | Ticketed streaming at `GET /v1/attachments/{uuid}/{filename}` ([src/server_components/attachment_routes.py](../src/server_components/attachment_routes.py)) |
+| Bot sessions | Non-bridge tools blocked ([src/server_components/bot_restrictions.py](../src/server_components/bot_restrictions.py)) |
+
+**Not shipped on `master`:** per-chat ACL (branch `feature/acl`), directory sandbox allowlists, input/output prompt-injection scanners.
+
+### Other shipped features
+
+- HTTP-MTProto bridge: `POST /mtproto-api/{method}` — [MTProto-Bridge.md](MTProto-Bridge.md)
+- Premium voice transcription in message flows — [Tools-Reference.md](Tools-Reference.md)
+- Multi-account tool prefix (`PREFIX_MCP_TOOLS_WITH_ACCOUNT`) — [Installation.md](Installation.md#multi-account-mcp-tool-prefix)
+- Health endpoint `/health` — [src/server_components/health.py](../src/server_components/health.py)
+- Docker image (GHCR) with `traefik-public` network; Traefik router labels are manual per [Installation.md](Installation.md)
+- Distribution: `uvx`, PyPI, Docker
+
+### Known gaps vs competitors (research summary)
+
+| Capability | fast-mcp-telegram today | Notable alternative |
+| --- | --- | --- |
+| Per-chat ACL | Not on `master`; WIP on `feature/acl` | mcp-telegram (Prgebish) — default-deny always on |
+| Local SQLite message cache | Not implemented | telegram-mcp-server (kfastov) — background sync |
+| Enterprise IdP / OAuth2 | Not implemented | StackOne — managed OAuth |
+
+## Research documents (third-party)
+
+| Document | Contents |
+| --- | --- |
+| [Roadmap.md](Roadmap.md) | Official product roadmap and branch layout |
+| [research/gemini-competitive-analysis.md](research/gemini-competitive-analysis.md) | MCP/Telegram landscape, competitor table, ecosystem risks |
+| [research/gemini-strategy-monetization.md](research/gemini-strategy-monetization.md) | Aspirational positioning and monetization hypotheses |
+| [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md) | Proposed features, phase timeline (planned vs shipped) |
+
+ACL design docs live on branch `feature/acl` ([acl-design-brief.md](research/acl-design-brief.md) after merge).
+
+## See also
+
+- [README.md](../README.md) — features and quick start
+- [SECURITY.md](../SECURITY.md) — auth model and file security
+- [Installation.md](Installation.md) — deployment and configuration
+- [Tools-Reference.md](Tools-Reference.md) — tool API reference
+- [MTProto-Bridge.md](MTProto-Bridge.md) — HTTP-MTProto bridge

--- a/docs/Strategic-Market-Positioning.md
+++ b/docs/Strategic-Market-Positioning.md
@@ -39,7 +39,17 @@ Configured in [src/config/server_config.py](../src/config/server_config.py). Doc
 - Session files at `~/.config/fast-mcp-telegram/{token}.session`
 - LRU session cache (`MAX_ACTIVE_SESSIONS`) in [src/client/connection.py](../src/client/connection.py)
 - URL-based auth for headerless clients: `/v1/url_auth/{token}/mcp/...` ([SECURITY.md](../SECURITY.md))
-- **Scope:** a valid Bearer token grants **full access** to that Telegram account — no per-chat ACL on `master` (see branch `feature/acl`)
+- **Scope:** a valid Bearer token grants **full access** to that Telegram account — **unless** opt-in session ACL is enabled and the token has an entry in `acl.yaml` ([SECURITY.md](../SECURITY.md#opt-in-session-acl-http-auth))
+
+### Session ACL (shipped, opt-in)
+
+| Control | Behavior |
+| --- | --- |
+| Enable | `ACL_ENABLED=true` + config file (default `{session_directory}/acl.yaml`) |
+| Unlisted tokens | Full account access (backward compatible) |
+| Listed tokens | Chat whitelist, optional read-only, optional global search block |
+
+See [research/acl-design-brief.md](research/acl-design-brief.md) and [Roadmap.md](Roadmap.md).
 
 ### Security (shipped)
 
@@ -51,7 +61,7 @@ Configured in [src/config/server_config.py](../src/config/server_config.py). Doc
 | Attachments | Ticketed streaming at `GET /v1/attachments/{uuid}/{filename}` ([src/server_components/attachment_routes.py](../src/server_components/attachment_routes.py)) |
 | Bot sessions | Non-bridge tools blocked ([src/server_components/bot_restrictions.py](../src/server_components/bot_restrictions.py)) |
 
-**Not shipped on `master`:** per-chat ACL (branch `feature/acl`), directory sandbox allowlists, input/output prompt-injection scanners.
+**Not shipped:** directory sandbox allowlists, input/output prompt-injection scanners. Per-chat ACL is **opt-in** when `ACL_ENABLED=true` ([SECURITY.md](../SECURITY.md)).
 
 ### Other shipped features
 
@@ -66,7 +76,7 @@ Configured in [src/config/server_config.py](../src/config/server_config.py). Doc
 
 | Capability | fast-mcp-telegram today | Notable alternative |
 | --- | --- | --- |
-| Per-chat ACL | Not on `master`; WIP on `feature/acl` | mcp-telegram (Prgebish) — default-deny always on |
+| Per-chat ACL | Opt-in (`ACL_ENABLED`) | mcp-telegram (Prgebish) — default-deny always on |
 | Local SQLite message cache | Not implemented | telegram-mcp-server (kfastov) — background sync |
 | Enterprise IdP / OAuth2 | Not implemented | StackOne — managed OAuth |
 
@@ -74,12 +84,13 @@ Configured in [src/config/server_config.py](../src/config/server_config.py). Doc
 
 | Document | Contents |
 | --- | --- |
-| [Roadmap.md](Roadmap.md) | Official product roadmap and branch layout |
+| [Roadmap.md](Roadmap.md) | Official product roadmap |
+| [research/acl-operator-research.md](research/acl-operator-research.md) | ACL competitor audit and personas |
 | [research/gemini-competitive-analysis.md](research/gemini-competitive-analysis.md) | MCP/Telegram landscape, competitor table, ecosystem risks |
 | [research/gemini-strategy-monetization.md](research/gemini-strategy-monetization.md) | Aspirational positioning and monetization hypotheses |
 | [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md) | Proposed features, phase timeline (planned vs shipped) |
-
-ACL design docs live on branch `feature/acl` ([acl-design-brief.md](research/acl-design-brief.md) after merge).
+| [research/gemini-strategy-monetization.md](research/gemini-strategy-monetization.md) | Aspirational positioning and monetization hypotheses |
+| [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md) | Proposed features, phase timeline (planned vs shipped) |
 
 ## See also
 

--- a/docs/adr/0001-agent-scoped-session-acl.md
+++ b/docs/adr/0001-agent-scoped-session-acl.md
@@ -1,0 +1,66 @@
+# ADR 0001: Agent-scoped session ACL (guardrails, not account lockdown)
+
+**Status:** accepted  
+**Date:** 2026-05-27
+
+## Context
+
+fast-mcp-telegram supports **http-auth** hosting: one gateway, many Bearer tokens, typically one Telegram account per token. Operators may run **personal** accounts (one human, one agent) or **shared** accounts (team inbox, automation posting to channels).
+
+Telegram is inherently **multi-device**: the same account remains fully usable in official clients, other bots, and direct API access outside this MCP server. Any policy that assumes “the MCP server is the security perimeter for the Telegram account” is misleading for personal use and incomplete for shared hosting.
+
+**Shared team accounts** add a human threat model beyond agent accidents: multiple people may share one Bearer token on an http-auth host. Chat **lanes** (`chats` allowlist) limit which workspaces an agent may touch, but a malicious or curious teammate with the same token could still read **sensitive Telegram peers** used for account and bot security — e.g. login PIN codes from Telegram’s service user (`777000`), BotFather (`93372553`), and related official bots — unless the server enforces a **sensitive peer denylist** independent of the chat whitelist.
+
+Prior research compared competitors (e.g. default-deny chat ACL in other MCP servers). That informed **mechanisms** (chat whitelist, read-only, search scope) but must not drive our **primary goal**: enterprise zero-trust account lockdown or feature parity as the north star.
+
+## Decision
+
+**Session ACL is agent guardrails** — scoped **lanes** for MCP/MTProto tool use per Bearer token, not account-wide lockdown.
+
+| Lens | Meaning |
+| --- | --- |
+| **Scope** | Workspace **lane**: which chats an agent profile may touch via tools |
+| **Capabilities** | Agent **profiles**: read, write (send/edit), search, MTProto — expressed as `read_only`, `allow_global_search`, future `allow_mtproto`, etc. |
+| **Default for personal** | Opt-in ACL; tokens **omitted** from config keep full tool access (human Telegram use unchanged) |
+| **Default for multi-tenant** | `ACL_DEFAULT=deny` may be offered later; **not** the recommended default for personal/demo hosting |
+
+ACL applies only when **`ACL_ENABLED=true`** on **http-auth**. No ACL on stdio or http-no-auth in the current design.
+
+Human operators continue to use Telegram normally; guardrails reduce **accidental** cross-lane data mixup and **inadvertent** destructive tool actions by agents connected through this server, and — for shared tokens — **intentional** reads of security-sensitive peers via MCP tools.
+
+**Sensitive peer denylist:** When ACL is enabled, a server-maintained set of peer ids (login/service notifications, BotFather, etc.) is **always denied** for MCP tool access, even if a token’s `chats` allowlist would otherwise include them. Operators may **extend** the denylist per deployment; they cannot disable built-in defaults. This is guardrails for **blast radius on shared tokens**, not a substitute for rotating compromised tokens or Telegram-side 2FA.
+
+## Consequences
+
+### Policy model
+
+- Static server-side file (`acl.yaml` / JSON); no MCP tool to edit ACL in v1.
+- Enforcement at tool boundaries (pre-check + post-filter where needed).
+- Errors should name the fix (token, chat id, flag) for operators and agents.
+
+### Defaults and phases
+
+- **Phase 1 (merge blockers):** correctness and operator docs — empty `chats` leak fix, malformed token handling, `read_only` requires `chats` validation, SECURITY.md runbook, alignment with this ADR.
+- **Phase 1.5 (Trust lane):** **sensitive peer denylist** — server defaults always on when `ACL_ENABLED`; optional operator `blocked_peers.extend`; enforced on chat-scoped tools, `find_chats` / global search post-filters, and `invoke_mtproto` / MTProto bridge (no bypass). See [acl-design-brief.md](../research/acl-design-brief.md).
+- **Phase 2 (v1.5):** `ACL_DEFAULT` env (default `full_access`), `allow_mtproto` default false for listed tokens, `allow_global_search` blocks MTProto for agent profiles, enforcement registry, config warnings.
+- **Phase 3 (roadmap, deferred):** file-watch reload, external ACL store, per-chat permission matrix — lower priority than agent-profile guardrails.
+
+### Documentation tone
+
+- Describe ACL as **lanes and agent profiles**, not “zero-trust” or “security perimeter.”
+- Competitor default-deny is a **reference**, not a product requirement.
+- Roadmap **Trust** lane: blast-radius and agent correctness for shared hosting, not replacing Telegram account security.
+- Shared-team threat: document that ACL + lanes do **not** stop a teammate with the raw Bearer token from calling the API outside MCP; sensitive peer blocking addresses **in-server** exfiltration of login codes and bot-administration chats only.
+
+### Deferred
+
+- Prgebish-style per-operation matrix (`draft`, `mark_read`, per-chat send/read split) — Phase 3 unless operator demand.
+- Dynamic ACL via agents; username→id resolve at load; ACL-aware SQLite cache — roadmap items.
+- Stdio filesystem sandbox — separate track.
+
+## References
+
+- [acl-design-brief.md](../research/acl-design-brief.md) — policy model and phases
+- [acl-operator-research.md](../research/acl-operator-research.md) — competitor notes (reference only)
+- [Roadmap.md](../Roadmap.md) — Trust lane
+- [session_acl.py](../../src/server_components/session_acl.py) — implementation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records
+
+Concise records of significant technical decisions for fast-mcp-telegram.
+
+## Convention
+
+| Field | Rule |
+| --- | --- |
+| **Location** | `docs/adr/NNNN-short-title.md` |
+| **Numbering** | Four-digit sequence (`0001`, `0002`, …) |
+| **Status** | `proposed`, `accepted`, `superseded`, `deprecated` |
+| **Length** | Prefer under ~100 lines; English only |
+| **Links** | Reference research notes, code paths, and [Roadmap.md](../Roadmap.md) lanes when relevant |
+
+## Index
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](0001-agent-scoped-session-acl.md) | Agent-scoped session ACL (guardrails, not account lockdown) | accepted (2026-05-27) |

--- a/docs/research/acl-design-brief.md
+++ b/docs/research/acl-design-brief.md
@@ -1,0 +1,80 @@
+# Session ACL design brief (v1)
+
+Status: **Approved for implementation** (2026-05-26). Implements opt-in static ACL for `http-auth` only.
+
+## Goals
+
+- Limit blast radius for shared http-auth hosting without breaking tokens that have no ACL entry.
+- Support four operator personas from [acl-operator-research.md](acl-operator-research.md).
+- No MCP tool to change ACL in v1 (server-side file only).
+
+## Non-goals (v1)
+
+- Default-deny for all tokens
+- Dynamic/runtime ACL updates via agents
+- Per-operation matrix beyond `read_only` + `allow_global_search`
+- ACL on stdio or http-no-auth modes
+- Chat resolution by username at config load (match normalized ids/usernames at enforcement time)
+
+## Configuration
+
+Enable with `ACL_ENABLED=true`. Optional path override: `ACL_CONFIG_PATH` (default `{session_directory}/acl.yaml`). JSON (`.json`) also supported.
+
+### Schema
+
+```yaml
+# Tokens omitted from this file retain full account access when ACL is enabled.
+tokens:
+  "<bearer-token>":
+    chats:
+      - me                    # Saved Messages
+      - "@workgroup"          # username without requiring live resolve at load
+      - -1001234567890        # numeric chat/channel id
+    read_only: false         # default false
+    allow_global_search: true  # default true
+```
+
+### Persona presets (operator examples)
+
+| Persona | Example rule |
+| --- | --- |
+| personal_demo | *(omit token from file)* |
+| team_shared | `chats: [work ids…]`, `read_only: false`, `allow_global_search: true` |
+| readonly_analyst | `chats: [...]`, `read_only: true`, `allow_global_search: true` |
+| automation_bot | `chats: [channel ids…]`, `read_only: false`, `allow_global_search: false` |
+
+When `chats` is empty for a listed token, all chat-scoped operations are denied.
+
+## Enforcement map
+
+| Tool / route | Pre-check | Post-filter |
+| --- | --- | --- |
+| `get_messages` | `chat_id` in whitelist | — |
+| `get_chat_info` | `chat_id` in whitelist | — |
+| `send_message`, `edit_message` | whitelist + not `read_only` | — |
+| `send_message_to_phone` | blocked if whitelist configured | — |
+| `find_chats` | — | filter `chats[]` to whitelist |
+| `search_messages_globally` | `allow_global_search` | filter `messages[]` to whitelist |
+| `invoke_mtproto` | blocked when `read_only` | — |
+| `POST /mtproto-api/*` | blocked when `read_only` | — |
+
+Errors use MCP-style `ok: false` with HTTP 403 on MTProto bridge.
+
+## Implementation
+
+- Module: [src/server_components/session_acl.py](../../src/server_components/session_acl.py)
+- Decorator: `enforce_session_acl` in [tools_register.py](../../src/server_components/tools_register.py)
+- Config: [server_config.py](../../src/config/server_config.py) — `ACL_ENABLED`, `ACL_CONFIG_PATH`
+- Example: [acl.yaml.example](../../acl.yaml.example)
+- Tests: [tests/test_session_acl.py](../../tests/test_session_acl.py)
+
+## Future (v2 candidates)
+
+- Permission matrix: `read`, `send`, `edit` per chat (Prgebish parity)
+- Admin HTTP API to reload ACL without restart
+- Username→id resolution at config load
+- ACL-aware SQLite cache (only sync whitelisted chats)
+
+---
+
+[← Operator research](acl-operator-research.md) · [Roadmap](../Roadmap.md)

--- a/docs/research/acl-design-brief.md
+++ b/docs/research/acl-design-brief.md
@@ -1,80 +1,244 @@
-# Session ACL design brief (v1)
+# Session ACL design brief — agent guardrails
 
-Status: **Approved for implementation** (2026-05-26). Implements opt-in static ACL for `http-auth` only.
+**Status:** Approved direction (2026-05-27). Supersedes zero-trust / account-lockdown framing.  
+**ADR:** [ADR 0001 — Agent-scoped session ACL](../adr/0001-agent-scoped-session-acl.md).
 
-## Goals
+## First principles
 
-- Limit blast radius for shared http-auth hosting without breaking tokens that have no ACL entry.
-- Support four operator personas from [acl-operator-research.md](acl-operator-research.md).
-- No MCP tool to change ACL in v1 (server-side file only).
 
-## Non-goals (v1)
+| Principle                       | Implication                                                                                                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Telegram is multi-device**    | Humans use the account outside MCP; ACL does not “secure the account.”                                                                                        |
+| **MCP is an agent surface**     | Guardrails limit what **connected agents** can do via tools, not human clients.                                                                               |
+| **Lanes, not lockdown**         | Each Bearer token maps to a **workspace lane** (chat set + capability profile).                                                                               |
+| **Opt-in for personal hosting** | Unlisted tokens keep full tool access; avoids breaking demos and single-user setups.                                                                          |
+| **Shared hosting needs lanes**  | Team/automation tokens get explicit profiles so agents do not mix work and personal chats.                                                                    |
+| **Shared token, human threat**  | Teammates with the same Bearer token can abuse MCP tools; **sensitive peers** (login codes, BotFather) need a server denylist **outside** the chat allowlist. |
 
-- Default-deny for all tokens
-- Dynamic/runtime ACL updates via agents
-- Per-operation matrix beyond `read_only` + `allow_global_search`
-- ACL on stdio or http-no-auth modes
-- Chat resolution by username at config load (match normalized ids/usernames at enforcement time)
 
-## Configuration
+**Not goals:** enterprise zero-trust perimeter, Prgebish default-deny parity, or blocking legitimate human Telegram use. Sensitive peer blocking does **not** stop humans using the official Telegram app or calling Telegram APIs outside this server.
 
-Enable with `ACL_ENABLED=true`. Optional path override: `ACL_CONFIG_PATH` (default `{session_directory}/acl.yaml`). JSON (`.json`) also supported.
+## Learning fields (build–measure–learn)
 
-### Schema
+
+| Field              | Content                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Hypothesis**     | Static per-token lanes plus clear agent profiles prevent accidental cross-chat access and unintended send/MTProto actions without harming personal single-token deployments.                            |
+| **Success signal** | Operators run multiple agents on one http-auth host with confidence; ACL denials are understandable; no reported “empty chats leaked everything” or silent full-access regressions for unlisted tokens. |
+| **Kill / stop**    | If guardrails require default-deny for all tokens to be safe, or if enforcement cannot be centralized without tool drift — narrow to Phase 1 correctness only and defer profile expansion.              |
+
+
+## Policy model
+
+### Scope = workspace lane
+
+- `**chats`**: allowlist of chat ids / `@username` / `me` (Saved Messages) for this token’s lane.
+- Tokens **omitted** from the file: full lane (all chats) when `ACL_ENABLED=true`.
+- Tokens **listed** with empty `chats`: deny chat-scoped operations (explicit empty lane — must not leak all chats).
+
+### Capabilities = agent profiles
+
+Expressed as flags today; named profiles for operators:
+
+
+| Agent profile                         | Typical `chats` | `read_only` | `allow_global_search` | `allow_mtproto` (Phase 2) |
+| ------------------------------------- | --------------- | ----------- | --------------------- | ------------------------- |
+| **full_access** *(default, unlisted)* | —               | false       | true                  | true                      |
+| **analyst**                           | lane list       | true        | true                  | false                     |
+| **team_lane**                         | work ids        | false       | true                  | false                     |
+| **bot**                               | peer ids        | false       | false                 | false                     |
+
+
+Phase 2 adds `**allow_mtproto`** (default **false** for listed tokens). When `allow_global_search` is false, MTProto remains blocked for that profile even if `read_only` is false.
+
+### Sensitive peers = server denylist (Phase 1.5)
+
+Orthogonal to **workspace lane** (`chats` allowlist):
+
+
+| Dimension           | `chats` (lane)                                               | `blocked_peers` (sensitive)                                          |
+| ------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| **Question**        | Which chats may this token use?                              | Which peers must **never** be reachable via MCP tools?               |
+| **Default**         | Unlisted token → all chats; listed empty → deny all chat ops | **Built-in server list always applied** when `ACL_ENABLED`           |
+| **Operator config** | Per-token `chats`                                            | Optional **deployment-wide** `blocked_peers.extend` only             |
+| **Override**        | Per-token allowlist can include work ids                     | Operators **cannot** remove built-in sensitive ids                   |
+| **Threat**          | Agent crosses work/personal boundary                         | Malicious teammate reads login PINs or revokes bots via shared token |
+
+
+Built-in defaults (see [Suggested default denylist](#suggested-default-denylist-research)) target account takeover and bot credential exposure. Human operators still use Telegram clients normally.
+
+**Minimal config shape (planned):**
 
 ```yaml
-# Tokens omitted from this file retain full account access when ACL is enabled.
+# Top-level — applies to every token when ACL_ENABLED=true
+blocked_peers:
+  extend:
+    - 1234567890          # optional numeric peer ids
+    # - "@SomeOfficialBot"  # deferred: resolve at enforcement like chats
+
+tokens:
+  "<bearer-token>":
+    chats: [ ... ]
+    read_only: false
+```
+
+- `**blocked_peers.extend**`: optional operator additions merged **on top of** immutable server defaults (not per-token in v1 — keeps shared-team policy consistent across tokens on one host).
+- **Env alternative (optional implementation):** `ACL_BLOCKED_PEERS_EXTEND` as comma-separated ids for containers without editing YAML.
+- **No `blocked_peers.defaults` in file** — defaults live in code + SECURITY.md; document ids and rationale there.
+
+**Enforcement (when implemented):** same central checks as lane ACL; deny must win if a peer is both in `chats` and on the sensitive list.
+
+
+| Tool / route                            | Behavior                                                                                                                   |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `get_messages`, `get_chat_info`         | Pre-check: `chat_id` not in sensitive set                                                                                  |
+| `send_message`, `edit_message`          | Pre-check: target chat not sensitive                                                                                       |
+| `find_chats`                            | Post-filter: drop sensitive peers from `chats[]`                                                                           |
+| `search_messages_globally`              | Post-filter: drop messages whose peer is sensitive                                                                         |
+| `invoke_mtproto`, `POST /mtproto-api/`* | Pre-check peer/chat/user id arguments where applicable; block TL methods whose target is a sensitive peer (no lane bypass) |
+
+
+Errors should name the peer class (“sensitive peer blocked”) and point to SECURITY.md, not imply the operator can allowlist BotFather via `chats`.
+
+### Environment defaults (Phase 2)
+
+
+| Variable      | Default       | Notes                                                                             |
+| ------------- | ------------- | --------------------------------------------------------------------------------- |
+| `ACL_ENABLED` | false         | Opt-in                                                                            |
+| `ACL_DEFAULT` | `full_access` | Optional `deny` for strict multi-tenant; **not** recommended default for personal |
+
+
+## Configuration (current + planned)
+
+Enable with `ACL_ENABLED=true`. Path: `ACL_CONFIG_PATH` or `{session_directory}/acl.yaml`. JSON supported.
+
+```yaml
+# Agent guardrails: per-token lane + profile. Unlisted tokens = full_access.
+# When ACL is enabled, server-built-in sensitive peers are always blocked via MCP;
+# optional deployment extension (Phase 1.5):
+# blocked_peers:
+#   extend: []
+
 tokens:
   "<bearer-token>":
     chats:
-      - me                    # Saved Messages
-      - "@workgroup"          # username without requiring live resolve at load
-      - -1001234567890        # numeric chat/channel id
-    read_only: false         # default false
-    allow_global_search: true  # default true
+      - me
+      - "@workgroup"
+      - -1001234567890
+    read_only: true
+    allow_global_search: true
+    # allow_mtproto: false   # Phase 2 — default false when token is listed
 ```
 
-### Persona presets (operator examples)
+See [acl.yaml.example](../../acl.yaml.example).
 
-| Persona | Example rule |
-| --- | --- |
-| personal_demo | *(omit token from file)* |
-| team_shared | `chats: [work ids…]`, `read_only: false`, `allow_global_search: true` |
-| readonly_analyst | `chats: [...]`, `read_only: true`, `allow_global_search: true` |
-| automation_bot | `chats: [channel ids…]`, `read_only: false`, `allow_global_search: false` |
+## Enforcement map (MVP + registry target)
 
-When `chats` is empty for a listed token, all chat-scoped operations are denied.
 
-## Enforcement map
+| Tool / route                   | Pre-check                               | Post-filter                 |
+| ------------------------------ | --------------------------------------- | --------------------------- |
+| `get_messages`                 | `chat_id` in lane                       | —                           |
+| `get_chat_info`                | `chat_id` in lane                       | —                           |
+| `send_message`, `edit_message` | lane + not `read_only`                  | —                           |
+| `send_message_to_phone`        | blocked if lane configured              | —                           |
+| `find_chats`                   | —                                       | filter `chats[]` to lane    |
+| `search_messages_globally`     | `allow_global_search`                   | filter `messages[]` to lane |
+| `invoke_mtproto`               | `read_only` / `allow_mtproto` (Phase 2) | —                           |
+| `POST /mtproto-api/*`          | same as invoke                          | —                           |
 
-| Tool / route | Pre-check | Post-filter |
-| --- | --- | --- |
-| `get_messages` | `chat_id` in whitelist | — |
-| `get_chat_info` | `chat_id` in whitelist | — |
-| `send_message`, `edit_message` | whitelist + not `read_only` | — |
-| `send_message_to_phone` | blocked if whitelist configured | — |
-| `find_chats` | — | filter `chats[]` to whitelist |
-| `search_messages_globally` | `allow_global_search` | filter `messages[]` to whitelist |
-| `invoke_mtproto` | blocked when `read_only` | — |
-| `POST /mtproto-api/*` | blocked when `read_only` | — |
 
-Errors use MCP-style `ok: false` with HTTP 403 on MTProto bridge.
+Central **enforcement registry** (Phase 2): one map from tool/route → checks to avoid drift.
 
-## Implementation
+Errors: MCP `ok: false` with actionable text; HTTP 403 on MTProto bridge.
 
-- Module: [src/server_components/session_acl.py](../../src/server_components/session_acl.py)
-- Decorator: `enforce_session_acl` in [tools_register.py](../../src/server_components/tools_register.py)
-- Config: [server_config.py](../../src/config/server_config.py) — `ACL_ENABLED`, `ACL_CONFIG_PATH`
-- Example: [acl.yaml.example](../../acl.yaml.example)
-- Tests: [tests/test_session_acl.py](../../tests/test_session_acl.py)
+## Implementation pointers
 
-## Future (v2 candidates)
+- [session_acl.py](../../src/server_components/session_acl.py)
+- `enforce_session_acl` in [tools_register.py](../../src/server_components/tools_register.py)
+- [server_config.py](../../src/config/server_config.py) — `ACL_ENABLED`, `ACL_CONFIG_PATH`
+- [tests/test_session_acl.py](../../tests/test_session_acl.py)
+- Operator runbook: [SECURITY.md](../../SECURITY.md) (Phase 1 alignment)
 
-- Permission matrix: `read`, `send`, `edit` per chat (Prgebish parity)
-- Admin HTTP API to reload ACL without restart
-- Username→id resolution at config load
-- ACL-aware SQLite cache (only sync whitelisted chats)
+## Phased delivery
+
+### Phase 1 — merge blockers (Trust lane)
+
+
+| Item                                    | Rationale                                              |
+| --------------------------------------- | ------------------------------------------------------ |
+| Empty `chats` leak fix                  | Listed token with `chats: []` must deny, not allow all |
+| Malformed token handling                | Safe parsing; clear errors                             |
+| `read_only` requires `chats` validation | Analyst profile must define a lane                     |
+| SECURITY.md operator runbook            | How to enable ACL, profiles, troubleshooting           |
+| ADR + brief alignment                   | Agent-guardrails vocabulary in docs                    |
+
+
+### Phase 1.5 — sensitive peer denylist (Trust lane)
+
+
+| Item                       | Rationale                                              |
+| -------------------------- | ------------------------------------------------------ |
+| Server default denylist    | `777000`, BotFather, etc. — not removable by operators |
+| `blocked_peers.extend`     | Optional deployment-wide extras                        |
+| Tool + MTProto enforcement | No bypass via `invoke_mtproto` or global search        |
+| SECURITY.md section        | List defaults, shared-team threat, extend syntax       |
+| Tests                      | Deny read/send/search for built-in ids; extend merges  |
+
+
+**Placement:** After Phase 1 merge blockers, **before** Phase 2 `allow_mtproto` / registry — so raw MTProto cannot read login-code chats while profile flags are still catching up.
+
+### Phase 2 — v1.5 guardrails
+
+
+| Item                                 | Rationale                                               |
+| ------------------------------------ | ------------------------------------------------------- |
+| `ACL_DEFAULT` env                    | `full_access` default; optional `deny` for multi-tenant |
+| `allow_mtproto`                      | Default false for listed tokens                         |
+| `allow_global_search` blocks MTProto | Bot profile cannot bypass via raw MTProto               |
+| Enforcement registry                 | DRY tool/route registration                             |
+| Config load warnings                 | Unknown keys, empty lane, risky combos                  |
+
+
+### Phase 3 — roadmap (deferred, lower priority)
+
+- File-watch reload without restart
+- External ACL store (e.g. object storage / API)
+- Per-chat permission matrix (read/send/edit split)
+- **Chat metadata registry** — operator-curated titles, descriptions, tags, and navigation hints for lane chats; complements allowlists so team agents can interpret `find_chats` results (see [Roadmap](../Roadmap.md) Trust lane)
+
+## Suggested default denylist (research)
+
+Document in SECURITY.md at implementation time; verify ids on a live account if disputes arise.
+
+
+| Peer id             | Handle / role                                            | Why block MCP access                                                                                                                                                                                          |
+| ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **777000**          | Telegram service / login notifications                   | Delivers **login verification codes** and security alerts ([Telegram API auth](https://core.telegram.org/api/auth) — “login notification service user”). Reading via MCP = credential theft on shared tokens. |
+| **93372553**        | [@BotFather](https://t.me/BotFather)                     | Create/revoke bots, reveal **bot tokens**, change bot settings — full bot-account takeover.                                                                                                                   |
+| **178220800**       | [@SpamBot](https://t.me/spambot)                         | Official spam/limit status and appeals — account state manipulation; common in restriction workflows.                                                                                                         |
+| *Research / tier-2* | @VerifyBot, @PremiumBot, @PressBot, “Telegram Tips” bots | Official flows; add after confirming stable numeric ids on production accounts.                                                                                                                               |
+| *Research / tier-2* | Human “Telegram Support” in-app chat                     | May not be a stable user id across locales; prefer in-app only.                                                                                                                                               |
+
+
+**Caveats:**
+
+- **777000** may appear as `from` on some channel/group messages (Telegram backward-compat); enforcement should use the **target chat** of the tool call, not heuristic blocking of unrelated group traffic unless product decision says otherwise.
+- Denylist is **numeric id** at enforcement time; `@username` in `extend` follows the same deferred-resolve pattern as `chats`.
+- New official security bots should be added via server release + changelog, not silently relying on operators to extend.
+
+## Non-goals
+
+- ACL on stdio or http-no-auth (current)
+- Per-token sensitive-peer overrides (allow BotFather for one token) — undermines shared-team model; use separate Telegram account + token instead
+- MCP tool to mutate ACL at runtime
+- Chat resolution by username at config load (match at enforcement time)
+- Replacing Telegram account security or human client access
+
+## Competitor notes (reference only)
+
+[acl-operator-research.md](acl-operator-research.md) documents Prgebish default-deny and others for **mechanism ideas**, not as the product north star.
 
 ---
 
-[← Operator research](acl-operator-research.md) · [Roadmap](../Roadmap.md)
+[← ADR 0001](../adr/0001-agent-scoped-session-acl.md) · [Operator research](acl-operator-research.md) · [Roadmap](../Roadmap.md)

--- a/docs/research/acl-operator-research.md
+++ b/docs/research/acl-operator-research.md
@@ -1,0 +1,79 @@
+# Session ACL: competitor audit and operator personas
+
+Research date: 2026-05-26. Sources: public docs and READMEs for Prgebish/mcp-telegram, chigwell/telegram-mcp, kfastov/telegram-mcp-server.
+
+## Competitor models
+
+### Prgebish/mcp-telegram (Go)
+
+| Aspect | Model |
+| --- | --- |
+| Default policy | **Default-deny** — no chat accessible unless whitelisted in `acl.chats` |
+| Config | Single YAML file with env expansion |
+| Match keys | `@username`, `user:ID`, `channel:ID`, phone |
+| Permissions | Per-chat: `read`, `send`, `draft`, `mark_read` |
+| Tool gating | `tg_history`/`tg_search` need `read`; `tg_send` needs `send` |
+| Dialog listing | `tg_dialogs` returns **only** ACL-visible chats |
+| Filesystem | `allowed_upload_dirs`, `media.directory` boundaries |
+| Rate limiting | Built-in token bucket middleware |
+| Multi-user | Single-user process (one config file) |
+
+**Takeaway:** Strongest ACL story; chat + operation matrix; default-deny is safe but breaks backward compatibility for open demos.
+
+### chigwell/telegram-mcp (Python / Telethon)
+
+| Aspect | Model |
+| --- | --- |
+| Access control | **No per-chat ACL** — full account access |
+| File paths | MCP Roots / CLI allowlist for file-path tools (deny-all until roots configured) |
+| Tool count | 60+ narrow tools (high context cost) |
+| Multi-user | Local stdio / single instance |
+
+**Takeaway:** Security focus is filesystem roots, not Telegram chat scope. Not a direct ACL competitor for http-auth hosting.
+
+### kfastov/telegram-mcp-server (Node / MtCute)
+
+| Aspect | Model |
+| --- | --- |
+| Access control | **No formal ACL** |
+| Persistence | SQLite `data/messages.db` + background sync jobs |
+| Sync tools | `scheduleMessageSync`, `listMessageSyncJobs` |
+| Transport | Streamable HTTP `/mcp` |
+| Multi-user | Single-user local deployment |
+
+**Takeaway:** Performance via offline archive, not tenant scoping. Relevant for Phase 2 SQLite backlog.
+
+### fast-mcp-telegram (this project, before ACL MVP)
+
+| Aspect | Model |
+| --- | --- |
+| Multi-user | Per-token `.session` files + Bearer auth on http-auth |
+| Scope | **Full account** per valid token |
+| Files (HTTP) | Local paths blocked; URL SSRF checks |
+| Files (stdio) | Local paths allowed (no sandbox) |
+
+---
+
+## Persona → competitor fit
+
+| Persona | Need | Best reference |
+| --- | --- | --- |
+| **personal_demo** | Full account try-out on public host | fast-mcp-telegram today (no ACL entry) |
+| **team_shared** | Work chats only per token | Prgebish chat whitelist |
+| **readonly_analyst** | Read/search, no send/edit/mtproto | Prgebish `read` without `send` |
+| **automation_bot** | Send to specific channels; no global exfil | Chat whitelist + block global search |
+
+---
+
+## Recommended direction for fast-mcp-telegram
+
+1. **Opt-in ACL** (not Prgebish default-deny globally) — tokens without config keep full access for tg-mcp demo compatibility.
+2. **Per-token rules** keyed by Bearer token string in server-side file (not agent-configurable).
+3. **Dimensions for v1:** `chats`, `read_only`, `allow_global_search` — covers all four personas without a full permission matrix yet.
+4. **Defer** Prgebish-style `draft`/`mark_read` granularity and filesystem ACL until stdio sandbox track.
+
+See [acl-design-brief.md](acl-design-brief.md) for schema and enforcement map.
+
+---
+
+[← Strategic index](../Strategic-Market-Positioning.md) · [Design brief →](acl-design-brief.md)

--- a/docs/research/gemini-competitive-analysis.md
+++ b/docs/research/gemini-competitive-analysis.md
@@ -1,0 +1,64 @@
+# Gemini Research: Competitive Landscape and Ecosystem Analysis
+
+> **Source:** [Gemini shared research](https://gemini.google.com/share/b1d8cb8b23c2) (2026-05-26). Unverified third-party analysis — competitor cells marked *unverified* were not independently checked. For current product facts see [Strategic-Market-Positioning.md](../Strategic-Market-Positioning.md).
+
+## Competitive Landscape Analysis of Telegram MCP Infrastructure
+
+The rapid expansion of the Model Context Protocol (MCP) has shifted the paradigm of artificial intelligence integration, transitioning large language models (LLMs) from static knowledge retrievers to active agents capable of executing real-world tasks. Messaging channels are becoming critical interfaces for autonomous agents.
+
+Integrating AI with Telegram presents infrastructure challenges:
+
+- Session state isolation
+- Strict API rate-limiting
+- Risk of account suspension
+- Excessive token usage during tool discovery
+
+The open-source project **fast-mcp-telegram** addresses these challenges by acting as an asynchronous, Python-based MCP server built on the FastMCP framework. By combining direct Telegram User API (MTProto) access with an HTTP-MTProto bridge, it supports remote-ready multi-user configuration that bypasses typical Bot API limitations.
+
+### Competitor comparison
+
+| Feature | fast-mcp-telegram | telegram-mcp (chigwell) | mcp-telegram (Prgebish) | telegram-mcp (chaindead) | telegram-mcp-server (kfastov) | StackOne Telegram MCP |
+| --- | --- | --- | --- | --- | --- | --- |
+| Core language & runtime | Python / FastMCP | Python / Telethon | *unverified* | Go | Node.js / MtCute | Enterprise SaaS platform |
+| Protocol interface | MTProto User API | MTProto User API | MTProto User API | MTProto User API | MTProto User API | Telegram Bot API *unverified* |
+| Security & authorization | Multi-user Bearer auth, web setup, per-token session files; **no per-chat ACL** | Bot token or single-user env auth | Strict default-deny ACL, per-chat permissions, filesystem boundaries | Single-user local session | Local env vars, session file serialization | Managed IdP, OAuth, prompt-injection defense *unverified* |
+| Tooling philosophy | **AI-optimized:** 8 consolidated tools with multi-parameter signatures | **Feature-heavy:** 60+ narrow tools *unverified count* | *unverified* | Standard messaging, drafts, dialog management | **Database-centric:** SQLite background sync | Dynamic tool discovery; “96% context reduction” *unverified marketing claim* |
+| Deployment topology | **Three modes:** stdio, http-no-auth, http-auth; Docker + manual Traefik labels | Local stdio, single-instance bot gateways | Local Go binary or npx *unverified* | *unverified* | Local Node.js + SQLite | Managed multi-tenant cloud |
+
+## Deconstruction of Ecosystem Vulnerabilities and Tooling Overheads
+
+### Security vulnerabilities and file-handling deficiencies
+
+MCP servers grant autonomous agents programmatic access to local or remote system APIs. This introduces significant security risks when input validation is overlooked.
+
+According to third-party audits by the open-source security scanner **Sigil** *unverified — no link or date in source report*, several highly installed MCP servers failed verification tests due to severe vulnerability patterns in file-handling logic.
+
+Without path restrictions, an agent manipulated by indirect prompt injection could read sensitive local files via unrestricted download directories.
+
+**fast-mcp-telegram today** (corrected vs original report):
+
+- **Stdio mode:** local file paths are allowed for attachments — there is **no** directory allowlist or sandbox
+- **HTTP modes:** local paths are **rejected**; only URL downloads with SSRF validation ([SECURITY.md](../../SECURITY.md))
+
+Open-source **mcp-telegram** (Prgebish) offers a strict default-deny ACL — a capability **fast-mcp-telegram does not yet ship**. See [gemini-roadmap-proposal.md](gemini-roadmap-proposal.md) for the proposed ACL work.
+
+### The identity paradox: User Client API (MTProto) versus Bot API
+
+Standard Bot API platforms are relatively easy to deploy but impose limitations on search, history depth, and user-like behavior.
+
+**User API (MTProto)** tools bypass these restrictions, allowing the AI agent to search, read, and write as the authenticated user.
+
+Risks:
+
+- Session files under `~/.config/fast-mcp-telegram/` must be protected; compromise grants full account access
+- Rapid LLM queries can trigger Telegram `FLOOD_WAIT` errors
+
+### The prompt window "tax" of expansive tool catalogs
+
+When an MCP agent connects, tool schemas are injected into the prompt. “Kitchen-sink” servers with dozens of narrow tools consume thousands of tokens per turn.
+
+**fast-mcp-telegram** ships **8 consolidated tools** (see [Strategic-Market-Positioning.md](../Strategic-Market-Positioning.md)). Some MCP clients have JSON Schema compatibility limitations; treat client-specific schema issues as environment-dependent.
+
+---
+
+[← Index](../Strategic-Market-Positioning.md) · [Strategy & monetization →](gemini-strategy-monetization.md)

--- a/docs/research/gemini-roadmap-proposal.md
+++ b/docs/research/gemini-roadmap-proposal.md
@@ -1,0 +1,67 @@
+# Gemini Research: Proposed Roadmap and Implementation Phases
+
+> **Source:** [Gemini shared research](https://gemini.google.com/share/b1d8cb8b23c2) (2026-05-26). Items in **Proposed** are not implemented unless marked **Shipped**. See [Strategic-Market-Positioning.md](../Strategic-Market-Positioning.md) for verified current state.
+
+## Already shipped (media and security baseline)
+
+The original report listed these under “future” roadmap item 5. They exist today:
+
+| Capability | Location |
+| --- | --- |
+| SSRF-protected URL downloads | [src/tools/messages/security.py](../../src/tools/messages/security.py), [SECURITY.md](../../SECURITY.md) |
+| Attachment streaming | `GET /v1/attachments/{uuid}/{filename}` — [src/server_components/attachment_routes.py](../../src/server_components/attachment_routes.py) |
+| Premium voice transcription | [src/utils/message_format.py](../../src/utils/message_format.py) |
+| Attachment URLs in tool output | [src/utils/message_format.py](../../src/utils/message_format.py) |
+
+## Proposed next-generation features
+
+### 1. Dynamic zero-trust ACL engine
+
+Transition from static configuration to dynamic ACL for secure multi-user deployments.
+
+- **Mechanism:** Load `acl.yaml` or JSON ACL at session init; map tokens to permitted `chat_id` values
+- **Target tool:** `configure_session_acl`
+- **Enforcement:** Block `get_messages` / `send_message` when `chat_id` is not whitelisted
+
+### 2. Pre-execution payload filtering and indirect prompt injection defense
+
+- **Mechanism:** Scan payloads from `get_messages` and `search_messages_globally` before they reach the LLM
+- **Target tool:** `sanitize_chat_context`
+- **Note:** today only log param sanitization exists in [src/utils/logging_utils.py](../../src/utils/logging_utils.py) — not message-content scanning
+
+### 3. Asynchronous SQLite archiving and differential synchronization
+
+Inspired by kfastov message-sync:
+
+- **Mechanism:** Background worker per session; incremental SQLite archive with sync cursors
+- **Target tool:** `sync_chat_history`
+- **Impact:** Local queries instead of outbound MTProto; reduced `FLOOD_WAIT` risk
+
+### 4. Dynamic multi-tenant OAuth2 and identity broker integration
+
+- **Mechanism:** OAuth2 Token Exchange (RFC 8693) with Keycloak, Okta, etc.
+- **Target tool:** `broker_user_session`
+- **Goal:** Short-lived MTProto sessions mapped from enterprise JWTs
+
+### 5. Extended media processing (net-new only)
+
+Shipped baseline covers download, SSRF checks, and voice transcription. Remaining proposals:
+
+- **Target tool:** `extract_and_process_media` — unified download + validate + OCR/transcription pipeline
+- **Future:** sandboxed attachment storage, non-voice media pipelines, document OCR
+
+## Implementation phases
+
+| Phase | Horizon | Planned scope | Already shipped in this area |
+| --- | --- | --- | --- |
+| Phase 1: Security hardening | Short-term | Default-deny ACL, directory sandbox for stdio paths, I/O injection scanner | SSRF URL validation; HTTP local-path blocking; attachment tickets |
+| Phase 2: Offline archiving | Medium-term | SQLite background sync; local query path | — |
+| Phase 3: Identity federation | Long-term | OAuth2 token exchange; Keycloak/Vault credential mapping | Bearer tokens + web setup only |
+
+## Strategic outcome (research summary)
+
+Repositioning as a secure multi-tenant gateway addresses real ecosystem gaps (context overhead, session brokerage). The phased plan above separates **shipped** security primitives from **planned** ACL, archiving, and IdP work.
+
+---
+
+[← Strategy & monetization](gemini-strategy-monetization.md) · [Index](../Strategic-Market-Positioning.md)

--- a/docs/research/gemini-strategy-monetization.md
+++ b/docs/research/gemini-strategy-monetization.md
@@ -1,0 +1,59 @@
+# Gemini Research: Recommended Positioning and Monetization
+
+> **Source:** [Gemini shared research](https://gemini.google.com/share/b1d8cb8b23c2) (2026-05-26). Everything in this document is **aspirational research** — not an official project commitment. For shipped features see [Strategic-Market-Positioning.md](../Strategic-Market-Positioning.md).
+
+## Recommended positioning (aspirational)
+
+Suggested narrative to maximize adoption:
+
+> **The Secure, Multi-Tenant Agent Communication Gateway for High-Performance AI Teams & Regulated Compliance Environments**
+
+This shifts the story from a personal developer tool to team/enterprise infrastructure. **Future work** would be required for most security claims below.
+
+### Multi-user security and session isolation (future)
+
+- **Future:** strict default-deny ACL and per-session chat whitelists
+- **Today:** opaque Bearer tokens with per-token `.session` file isolation; tokens are not encrypted at rest
+- **Today:** one user's token cannot access another user's session file, but each token has **full account scope** (no chat limits)
+- **Future:** sandboxed directory allowlists for stdio local paths
+- **Today:** HTTP modes reject local paths; URL downloads use SSRF checks ([SECURITY.md](../../SECURITY.md))
+
+### Optimized context window orchestration (partially shipped)
+
+- **Today:** 8 consolidated MCP tools with rich parameter surfaces ([Tools-Reference.md](../Tools-Reference.md))
+- **Future:** further schema optimization for specific MCP clients
+
+### Decentralized session brokerage (partially shipped)
+
+- **Today:** remote web-setup interface and HTTP-MTProto bridge ([Installation.md](../Installation.md), [MTProto-Bridge.md](../MTProto-Bridge.md))
+- **Today:** single gateway instance routes multiple users via distinct Bearer tokens
+- **Future:** OAuth2 / enterprise IdP federation (see [gemini-roadmap-proposal.md](gemini-roadmap-proposal.md))
+
+## Practical monetization architecture (research hypotheses only)
+
+The models below are **external research ideas**. The project has not committed to any monetization path.
+
+### Model 1: Pay-per-tool-call micropayments
+
+Using billing proxies like **xpay** or **MCP-Hive**:
+
+- Register the host server; proxy auto-discovers tools and sets per-invocation pricing
+- Clients connect via proxy URL with API key; payment via **x402** protocol *unverified integration*
+
+### Model 2: Contextual agentic advertising
+
+Integrate something like the **Kone SDK** into tool outputs for intent-matched sponsor metadata. Revenue via CPC/CPM *speculative*.
+
+### Model 3: Apify Store managed hosting
+
+Package as an Apify Actor with Standby Mode for persistent HTTP. Apify handles billing/tax; subscription tiers (e.g. $9/month) *illustrative*.
+
+### Model 4: B2B enterprise compliance archiving
+
+> **Disclaimer:** fast-mcp-telegram does **not** provide SEC/FINRA/HIPAA archiving today. Penalty figures and regulatory trends in the source report are **unsourced** — verify independently; this is not legal advice.
+
+Concept: package the multi-user HTTP bridge as a compliance sync agent into immutable audit stores. Illustrative pricing: $15–50/seat/month plus setup fees.
+
+---
+
+[← Competitive analysis](gemini-competitive-analysis.md) · [Roadmap proposal →](gemini-roadmap-proposal.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fast-mcp-telegram"
-version = "0.19.0"
+version = "0.20.0"
 description = "MCP server with Telegram search and messaging capabilities"
 authors = [
     {name = "Alexey Leshchenko", email = "leshchenko@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fast-mcp-telegram"
-version = "0.19.1"
+version = "0.19.0"
 description = "MCP server with Telegram search and messaging capabilities"
 authors = [
     {name = "Alexey Leshchenko", email = "leshchenko@gmail.com"}
@@ -29,7 +29,8 @@ dependencies = [
     "telethon",
     "TelethonFakeTLS",  # For fake TLS (EE prefix) MTProto proxy support
     "jinja2",
-    "pydantic-settings"
+    "pydantic-settings",
+    "pyyaml",
 ]
 
 [project.urls]

--- a/scripts/acl_mcp_smoke.sh
+++ b/scripts/acl_mcp_smoke.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Minimal ACL smoke test: call get_messages as each ACL profile via curl.
+# Requires http-auth server with ACL_ENABLED=true and acl.dev.yaml (see CONTRIBUTING.md).
+#
+# Token resolution (in order):
+#   1. ACL_CONFIG_PATH (default: acl.dev.yaml) — profile keys from tokens: block
+#   2. BEARER_TOKEN_FOR_TESTING — overrides readonly profile when set
+#   3. Example placeholders from acl.dev.yaml.example when config file is missing
+set -euo pipefail
+
+BASE_URL="${ACL_SMOKE_URL:-http://127.0.0.1:8765/v1/mcp}"
+ACL_CONFIG_PATH="${ACL_CONFIG_PATH:-acl.dev.yaml}"
+
+mapfile -t ACL_TOKENS < <(
+  python3 - "$ACL_CONFIG_PATH" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("error: PyYAML required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(1)
+
+DEFAULTS = {
+    "readonly": "dev_acl_readonly_abcdefghijklmnopqrstuvwxz0",
+    "empty_lane": "dev_acl_empty_lane_abcdefghijklmnopqrstuvwx",
+    "team": "dev_acl_team_lane__abcdefghijklmnopqrstuvwx",
+}
+
+def pick_by_prefix(tokens: dict, prefix: str, fallback: str) -> str:
+    for key in tokens:
+        if key.startswith(prefix):
+            return key
+    return fallback
+
+def pick_by_shape(tokens: dict) -> dict[str, str]:
+    profiles = dict(DEFAULTS)
+    readonly_env = os.environ.get("BEARER_TOKEN_FOR_TESTING", "").strip()
+    if readonly_env:
+        profiles["readonly"] = readonly_env
+
+    for key, cfg in tokens.items():
+        if not isinstance(cfg, dict):
+            continue
+        chats = cfg.get("chats") or []
+        read_only = bool(cfg.get("read_only"))
+        if read_only and "me" in chats:
+            profiles["readonly"] = key
+        elif chats == []:
+            profiles["empty_lane"] = key
+        elif not read_only and chats:
+            profiles["team"] = key
+
+    profiles["readonly"] = pick_by_prefix(tokens, "dev_acl_readonly", profiles["readonly"])
+    profiles["empty_lane"] = pick_by_prefix(tokens, "dev_acl_empty_lane", profiles["empty_lane"])
+    profiles["team"] = pick_by_prefix(tokens, "dev_acl_team_lane", profiles["team"])
+    if readonly_env:
+        profiles["readonly"] = readonly_env
+    return profiles
+
+config_path = Path(sys.argv[1])
+if config_path.is_file():
+    data = yaml.safe_load(config_path.read_text()) or {}
+    tokens = data.get("tokens") or {}
+    if not isinstance(tokens, dict):
+        tokens = {}
+    profiles = pick_by_shape(tokens)
+else:
+    profiles = dict(DEFAULTS)
+    readonly_env = os.environ.get("BEARER_TOKEN_FOR_TESTING", "").strip()
+    if readonly_env:
+        profiles["readonly"] = readonly_env
+    print(
+        f"note: {config_path} not found; using example tokens "
+        f"(copy acl.dev.yaml.example → acl.dev.yaml for local profiles)",
+        file=sys.stderr,
+    )
+
+for name in ("readonly", "empty_lane", "team"):
+    print(profiles[name])
+PY
+)
+
+READONLY_TOKEN="${ACL_TOKENS[0]}"
+EMPTY_LANE_TOKEN="${ACL_TOKENS[1]}"
+TEAM_TOKEN="${ACL_TOKENS[2]}"
+
+call_tool() {
+  local token="$1"
+  local label="$2"
+  echo "--- ${label} (${token:0:24}...) ---"
+  curl -sS -X POST "${BASE_URL}" \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "tools/call",
+      "params": {
+        "name": "get_messages",
+        "arguments": {"chat_id": "me", "limit": 1}
+      }
+    }'
+  echo
+}
+
+if ! curl -sS --connect-timeout 2 -o /dev/null "${BASE_URL}" 2>/dev/null; then
+  echo "skip: no server at ${BASE_URL} (start http-auth ACL server on port 8765 first)"
+  exit 0
+fi
+
+call_tool "${READONLY_TOKEN}" "readonly"
+call_tool "${EMPTY_LANE_TOKEN}" "empty-lane"
+call_tool "${TEAM_TOKEN}" "team"

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -183,12 +183,12 @@ def _session_file_exists(session_path: Path) -> bool:
 
 def _unlink_session_file(session_path: Path) -> None:
     """Remove the on-disk Telethon session file for ``session_path``."""
-    path_to_remove = (
-        session_path
-        if session_path.suffix == ".session"
-        else session_path.with_suffix(".session")
-    )
-    path_to_remove.unlink(missing_ok=True)
+    if session_path.suffix == ".session":
+        session_path.unlink(missing_ok=True)
+        return
+    session_path.with_suffix(".session").unlink(missing_ok=True)
+    if session_path.is_file():
+        session_path.unlink(missing_ok=True)
 
 
 async def _safe_disconnect_after_verify_failure(client: TelegramClient) -> None:

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -161,6 +161,36 @@ def _error_message_suggests_auth_issue(exc: BaseException) -> bool:
     return any(s in lowered for s in _AUTH_ERROR_SUBSTRINGS)
 
 
+def _resolve_session_path_for_token(token: str) -> Path:
+    """Map token to Telethon session path.
+
+    When auth is disabled (stdio / http-no-auth), the configured ``session_name``
+    (e.g. ``telegram``) is not a bearer token — use ``config.session_path`` directly.
+    """
+    config = get_config()
+    if config.disable_auth and token == config.session_name:
+        return config.session_path
+    return validated_session_file_path(SESSION_DIR, token)
+
+
+def _session_file_exists(session_path: Path) -> bool:
+    """True if a Telethon session file exists for ``session_path`` (with or without .session suffix)."""
+    if session_path.suffix == ".session":
+        return session_path.is_file()
+    with_suffix = session_path.with_suffix(".session")
+    return with_suffix.is_file() or session_path.is_file()
+
+
+def _unlink_session_file(session_path: Path) -> None:
+    """Remove the on-disk Telethon session file for ``session_path``."""
+    path_to_remove = (
+        session_path
+        if session_path.suffix == ".session"
+        else session_path.with_suffix(".session")
+    )
+    path_to_remove.unlink(missing_ok=True)
+
+
 async def _safe_disconnect_after_verify_failure(client: TelegramClient) -> None:
     try:
         if client.is_connected():
@@ -249,10 +279,10 @@ async def _build_telegram_client_for_token(
 
 
 def _try_unlink_session_on_auth_error(session_path: Path, token: str) -> None:
-    if not session_path.exists():
+    if not _session_file_exists(session_path):
         return
     try:
-        session_path.unlink()
+        _unlink_session_file(session_path)
         logger.warning(
             f"Auto-deleted invalid session file for token {token[:8]}... due to auth error"
         )
@@ -293,7 +323,7 @@ async def _get_client_by_token(token: str) -> TelegramClient:
             return client
 
         try:
-            session_path = validated_session_file_path(SESSION_DIR, token)
+            session_path = _resolve_session_path_for_token(token)
         except InvalidSessionTokenError as e:
             raise SessionNotAuthorizedError("Invalid bearer token") from e
 
@@ -403,12 +433,12 @@ async def ensure_connection(client: TelegramClient, token: str) -> bool:
             )
             # Remove session file immediately to prevent loop
             try:
-                session_path = validated_session_file_path(SESSION_DIR, token)
+                session_path = _resolve_session_path_for_token(token)
             except InvalidSessionTokenError:
                 session_path = None
-            if session_path is not None and session_path.exists():
+            if session_path is not None and _session_file_exists(session_path):
                 try:
-                    session_path.unlink()
+                    _unlink_session_file(session_path)
                     logger.info(f"Removed fatal session file for token {token[:8]}...")
                 except Exception as del_e:
                     logger.warning(f"Failed to remove fatal session file: {del_e}")
@@ -493,12 +523,12 @@ async def cleanup_failed_sessions():
 
             # Remove session file
             try:
-                session_path = validated_session_file_path(SESSION_DIR, token)
+                session_path = _resolve_session_path_for_token(token)
             except InvalidSessionTokenError:
                 continue
-            if session_path.exists():
+            if _session_file_exists(session_path):
                 try:
-                    session_path.unlink()
+                    _unlink_session_file(session_path)
                     logger.info(f"Removed failed session file for token {token[:8]}...")
                 except Exception as e:
                     logger.warning(

--- a/src/config/server_config.py
+++ b/src/config/server_config.py
@@ -200,6 +200,23 @@ class ServerConfig(BaseSettings):
         description="TTL for in-memory attachment download tickets (seconds)",
     )
 
+    acl_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("acl_enabled", "ACL_ENABLED"),
+        description=(
+            "Enable opt-in per-token session ACL from acl config file (http-auth only)"
+        ),
+    )
+
+    acl_config_path: str = Field(
+        default="",
+        validation_alias=AliasChoices("acl_config_path", "ACL_CONFIG_PATH"),
+        description=(
+            "Path to session ACL YAML/JSON file "
+            "(default: {session_directory}/acl.yaml)"
+        ),
+    )
+
     # Logging configuration
     log_level: str = Field(
         default="DEBUG", description="Logging level (DEBUG, INFO, WARNING, ERROR)"
@@ -248,6 +265,13 @@ class ServerConfig(BaseSettings):
     def require_auth(self) -> bool:
         """Whether authentication is required (no fallback)."""
         return self.server_mode == ServerMode.HTTP_AUTH
+
+    @property
+    def acl_config_file(self) -> Path:
+        """Resolved ACL config path."""
+        if self.acl_config_path.strip():
+            return Path(self.acl_config_path).expanduser()
+        return self.session_directory / "acl.yaml"
 
     @property
     def session_directory(self) -> Path:

--- a/src/config/server_config.py
+++ b/src/config/server_config.py
@@ -341,6 +341,12 @@ class ServerConfig(BaseSettings):
                 "⚠️ Production mode without API credentials - ensure they're available for setup"
             )
 
+        if self.acl_enabled and not self.disable_auth:
+            from src.server_components.session_acl import validate_acl_config
+
+            validate_acl_config()
+            logger.info(f"🔒 Session ACL enabled: {self.acl_config_file}")
+
     @classmethod
     def from_args_and_env(cls) -> "ServerConfig":
         """Create configuration from command line arguments and environment variables.
@@ -348,7 +354,11 @@ class ServerConfig(BaseSettings):
         With native CLI parsing, this simply creates the config instance.
         pydantic-settings automatically handles CLI args, env vars, and .env files.
         """
+        global _config
         config = cls()
+        # Register before validate_config so ACL and other validators can call get_config()
+        # without re-entering from_args_and_env (RecursionError during startup).
+        _config = config
         config.validate_config()
         return config
 

--- a/src/server_components/attachment_tickets.py
+++ b/src/server_components/attachment_tickets.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+from collections.abc import Iterable
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from src.config.server_config import get_config
@@ -24,6 +27,9 @@ class AttachmentTicket:
 
 _tickets: dict[str, AttachmentTicket] = {}
 _lock = asyncio.Lock()
+_minted_ticket_ids: ContextVar[list[str] | None] = ContextVar(
+    "_minted_ticket_ids", default=None
+)
 
 
 def _prune_expired_unlocked() -> None:
@@ -31,6 +37,31 @@ def _prune_expired_unlocked() -> None:
     dead = [k for k, v in _tickets.items() if v.expires_at <= now]
     for k in dead:
         del _tickets[k]
+
+
+@contextmanager
+def track_minted_attachment_tickets():
+    """Collect ticket IDs minted during this block (for ACL post-filter cleanup)."""
+    ids: list[str] = []
+    token = _minted_ticket_ids.set(ids)
+    try:
+        yield ids
+    finally:
+        _minted_ticket_ids.reset(token)
+
+
+async def revoke_attachment_tickets(ticket_ids: Iterable[str]) -> int:
+    """Remove tickets by ID. Returns count removed."""
+    ids = [tid for tid in ticket_ids if tid]
+    if not ids:
+        return 0
+    async with _lock:
+        removed = 0
+        for tid in ids:
+            if tid in _tickets:
+                del _tickets[tid]
+                removed += 1
+        return removed
 
 
 async def mint_attachment_ticket(
@@ -56,6 +87,9 @@ async def mint_attachment_ticket(
     async with _lock:
         _prune_expired_unlocked()
         _tickets[tid] = rec
+    tracking = _minted_ticket_ids.get()
+    if tracking is not None:
+        tracking.append(tid)
     return tid
 
 

--- a/src/server_components/mtproto_api.py
+++ b/src/server_components/mtproto_api.py
@@ -67,6 +67,13 @@ def register_mtproto_api_routes(mcp_app) -> None:
         resolve = bool(body.get("resolve", True))  # Default to True
         allow_dangerous = bool(body.get("allow_dangerous", False))
 
+        if config.require_auth:
+            from src.server_components.session_acl import check_mtproto_api_access
+
+            token = extract_bearer_token_from_request(request)
+            if acl_denial := check_mtproto_api_access(token, allow_dangerous=allow_dangerous):
+                return JSONResponse(acl_denial, status_code=403)
+
         # Deny dangerous methods unless explicitly allowed
         if (normalized_method in DANGEROUS_METHODS) and not allow_dangerous:
             error = log_and_build_error(

--- a/src/server_components/session_acl.py
+++ b/src/server_components/session_acl.py
@@ -16,8 +16,11 @@ from typing import Any, Callable
 
 import yaml
 
-from src.client.connection import get_request_token
 from src.config.server_config import get_config
+from src.server_components.attachment_tickets import (
+    revoke_attachment_tickets,
+    track_minted_attachment_tickets,
+)
 from src.utils.error_handling import log_and_build_error
 
 logger = logging.getLogger(__name__)
@@ -29,13 +32,17 @@ _WRITE_OPERATIONS = frozenset(
         "send_message_to_phone",
     }
 )
-_READ_OPERATIONS = frozenset(
-    {
-        "get_messages",
-        "get_chat_info",
-        "find_chats",
-        "search_messages_globally",
-    }
+_LIST_RESULT_OPERATIONS = frozenset({"find_chats", "search_messages_globally"})
+
+_EMPTY_LANE_DENY_MSG = (
+    "Session ACL: this token has an empty chat lane (chats: [] or chats omitted). "
+    "Add at least one chat id, @username, or me to the token entry in the ACL config."
+)
+_LISTED_TOKEN_MTPROTO_DENY_MSG = (
+    "Session ACL: invoke_mtproto is not permitted for tokens listed in the ACL config."
+)
+_LISTED_TOKEN_MTPROTO_API_DENY_MSG = (
+    "Session ACL: HTTP MTProto bridge is not permitted for tokens listed in the ACL config."
 )
 
 _acl_cache: dict[str, Any] | None = None
@@ -68,33 +75,84 @@ def clear_acl_cache() -> None:
     _acl_cache_path = None
 
 
-def _acl_file_path() -> Path | None:
+def _configured_acl_path() -> Path | None:
     config = get_config()
     if not config.acl_enabled:
         return None
+    return config.acl_config_file
+
+
+class AclConfigError(ValueError):
+    """Raised when ACL is enabled but the config file is missing or invalid."""
+
+
+def _validate_acl_document(doc: dict[str, Any], path: Path) -> None:
+    """Fail-closed startup validation for token entries."""
+    tokens = doc.get("tokens") or {}
+    if not isinstance(tokens, dict):
+        raise AclConfigError(f"ACL config 'tokens' must be a mapping: {path}")
+
+    for token_key, raw in tokens.items():
+        prefix = str(token_key)[:8]
+        if not isinstance(raw, dict):
+            raise AclConfigError(
+                f"ACL config entry for token prefix {prefix}... must be a mapping, "
+                f"not {type(raw).__name__}: {path}"
+            )
+        rule = TokenAclRule.from_dict(raw)
+        if rule.read_only and not rule.chats:
+            raise AclConfigError(
+                f"ACL token prefix {prefix}... has read_only: true but empty or missing "
+                f"chats. Analyst profile requires a non-empty chat lane: {path}"
+            )
+
+
+def validate_acl_config() -> None:
+    """Fail-closed: refuse startup when ACL is enabled but config is absent or invalid."""
+    config = get_config()
+    if not config.acl_enabled or config.disable_auth:
+        return
     path = config.acl_config_file
-    return path if path.is_file() else None
+    if not path.is_file():
+        raise AclConfigError(
+            f"ACL is enabled (ACL_ENABLED=true) but ACL config file not found: {path}. "
+            "Create the file or set ACL_CONFIG_PATH to a valid path."
+        )
+    _load_acl_document()
 
 
 def _load_acl_document() -> dict[str, Any]:
     global _acl_cache, _acl_cache_path
-    path = _acl_file_path()
+    path = _configured_acl_path()
     if path is None:
         _acl_cache = {}
         _acl_cache_path = None
         return _acl_cache
 
+    if not path.is_file():
+        raise AclConfigError(f"ACL config file not found: {path}")
+
     if _acl_cache is not None and _acl_cache_path == path:
         return _acl_cache
 
     text = path.read_text(encoding="utf-8")
-    if path.suffix.lower() == ".json":
-        doc = json.loads(text)
-    else:
-        doc = yaml.safe_load(text) or {}
+    try:
+        if path.suffix.lower() == ".json":
+            doc = json.loads(text)
+        else:
+            doc = yaml.safe_load(text) or {}
+    except json.JSONDecodeError as exc:
+        raise AclConfigError(
+            f"ACL config is not valid JSON: {path} ({exc.msg} at line {exc.lineno}, "
+            f"column {exc.colno})"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise AclConfigError(f"ACL config is not valid YAML: {path} ({exc})") from exc
 
     if not isinstance(doc, dict):
-        raise ValueError(f"ACL config must be a mapping: {path}")
+        raise AclConfigError(f"ACL config must be a mapping: {path}")
+
+    _validate_acl_document(doc, path)
 
     _acl_cache = doc
     _acl_cache_path = path
@@ -118,8 +176,11 @@ def _rules_for_token(token: str | None) -> TokenAclRule | None:
     if raw is None:
         return None
     if not isinstance(raw, dict):
-        logger.warning("Ignoring invalid ACL entry for token prefix %s...", token[:8])
-        return None
+        logger.error(
+            "Invalid ACL entry for token prefix %s... (expected mapping); denying all tool access",
+            token[:8],
+        )
+        return TokenAclRule()
     return TokenAclRule.from_dict(raw)
 
 
@@ -152,8 +213,12 @@ def _chat_ref_matches(allowed: str | int, candidate: str | int) -> bool:
     return False
 
 
+def _is_empty_lane(rule: TokenAclRule) -> bool:
+    return not rule.chats
+
+
 def _is_chat_allowed(chat_ref: Any, rule: TokenAclRule) -> bool:
-    if not rule.chats:
+    if _is_empty_lane(rule):
         return False
     normalized = _normalize_chat_ref(chat_ref)
     return any(_chat_ref_matches(a, normalized) for a in rule.chats)
@@ -170,6 +235,8 @@ def _deny(operation: str, message: str, params: dict[str, Any] | None = None) ->
 
 def check_pre_tool_access(operation_name: str, kwargs: dict[str, Any]) -> dict[str, Any] | None:
     """Return an error dict when the tool call must be blocked, else None."""
+    from src.client.connection import get_request_token
+
     rule = _rules_for_token(get_request_token())
     if rule is None:
         return None
@@ -181,10 +248,30 @@ def check_pre_tool_access(operation_name: str, kwargs: dict[str, Any]) -> dict[s
             params=kwargs,
         )
 
-    if operation_name == "invoke_mtproto" and rule.read_only:
+    if _is_empty_lane(rule):
+        if operation_name in _LIST_RESULT_OPERATIONS:
+            return _deny(
+                operation_name,
+                _EMPTY_LANE_DENY_MSG,
+                params=kwargs,
+            )
+        if operation_name == "send_message_to_phone":
+            return _deny(
+                operation_name,
+                _EMPTY_LANE_DENY_MSG,
+                params=kwargs,
+            )
+
+    if operation_name == "invoke_mtproto":
+        if rule.read_only:
+            return _deny(
+                operation_name,
+                "Session ACL is read-only: invoke_mtproto is not permitted.",
+                params=kwargs,
+            )
         return _deny(
             operation_name,
-            "Session ACL is read-only: invoke_mtproto is not permitted.",
+            _LISTED_TOKEN_MTPROTO_DENY_MSG,
             params=kwargs,
         )
 
@@ -204,7 +291,7 @@ def check_pre_tool_access(operation_name: str, kwargs: dict[str, Any]) -> dict[s
                 params={"chat_id": chat_id},
             )
 
-    if operation_name == "send_message_to_phone" and rule.chats:
+    if operation_name == "send_message_to_phone" and not _is_empty_lane(rule):
         return _deny(
             operation_name,
             "Session ACL: send_message_to_phone is blocked when a chat whitelist is configured.",
@@ -226,8 +313,15 @@ def _message_chat_id(message: dict[str, Any]) -> str | int | None:
 
 def filter_tool_result(operation_name: str, result: Any) -> Any:
     """Post-filter tool results to enforce chat whitelist on list payloads."""
+    from src.client.connection import get_request_token
+
     rule = _rules_for_token(get_request_token())
-    if rule is None or not rule.chats or not isinstance(result, dict):
+    if rule is None or not isinstance(result, dict):
+        return result
+
+    if _is_empty_lane(rule):
+        if operation_name in _LIST_RESULT_OPERATIONS:
+            return _deny(operation_name, _EMPTY_LANE_DENY_MSG)
         return result
 
     if operation_name == "find_chats" and isinstance(result.get("chats"), list):
@@ -270,14 +364,46 @@ def enforce_session_acl(operation_name: str):
             denial = check_pre_tool_access(operation_name, kwargs)
             if denial is not None:
                 return denial
+
+            track_tickets = operation_name == "get_messages"
+            if track_tickets:
+                with track_minted_attachment_tickets() as minted_ids:
+                    result = await func(*args, **kwargs)
+                    return await _finalize_acl_result(
+                        operation_name, result, minted_ids
+                    )
+
             result = await func(*args, **kwargs)
-            if isinstance(result, dict) and result.get("ok") is False:
-                return result
-            return filter_tool_result(operation_name, result)
+            return await _finalize_acl_result(operation_name, result, [])
 
         return wrapper
 
     return decorator
+
+
+async def _finalize_acl_result(
+    operation_name: str,
+    result: Any,
+    minted_ids: list[str],
+) -> Any:
+    if isinstance(result, dict) and result.get("ok") is False:
+        return result
+    was_ok = isinstance(result, dict) and result.get("ok") is not False
+    filtered = filter_tool_result(operation_name, result)
+    if (
+        operation_name == "get_messages"
+        and was_ok
+        and isinstance(filtered, dict)
+        and filtered.get("ok") is False
+        and minted_ids
+    ):
+        removed = await revoke_attachment_tickets(minted_ids)
+        if removed:
+            logger.info(
+                "Revoked %d attachment ticket(s) after get_messages ACL denial",
+                removed,
+            )
+    return filtered
 
 
 def check_mtproto_api_access(
@@ -293,4 +419,8 @@ def check_mtproto_api_access(
             "Session ACL is read-only: HTTP MTProto bridge is not permitted.",
             params={"allow_dangerous": allow_dangerous},
         )
-    return None
+    return _deny(
+        "mtproto_api",
+        _LISTED_TOKEN_MTPROTO_API_DENY_MSG,
+        params={"allow_dangerous": allow_dangerous},
+    )

--- a/src/server_components/session_acl.py
+++ b/src/server_components/session_acl.py
@@ -7,6 +7,7 @@ restrictions. Tokens not listed keep full account access (backward compatible).
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 from dataclasses import dataclass, field
@@ -233,6 +234,15 @@ def _deny(operation: str, message: str, params: dict[str, Any] | None = None) ->
     )
 
 
+def _bind_tool_kwargs(
+    func: Callable, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge positional and keyword tool arguments for ACL pre-checks."""
+    bound = inspect.signature(func).bind(*args, **kwargs)
+    bound.apply_defaults()
+    return dict(bound.arguments)
+
+
 def check_pre_tool_access(operation_name: str, kwargs: dict[str, Any]) -> dict[str, Any] | None:
     """Return an error dict when the tool call must be blocked, else None."""
     from src.client.connection import get_request_token
@@ -361,7 +371,8 @@ def enforce_session_acl(operation_name: str):
     def decorator(func: Callable):
         @wraps(func)
         async def wrapper(*args, **kwargs):
-            denial = check_pre_tool_access(operation_name, kwargs)
+            bound_kwargs = _bind_tool_kwargs(func, args, kwargs)
+            denial = check_pre_tool_access(operation_name, bound_kwargs)
             if denial is not None:
                 return denial
 

--- a/src/server_components/session_acl.py
+++ b/src/server_components/session_acl.py
@@ -1,0 +1,296 @@
+"""
+Opt-in per-token session ACL for http-auth deployments.
+
+When ACL is enabled, tokens listed in the config file get chat and operation
+restrictions. Tokens not listed keep full account access (backward compatible).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+
+from src.client.connection import get_request_token
+from src.config.server_config import get_config
+from src.utils.error_handling import log_and_build_error
+
+logger = logging.getLogger(__name__)
+
+_WRITE_OPERATIONS = frozenset(
+    {
+        "send_message",
+        "edit_message",
+        "send_message_to_phone",
+    }
+)
+_READ_OPERATIONS = frozenset(
+    {
+        "get_messages",
+        "get_chat_info",
+        "find_chats",
+        "search_messages_globally",
+    }
+)
+
+_acl_cache: dict[str, Any] | None = None
+_acl_cache_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class TokenAclRule:
+    chats: frozenset[str | int] = field(default_factory=frozenset)
+    read_only: bool = False
+    allow_global_search: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TokenAclRule:
+        raw_chats = data.get("chats") or []
+        chats: set[str | int] = set()
+        for item in raw_chats:
+            chats.add(_normalize_chat_ref(item))
+        return cls(
+            chats=frozenset(chats),
+            read_only=bool(data.get("read_only", False)),
+            allow_global_search=bool(data.get("allow_global_search", True)),
+        )
+
+
+def clear_acl_cache() -> None:
+    """Reset loaded ACL config (for tests)."""
+    global _acl_cache, _acl_cache_path
+    _acl_cache = None
+    _acl_cache_path = None
+
+
+def _acl_file_path() -> Path | None:
+    config = get_config()
+    if not config.acl_enabled:
+        return None
+    path = config.acl_config_file
+    return path if path.is_file() else None
+
+
+def _load_acl_document() -> dict[str, Any]:
+    global _acl_cache, _acl_cache_path
+    path = _acl_file_path()
+    if path is None:
+        _acl_cache = {}
+        _acl_cache_path = None
+        return _acl_cache
+
+    if _acl_cache is not None and _acl_cache_path == path:
+        return _acl_cache
+
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        doc = json.loads(text)
+    else:
+        doc = yaml.safe_load(text) or {}
+
+    if not isinstance(doc, dict):
+        raise ValueError(f"ACL config must be a mapping: {path}")
+
+    _acl_cache = doc
+    _acl_cache_path = path
+    logger.info("Loaded session ACL config from %s", path)
+    return _acl_cache
+
+
+def _rules_for_token(token: str | None) -> TokenAclRule | None:
+    if not token:
+        return None
+    config = get_config()
+    if not config.acl_enabled or config.disable_auth:
+        return None
+
+    doc = _load_acl_document()
+    tokens = doc.get("tokens") or {}
+    if not isinstance(tokens, dict):
+        return None
+
+    raw = tokens.get(token)
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        logger.warning("Ignoring invalid ACL entry for token prefix %s...", token[:8])
+        return None
+    return TokenAclRule.from_dict(raw)
+
+
+def _normalize_chat_ref(value: Any) -> str | int:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    if not text:
+        return ""
+    lowered = text.lower()
+    if lowered in {"me", "saved", "saved messages"}:
+        return "me"
+    if text.startswith("@"):
+        return text[1:].lower()
+    try:
+        return int(text)
+    except ValueError:
+        return lowered
+
+
+def _chat_ref_matches(allowed: str | int, candidate: str | int) -> bool:
+    if allowed == candidate:
+        return True
+    if isinstance(allowed, str) and isinstance(candidate, str):
+        return allowed.lower() == candidate.lower()
+    return False
+
+
+def _is_chat_allowed(chat_ref: Any, rule: TokenAclRule) -> bool:
+    if not rule.chats:
+        return False
+    normalized = _normalize_chat_ref(chat_ref)
+    return any(_chat_ref_matches(a, normalized) for a in rule.chats)
+
+
+def _deny(operation: str, message: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    return log_and_build_error(
+        operation=operation,
+        error_message=message,
+        params=params,
+        error_code=-32007,
+    )
+
+
+def check_pre_tool_access(operation_name: str, kwargs: dict[str, Any]) -> dict[str, Any] | None:
+    """Return an error dict when the tool call must be blocked, else None."""
+    rule = _rules_for_token(get_request_token())
+    if rule is None:
+        return None
+
+    if rule.read_only and operation_name in _WRITE_OPERATIONS:
+        return _deny(
+            operation_name,
+            "Session ACL is read-only: send and edit operations are not permitted.",
+            params=kwargs,
+        )
+
+    if operation_name == "invoke_mtproto" and rule.read_only:
+        return _deny(
+            operation_name,
+            "Session ACL is read-only: invoke_mtproto is not permitted.",
+            params=kwargs,
+        )
+
+    if operation_name == "search_messages_globally" and not rule.allow_global_search:
+        return _deny(
+            operation_name,
+            "Session ACL disallows global message search for this token.",
+            params=kwargs,
+        )
+
+    chat_id = kwargs.get("chat_id")
+    if chat_id is not None and operation_name in _WRITE_OPERATIONS | {"get_messages", "get_chat_info"}:
+        if not _is_chat_allowed(chat_id, rule):
+            return _deny(
+                operation_name,
+                "Session ACL: chat is not in the allowed list for this token.",
+                params={"chat_id": chat_id},
+            )
+
+    if operation_name == "send_message_to_phone" and rule.chats:
+        return _deny(
+            operation_name,
+            "Session ACL: send_message_to_phone is blocked when a chat whitelist is configured.",
+            params=kwargs,
+        )
+
+    return None
+
+
+def _message_chat_id(message: dict[str, Any]) -> str | int | None:
+    for key in ("chat_id", "peer_id"):
+        if key in message:
+            return _normalize_chat_ref(message[key])
+    chat = message.get("chat")
+    if isinstance(chat, dict) and "id" in chat:
+        return _normalize_chat_ref(chat["id"])
+    return None
+
+
+def filter_tool_result(operation_name: str, result: Any) -> Any:
+    """Post-filter tool results to enforce chat whitelist on list payloads."""
+    rule = _rules_for_token(get_request_token())
+    if rule is None or not rule.chats or not isinstance(result, dict):
+        return result
+
+    if operation_name == "find_chats" and isinstance(result.get("chats"), list):
+        filtered = [
+            chat
+            for chat in result["chats"]
+            if isinstance(chat, dict)
+            and _is_chat_allowed(chat.get("id") or chat.get("chat_id"), rule)
+        ]
+        return {**result, "chats": filtered}
+
+    if operation_name == "search_messages_globally" and isinstance(result.get("messages"), list):
+        filtered = [
+            msg
+            for msg in result["messages"]
+            if isinstance(msg, dict)
+            and (cid := _message_chat_id(msg)) is not None
+            and _is_chat_allowed(cid, rule)
+        ]
+        return {**result, "messages": filtered}
+
+    if operation_name == "get_messages" and isinstance(result.get("messages"), list):
+        chat_id = result.get("chat_id")
+        if chat_id is not None and not _is_chat_allowed(chat_id, rule):
+            return _deny(
+                operation_name,
+                "Session ACL: chat is not in the allowed list for this token.",
+                params={"chat_id": chat_id},
+            )
+
+    return result
+
+
+def enforce_session_acl(operation_name: str):
+    """Decorator: pre-check ACL and post-filter list results."""
+
+    def decorator(func: Callable):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            denial = check_pre_tool_access(operation_name, kwargs)
+            if denial is not None:
+                return denial
+            result = await func(*args, **kwargs)
+            if isinstance(result, dict) and result.get("ok") is False:
+                return result
+            return filter_tool_result(operation_name, result)
+
+        return wrapper
+
+    return decorator
+
+
+def check_mtproto_api_access(
+    token: str | None, *, allow_dangerous: bool
+) -> dict[str, Any] | None:
+    """ACL gate for HTTP MTProto bridge (http-auth only)."""
+    rule = _rules_for_token(token)
+    if rule is None:
+        return None
+    if rule.read_only:
+        return _deny(
+            "mtproto_api",
+            "Session ACL is read-only: HTTP MTProto bridge is not permitted.",
+            params={"allow_dangerous": allow_dangerous},
+        )
+    return None

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -6,6 +6,7 @@ from mcp.types import ToolAnnotations
 from src.server_components import auth as server_auth
 from src.server_components import bot_restrictions
 from src.server_components import errors as server_errors
+from src.server_components.session_acl import enforce_session_acl
 from src.server_components.mcp_tool_types import (
     AllowDangerous,
     AutoExpandBatches,
@@ -117,6 +118,7 @@ def mcp_tool_with_restrictions(operation_name: str):
     def decorator(func):
         decorated_func = server_errors.with_error_handling(operation_name)(func)
         decorated_func = server_auth.with_auth_context(decorated_func)
+        decorated_func = enforce_session_acl(operation_name)(decorated_func)
         return bot_restrictions.restrict_non_bridge_for_bot_sessions(operation_name)(
             decorated_func
         )
@@ -319,6 +321,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     @server_errors.with_error_handling("invoke_mtproto")
     @server_auth.with_auth_context
+    @enforce_session_acl("invoke_mtproto")
     async def invoke_mtproto(
         method_full_name: MethodFullName,
         params_json: ParamsJson,

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -107,18 +107,24 @@ _DESC_INVOKE_MTPROTO = _tool_description(
 )
 
 
-def mcp_tool_with_restrictions(operation_name: str):
+def mcp_tool_with_restrictions(operation_name: str, *, allow_bot_sessions: bool = False):
     """
-    Combined decorator for MCP tools: error handling, auth context, bot restrictions.
+    Combined decorator for MCP tools: error handling, ACL, auth context, bot restrictions.
+
+    Call order (outer → inner): bot → auth → ACL → error → func.
+    Auth must run before ACL so get_request_token() is set for pre-checks.
 
     Args:
         operation_name: Name of the operation for error reporting and bot restrictions
+        allow_bot_sessions: When True, skip bot restriction (for MTProto bridge tools)
     """
 
     def decorator(func):
         decorated_func = server_errors.with_error_handling(operation_name)(func)
-        decorated_func = server_auth.with_auth_context(decorated_func)
         decorated_func = enforce_session_acl(operation_name)(decorated_func)
+        decorated_func = server_auth.with_auth_context(decorated_func)
+        if allow_bot_sessions:
+            return decorated_func
         return bot_restrictions.restrict_non_bridge_for_bot_sessions(operation_name)(
             decorated_func
         )
@@ -319,9 +325,7 @@ def register_tools(mcp: FastMCP) -> None:
             openWorldHint=True,
         ),
     )
-    @server_errors.with_error_handling("invoke_mtproto")
-    @server_auth.with_auth_context
-    @enforce_session_acl("invoke_mtproto")
+    @mcp_tool_with_restrictions("invoke_mtproto", allow_bot_sessions=True)
     async def invoke_mtproto(
         method_full_name: MethodFullName,
         params_json: ParamsJson,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def test_server(mock_client):
     # Override the client in the connection module for testing
     import src.client.connection as conn
 
+    original_get_client = conn._get_client_by_token
     conn._get_client_by_token = AsyncMock(return_value=mock_client)
 
     # Register simplified mock versions of tools for testing
@@ -178,7 +179,8 @@ def test_server(mock_client):
         """Edit existing message in Telegram chat."""
         return {"action": "edited", "message_id": message_id, "text": message}
 
-    return mcp
+    yield mcp
+    conn._get_client_by_token = original_get_client
 
 
 @pytest_asyncio.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -540,6 +540,28 @@ def make_mock_request(path, scheme="https", netloc="example.com", query=""):
 
 
 @pytest.fixture(autouse=True)
+def clear_request_token_context():
+    """Reset bearer token context between tests to avoid ACL/auth leakage."""
+    from src.client.connection import set_request_token
+
+    set_request_token(None)
+    yield
+    set_request_token(None)
+
+
+@pytest.fixture(autouse=True)
+def clear_connection_session_cache():
+    """Clear token session cache between tests to avoid cross-test pollution."""
+    import src.client.connection as conn
+
+    conn._session_cache.clear()
+    conn._connection_failures.clear()
+    yield
+    conn._session_cache.clear()
+    conn._connection_failures.clear()
+
+
+@pytest.fixture(autouse=True)
 def clear_entity_cache():
     """Clear entity type and folder caches before each test to avoid cache pollution.
 

--- a/tests/test_mcp_tool_acl_integration.py
+++ b/tests/test_mcp_tool_acl_integration.py
@@ -1,0 +1,168 @@
+"""End-to-end tests for mcp_tool_with_restrictions ACL enforcement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.config.server_config import ServerConfig, ServerMode, set_config
+from src.server_components.session_acl import clear_acl_cache
+from src.server_components.tools_register import mcp_tool_with_restrictions
+from tests.conftest import make_access_token
+
+
+@pytest.fixture(autouse=True)
+def _reset_acl():
+    clear_acl_cache()
+    yield
+    clear_acl_cache()
+
+
+@pytest.fixture
+def acl_config(tmp_path: Path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        """
+tokens:
+  token-readonly:
+    chats:
+      - me
+    read_only: true
+    allow_global_search: true
+  token-team:
+    chats:
+      - -1001234567890
+    read_only: false
+    allow_global_search: false
+""",
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    return acl_file
+
+
+@pytest.mark.asyncio
+async def test_read_only_token_blocks_send_message_via_decorator_chain(acl_config):
+    """Read-only ACL must block send_message before the tool body runs."""
+    tool_called = AsyncMock(return_value={"ok": True, "message_id": 1})
+
+    @mcp_tool_with_restrictions("send_message")
+    async def send_message(chat_id, message):
+        return await tool_called(chat_id=chat_id, message=message)
+
+    with patch(
+        "fastmcp.server.dependencies.get_access_token",
+        return_value=make_access_token("token-readonly"),
+    ):
+        result = await send_message(chat_id="me", message="hello")
+
+    assert result["ok"] is False
+    assert "read-only" in result["error"].lower()
+    tool_called.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_whitelist_blocks_forbidden_chat_via_decorator_chain(acl_config):
+    """Chat whitelist pre-check must block get_messages for non-listed chats."""
+    tool_called = AsyncMock(return_value={"ok": True, "messages": []})
+
+    @mcp_tool_with_restrictions("get_messages")
+    async def get_messages(chat_id, limit=50):
+        return await tool_called(chat_id=chat_id, limit=limit)
+
+    with patch(
+        "fastmcp.server.dependencies.get_access_token",
+        return_value=make_access_token("token-team"),
+    ):
+        result = await get_messages(chat_id=-1000000)
+
+    assert result["ok"] is False
+    assert "not in the allowed list" in result["error"]
+    tool_called.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_whitelist_allows_listed_chat_via_decorator_chain(acl_config):
+    """Listed chats pass ACL pre-check and reach the tool body."""
+    tool_called = AsyncMock(return_value={"ok": True, "messages": []})
+
+    @mcp_tool_with_restrictions("get_messages")
+    async def get_messages(chat_id, limit=50):
+        return await tool_called(chat_id=chat_id, limit=limit)
+
+    with patch(
+        "fastmcp.server.dependencies.get_access_token",
+        return_value=make_access_token("token-team"),
+    ):
+        result = await get_messages(chat_id=-1001234567890)
+
+    assert result == {"ok": True, "messages": []}
+    tool_called.assert_awaited_once_with(chat_id=-1001234567890, limit=50)
+
+
+@pytest.fixture
+def empty_lane_acl_config(tmp_path: Path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        'tokens:\n  empty-lane:\n    chats: []\n    read_only: false\n',
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    return acl_file
+
+
+@pytest.mark.asyncio
+async def test_empty_lane_blocks_find_chats_via_decorator_chain(empty_lane_acl_config):
+    """Empty chat lane must hard-deny find_chats before the tool body runs."""
+    tool_called = AsyncMock(return_value={"ok": True, "chats": [{"id": -100123, "title": "Leaked"}]})
+
+    @mcp_tool_with_restrictions("find_chats")
+    async def find_chats(query, limit=50):
+        return await tool_called(query=query, limit=limit)
+
+    with patch(
+        "fastmcp.server.dependencies.get_access_token",
+        return_value=make_access_token("empty-lane"),
+    ):
+        result = await find_chats(query="work")
+
+    assert result["ok"] is False
+    assert "empty chat lane" in result["error"].lower()
+    tool_called.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_whitelist_blocks_invoke_mtproto_via_decorator_chain(acl_config):
+    """Chat whitelist must block invoke_mtproto before the tool body runs."""
+    tool_called = AsyncMock(return_value={"ok": True, "result": {}})
+
+    @mcp_tool_with_restrictions("invoke_mtproto", allow_bot_sessions=True)
+    async def invoke_mtproto(method_full_name, params_json, allow_dangerous=False):
+        return await tool_called(
+            method_full_name=method_full_name,
+            params_json=params_json,
+            allow_dangerous=allow_dangerous,
+        )
+
+    with patch(
+        "fastmcp.server.dependencies.get_access_token",
+        return_value=make_access_token("token-team"),
+    ):
+        result = await invoke_mtproto(
+            method_full_name="messages.GetHistory",
+            params_json="{}",
+        )
+
+    assert result["ok"] is False
+    assert "listed in the acl config" in result["error"].lower()
+    tool_called.assert_not_called()

--- a/tests/test_mcp_tool_acl_integration.py
+++ b/tests/test_mcp_tool_acl_integration.py
@@ -88,6 +88,26 @@ async def test_chat_whitelist_blocks_forbidden_chat_via_decorator_chain(acl_conf
 
 
 @pytest.mark.asyncio
+async def test_positional_chat_id_blocked_by_acl_decorator_chain(acl_config):
+    """Positional chat_id must not bypass ACL pre-check (kwargs-only bypass)."""
+    tool_called = AsyncMock(return_value={"ok": True, "messages": []})
+
+    @mcp_tool_with_restrictions("get_messages")
+    async def get_messages(chat_id, limit=50):
+        return await tool_called(chat_id=chat_id, limit=limit)
+
+    with patch(
+        "fastmcp.server.dependencies.get_access_token",
+        return_value=make_access_token("token-team"),
+    ):
+        result = await get_messages(-1000000)
+
+    assert result["ok"] is False
+    assert "not in the allowed list" in result["error"]
+    tool_called.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_chat_whitelist_allows_listed_chat_via_decorator_chain(acl_config):
     """Listed chats pass ACL pre-check and reach the tool body."""
     tool_called = AsyncMock(return_value={"ok": True, "messages": []})

--- a/tests/test_session_acl.py
+++ b/tests/test_session_acl.py
@@ -11,9 +11,18 @@ from src.client.connection import set_request_token
 from src.config.server_config import ServerConfig, ServerMode, set_config
 from src.server_components.session_acl import (
     TokenAclRule,
+    check_mtproto_api_access,
     check_pre_tool_access,
     clear_acl_cache,
+    enforce_session_acl,
     filter_tool_result,
+    validate_acl_config,
+    AclConfigError,
+)
+from src.server_components.attachment_tickets import (
+    clear_attachment_tickets_for_tests,
+    get_attachment_ticket,
+    mint_attachment_ticket,
 )
 
 
@@ -147,3 +156,202 @@ def test_token_acl_rule_from_dict():
     assert "team" in rule.chats
     assert "me" in rule.chats
     assert -1001 in rule.chats
+
+
+def test_invoke_mtproto_blocked_when_chat_whitelist_configured(acl_config):
+    set_request_token("token-team")
+    denial = check_pre_tool_access(
+        "invoke_mtproto",
+        {"method_full_name": "messages.GetHistory", "params_json": "{}"},
+    )
+    assert denial is not None
+    assert "listed in the acl config" in denial["error"].lower()
+
+
+def test_invoke_mtproto_read_only_blocks_even_without_chat_whitelist(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        'tokens:\n  ro-no-chats:\n    chats:\n      - me\n    read_only: true\n',
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    set_request_token("ro-no-chats")
+    denial = check_pre_tool_access("invoke_mtproto", {"params_json": "{}"})
+    assert denial is not None
+    assert "read-only" in denial["error"].lower()
+
+
+def test_invoke_mtproto_blocked_when_empty_lane(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        'tokens:\n  open-empty:\n    chats: []\n    read_only: false\n',
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    set_request_token("open-empty")
+    denial = check_pre_tool_access("invoke_mtproto", {"params_json": "{}"})
+    assert denial is not None
+    assert "listed in the acl config" in denial["error"].lower()
+
+
+def test_mtproto_api_blocked_when_chat_whitelist_configured(acl_config):
+    denial = check_mtproto_api_access("token-team", allow_dangerous=False)
+    assert denial is not None
+    assert "listed in the acl config" in denial["error"].lower()
+
+
+def test_acl_enabled_missing_file_raises(tmp_path):
+    missing = tmp_path / "missing-acl.yaml"
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(missing)
+    set_config(config)
+    with pytest.raises(AclConfigError, match="ACL is enabled"):
+        validate_acl_config()
+
+
+def test_validate_config_raises_when_acl_file_missing(tmp_path):
+    missing = tmp_path / "missing-acl.yaml"
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(missing)
+    with pytest.raises(AclConfigError, match="ACL is enabled"):
+        config.validate_config()
+
+
+@pytest.mark.asyncio
+async def test_get_messages_post_filter_revokes_minted_attachment_tickets(acl_config):
+    """Post-filter ACL denial must revoke tickets minted during the tool call."""
+    await clear_attachment_tickets_for_tests()
+    set_request_token("token-team")
+    minted_ticket_id: str | None = None
+
+    @enforce_session_acl("get_messages")
+    async def get_messages(chat_id):
+        nonlocal minted_ticket_id
+        minted_ticket_id = await mint_attachment_ticket("token-team", -1000000, 42)
+        return {
+            "ok": True,
+            "chat_id": -1000000,
+            "messages": [{"id": 42}],
+        }
+
+    result = await get_messages(chat_id=-1001234567890)
+
+    assert result["ok"] is False
+    assert "not in the allowed list" in result["error"]
+    assert minted_ticket_id is not None
+    assert await get_attachment_ticket(minted_ticket_id) is None
+    await clear_attachment_tickets_for_tests()
+
+
+@pytest.fixture
+def empty_lane_config(tmp_path: Path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        'tokens:\n  empty-lane:\n    chats: []\n    read_only: false\n',
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    return acl_file
+
+
+def test_empty_lane_blocks_find_chats_pre_check(empty_lane_config):
+    set_request_token("empty-lane")
+    denial = check_pre_tool_access("find_chats", {"query": "work"})
+    assert denial is not None
+    assert denial["ok"] is False
+    assert "empty chat lane" in denial["error"].lower()
+
+
+def test_empty_lane_blocks_search_messages_globally(empty_lane_config):
+    set_request_token("empty-lane")
+    denial = check_pre_tool_access("search_messages_globally", {"query": "secret"})
+    assert denial is not None
+    assert "empty chat lane" in denial["error"].lower()
+
+
+def test_empty_lane_blocks_get_messages(empty_lane_config):
+    set_request_token("empty-lane")
+    denial = check_pre_tool_access("get_messages", {"chat_id": -100123})
+    assert denial is not None
+    assert "not in the allowed list" in denial["error"]
+
+
+def test_empty_lane_find_chats_post_filter_hard_deny(empty_lane_config):
+    """Empty lane must hard-deny find_chats, not return an empty list (leak prevention)."""
+    set_request_token("empty-lane")
+    result = filter_tool_result(
+        "find_chats",
+        {"ok": True, "chats": [{"id": -1001234567890, "title": "Leaked"}]},
+    )
+    assert result["ok"] is False
+    assert "empty chat lane" in result["error"].lower()
+
+
+def test_validate_acl_rejects_read_only_without_chats(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        'tokens:\n  bad-analyst:\n    read_only: true\n',
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    with pytest.raises(AclConfigError, match="read_only: true but empty"):
+        validate_acl_config()
+
+
+def test_validate_acl_rejects_malformed_yaml(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text("tokens:\n  bad:\n    chats: [\n", encoding="utf-8")
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    with pytest.raises(AclConfigError, match="not valid YAML"):
+        validate_acl_config()
+
+
+def test_validate_acl_rejects_malformed_json(tmp_path):
+    acl_file = tmp_path / "acl.json"
+    acl_file.write_text('{"tokens": ', encoding="utf-8")
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    with pytest.raises(AclConfigError, match="not valid JSON"):
+        validate_acl_config()
+
+
+def test_validate_acl_rejects_malformed_token_entry(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        'tokens:\n  bad-token: "not-a-mapping"\n',
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    with pytest.raises(AclConfigError, match="must be a mapping"):
+        validate_acl_config()

--- a/tests/test_session_acl.py
+++ b/tests/test_session_acl.py
@@ -1,0 +1,149 @@
+"""Tests for opt-in session ACL enforcement."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.client.connection import set_request_token
+from src.config.server_config import ServerConfig, ServerMode, set_config
+from src.server_components.session_acl import (
+    TokenAclRule,
+    check_pre_tool_access,
+    clear_acl_cache,
+    filter_tool_result,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_acl():
+    clear_acl_cache()
+    yield
+    clear_acl_cache()
+
+
+@pytest.fixture
+def acl_config(tmp_path: Path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        """
+tokens:
+  token-readonly:
+    chats:
+      - me
+    read_only: true
+    allow_global_search: true
+  token-team:
+    chats:
+      - -1001234567890
+      - "@workgroup"
+    read_only: false
+    allow_global_search: false
+  token-auto:
+    chats:
+      - -100999
+    read_only: false
+    allow_global_search: false
+""",
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    return acl_file
+
+
+def test_token_without_acl_entry_allows_all(acl_config):
+    set_request_token("unlisted-token")
+    assert check_pre_tool_access("send_message", {"chat_id": -1}) is None
+
+
+def test_read_only_blocks_send(acl_config):
+    set_request_token("token-readonly")
+    denial = check_pre_tool_access("send_message", {"chat_id": "me"})
+    assert denial is not None
+    assert denial["ok"] is False
+    assert "read-only" in denial["error"].lower()
+
+
+def test_chat_whitelist_blocks_unknown_chat(acl_config):
+    set_request_token("token-team")
+    denial = check_pre_tool_access("get_messages", {"chat_id": -1000000})
+    assert denial is not None
+    assert "not in the allowed list" in denial["error"]
+
+
+def test_chat_whitelist_allows_listed_chat(acl_config):
+    set_request_token("token-team")
+    assert check_pre_tool_access("get_messages", {"chat_id": -1001234567890}) is None
+
+
+def test_global_search_blocked_for_automation_persona(acl_config):
+    set_request_token("token-auto")
+    denial = check_pre_tool_access("search_messages_globally", {"query": "hello"})
+    assert denial is not None
+    assert "global message search" in denial["error"].lower()
+
+
+def test_find_chats_post_filter(acl_config):
+    set_request_token("token-team")
+    result = {
+        "chats": [
+            {"id": -1001234567890, "title": "Work"},
+            {"id": -1000000, "title": "Other"},
+        ]
+    }
+    filtered = filter_tool_result("find_chats", result)
+    assert len(filtered["chats"]) == 1
+    assert filtered["chats"][0]["id"] == -1001234567890
+
+
+def test_acl_disabled_skips_rules(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text('tokens:\n  t:\n    read_only: true\n', encoding="utf-8")
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = False
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    set_request_token("t")
+    assert check_pre_tool_access("send_message", {"chat_id": "me"}) is None
+
+
+def test_json_acl_file(tmp_path):
+    acl_file = tmp_path / "acl.json"
+    acl_file.write_text(
+        json.dumps(
+            {
+                "tokens": {
+                    "json-token": {
+                        "chats": ["me"],
+                        "read_only": True,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    set_request_token("json-token")
+    assert check_pre_tool_access("edit_message", {"chat_id": "me"}) is not None
+
+
+def test_token_acl_rule_from_dict():
+    rule = TokenAclRule.from_dict(
+        {"chats": ["@Team", "me", -1001], "read_only": True, "allow_global_search": False}
+    )
+    assert rule.read_only is True
+    assert rule.allow_global_search is False
+    assert "team" in rule.chats
+    assert "me" in rule.chats
+    assert -1001 in rule.chats

--- a/tests/test_stdio_default_session.py
+++ b/tests/test_stdio_default_session.py
@@ -1,0 +1,64 @@
+"""Stdio / no-auth default session path (reserved session_name, e.g. telegram)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.client.connection import (
+    _resolve_session_path_for_token,
+    get_connected_client,
+    set_request_token,
+)
+from src.config.server_config import ServerConfig, ServerMode, set_config
+from src.server_components.session_token_validation import (
+    InvalidSessionTokenError,
+    validated_session_file_path,
+)
+
+
+@pytest.fixture
+def stdio_config(tmp_path: Path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.STDIO
+    config.session_dir = str(session_dir)
+    config.session_name = "telegram"
+    set_config(config)
+    return config
+
+
+def test_resolve_session_path_uses_config_path_for_reserved_name(stdio_config):
+    """Reserved session_name must not go through bearer token validation in stdio mode."""
+    path = _resolve_session_path_for_token("telegram")
+    assert path == stdio_config.session_path
+    with pytest.raises(InvalidSessionTokenError):
+        validated_session_file_path(stdio_config.session_directory, "telegram")
+
+
+@pytest.mark.asyncio
+async def test_get_connected_client_stdio_default_session_name(stdio_config):
+    """get_connected_client with no request token uses session_path, not bearer rules."""
+    set_request_token(None)
+    mock_client = AsyncMock()
+    mock_client.is_connected.return_value = True
+
+    with patch(
+        "src.client.connection._build_telegram_client_for_token",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ) as build_mock:
+        with patch(
+            "src.client.connection.ensure_connection",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            client = await get_connected_client()
+
+    assert client is mock_client
+    build_mock.assert_awaited_once()
+    session_path_arg = build_mock.await_args[0][0]
+    assert session_path_arg == stdio_config.session_path

--- a/uv.lock
+++ b/uv.lock
@@ -448,6 +448,7 @@ dependencies = [
     { name = "fastmcp-slim", extra = ["server"] },
     { name = "jinja2" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "telethon" },
     { name = "telethonfaketls" },
 ]
@@ -467,6 +468,7 @@ requires-dist = [
     { name = "fastmcp-slim", extras = ["server"], specifier = ">=3.3" },
     { name = "jinja2" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "telethon" },
     { name = "telethonfaketls" },
 ]


### PR DESCRIPTION
## Summary

- **Session ACL Phase 1** for `http-auth`: opt-in per-token `acl.yaml` with agent-scoped lanes (MCP tools + MTProto bridge), fail-closed validation at startup, and empty-lane enforcement so misconfiguration does not silently widen access.
- **Hardening fixes**: stdio default session resolution, circular import avoidance in connection path, attachment ticket integration, and integration/unit coverage (`test_session_acl.py`, `test_mcp_tool_acl_integration.py`, `test_stdio_default_session.py`).
- **Documentation & ops**: [ADR 0001](docs/adr/0001-agent-scoped-session-acl.md), design/operator research notes, `acl.yaml.example` / `acl.dev.yaml.example`, CONTRIBUTING and SECURITY runbook updates, e2e smoke via `scripts/acl_mcp_smoke.sh` and pytest.

**Out of scope (follow-up PRs):**

- Phase 1.5: sensitive peer restrictions
- Phase 2: `allow_mtproto` / `ACL_DEFAULT` global defaults

## Test plan

- [ ] `uv run pytest tests/test_session_acl.py tests/test_mcp_tool_acl_integration.py tests/test_stdio_default_session.py`
- [ ] Review `acl.yaml.example` and `acl.dev.yaml.example` against your deployment layout
- [ ] Optional: `scripts/acl_mcp_smoke.sh` against a local or dev `http-auth` instance with a test ACL file
- [ ] Confirm http-auth rejects or scopes tools/MTProto per lane; stdio mode unaffected when ACL not configured

## Summary by Sourcery

Ввести опциональный ACL сеансов на уровне токенов для развёртываний с http-auth, интегрировать его применение в инструменты MCP и мост MTProto, усилить обработку сеансов и вложений, а также добавить документацию, примеры и тесты для поддержки операций на основе ACL и отслеживания дорожной карты.

New Features:
- Добавить опциональную конфигурацию ACL сеансов на уровне токена, загружаемую из YAML/JSON, с разделением чатов по «линиям» (chat lanes) и флагами возможностей для режима http-auth.
- Интегрировать применение ACL сеансов в инструменты MCP и HTTP‑мост MTProto, включая проверки только на чтение и белые списки чатов с понятными ответами при отказе.
- Предоставить пример конфигурационных файлов ACL и shell‑скрипт для «smoke‑тестирования» поведения ACL против локального сервера с http-auth.

Enhancements:
- Уточнить логику разрешения и очистки сеансов так, чтобы stdio/сеансы по умолчанию обходили проверку bearer‑токена, а общие помощники обрабатывали проверки существования и удаление.
- Отслеживать и отзывать тикеты на скачивание вложений, созданные во время вызовов get_messages, когда последующая пост‑фильтрация ACL запрещает доступ.
- Расширить регистрацию инструментов MCP, чтобы применять унифицированную обработку ошибок, контекст аутентификации, применение ACL и опциональное разрешение бот‑сеансов.
- Добавить проверку ACL на этапе запуска в конфигурацию сервера, чтобы при отсутствии или некорректности файлов ACL происходил отказ в закрытом режиме (fail closed) и логировалось состояние включённого ACL.
- Обновить обработку MTProto API, чтобы она учитывала решения ACL сеансов для перечисленных токенов и опасных операций.

Build:
- Повысить версию проекта до 0.20.0 и добавить PyYAML как зависимость для разбора конфигурации ACL.

Documentation:
- Задокументировать поведение ACL сеансов, рекомендации для операторов и обновления модели угроз в SECURITY.md, ADR 0001, кратком описании дизайна ACL и дополнительных исследовательских заметках.
- Добавить продуктовую дорожную карту, обзор стратегического позиционирования и индекс ADR для прояснения долгосрочного направления и раздельной (lane‑based) разработки.
- Расширить руководство CONTRIBUTING рабочими процессами разработки http-auth с упором на ACL, инструкциями по тестированию и примерами файлов ACL для разработки.

Tests:
- Добавить модульные и интеграционные тесты для правил ACL сеансов, поведения декораторов инструментов MCP, ACL‑ограничения MTProto API и очистки тикетов вложений при отказе ACL.
- Добавить тесты обработки stdio‑сеансов по умолчанию, чтобы гарантировать, что зарезервированные имена сеансов обходят проверку bearer‑токена и используют настроенный путь для сеансов.
- Ввести базовый уровень Gategrid и отчётные артефакты для поддержки будущей оценки и процессов gating.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce opt-in per-token session ACL for http-auth deployments, integrate enforcement into MCP tools and the MTProto bridge, harden session and attachment handling, and add documentation, examples, and tests to support ACL-based operations and roadmap tracking.

New Features:
- Add opt-in per-token session ACL configuration loaded from YAML/JSON with per-token chat lanes and capability flags for http-auth mode.
- Integrate session ACL enforcement into MCP tools and the HTTP MTProto bridge, including read-only and chat-whitelist checks with clear denial responses.
- Provide example ACL configuration files and a shell script to smoke-test ACL behavior against a local http-auth server.

Enhancements:
- Refine session resolution and cleanup logic so stdio/default sessions bypass bearer-token validation while shared helpers handle existence checks and deletion.
- Track and revoke attachment download tickets minted during get_messages calls when ACL post-filtering later denies access.
- Extend MCP tool registration to apply unified error handling, auth context, ACL enforcement, and optional bot-session allowances.
- Add startup-time ACL validation to server configuration to fail closed on missing or invalid ACL files and log enabled ACL state.
- Update MTProto API handling to respect session ACL decisions for listed tokens and dangerous operations.

Build:
- Bump project version to 0.20.0 and add PyYAML as a dependency for ACL configuration parsing.

Documentation:
- Document session ACL behavior, operator guidance, and threat model updates in SECURITY.md, ADR 0001, an ACL design brief, and additional research notes.
- Add a product roadmap, strategic positioning overview, and ADR index to clarify long-term direction and lane-based development.
- Expand CONTRIBUTING guidance with ACL-focused http-auth dev workflows, testing instructions, and example ACL dev files.

Tests:
- Add unit and integration tests for session ACL rules, MCP tool decorator behavior, MTProto API ACL gating, and attachment ticket cleanup on ACL denial.
- Add tests for stdio default-session handling to ensure reserved session names bypass bearer-token validation and use the configured session path.
- Introduce Gategrid baseline and report artifacts to support future evaluation and gating workflows.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести опциональный ACL сеансов на уровне токенов для развёртываний с http-auth, интегрировать его применение в инструменты MCP и мост MTProto, усилить обработку сеансов и вложений, а также добавить документацию, примеры и тесты для поддержки операций на основе ACL и отслеживания дорожной карты.

New Features:
- Добавить опциональную конфигурацию ACL сеансов на уровне токена, загружаемую из YAML/JSON, с разделением чатов по «линиям» (chat lanes) и флагами возможностей для режима http-auth.
- Интегрировать применение ACL сеансов в инструменты MCP и HTTP‑мост MTProto, включая проверки только на чтение и белые списки чатов с понятными ответами при отказе.
- Предоставить пример конфигурационных файлов ACL и shell‑скрипт для «smoke‑тестирования» поведения ACL против локального сервера с http-auth.

Enhancements:
- Уточнить логику разрешения и очистки сеансов так, чтобы stdio/сеансы по умолчанию обходили проверку bearer‑токена, а общие помощники обрабатывали проверки существования и удаление.
- Отслеживать и отзывать тикеты на скачивание вложений, созданные во время вызовов get_messages, когда последующая пост‑фильтрация ACL запрещает доступ.
- Расширить регистрацию инструментов MCP, чтобы применять унифицированную обработку ошибок, контекст аутентификации, применение ACL и опциональное разрешение бот‑сеансов.
- Добавить проверку ACL на этапе запуска в конфигурацию сервера, чтобы при отсутствии или некорректности файлов ACL происходил отказ в закрытом режиме (fail closed) и логировалось состояние включённого ACL.
- Обновить обработку MTProto API, чтобы она учитывала решения ACL сеансов для перечисленных токенов и опасных операций.

Build:
- Повысить версию проекта до 0.20.0 и добавить PyYAML как зависимость для разбора конфигурации ACL.

Documentation:
- Задокументировать поведение ACL сеансов, рекомендации для операторов и обновления модели угроз в SECURITY.md, ADR 0001, кратком описании дизайна ACL и дополнительных исследовательских заметках.
- Добавить продуктовую дорожную карту, обзор стратегического позиционирования и индекс ADR для прояснения долгосрочного направления и раздельной (lane‑based) разработки.
- Расширить руководство CONTRIBUTING рабочими процессами разработки http-auth с упором на ACL, инструкциями по тестированию и примерами файлов ACL для разработки.

Tests:
- Добавить модульные и интеграционные тесты для правил ACL сеансов, поведения декораторов инструментов MCP, ACL‑ограничения MTProto API и очистки тикетов вложений при отказе ACL.
- Добавить тесты обработки stdio‑сеансов по умолчанию, чтобы гарантировать, что зарезервированные имена сеансов обходят проверку bearer‑токена и используют настроенный путь для сеансов.
- Ввести базовый уровень Gategrid и отчётные артефакты для поддержки будущей оценки и процессов gating.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce opt-in per-token session ACL for http-auth deployments, integrate enforcement into MCP tools and the MTProto bridge, harden session and attachment handling, and add documentation, examples, and tests to support ACL-based operations and roadmap tracking.

New Features:
- Add opt-in per-token session ACL configuration loaded from YAML/JSON with per-token chat lanes and capability flags for http-auth mode.
- Integrate session ACL enforcement into MCP tools and the HTTP MTProto bridge, including read-only and chat-whitelist checks with clear denial responses.
- Provide example ACL configuration files and a shell script to smoke-test ACL behavior against a local http-auth server.

Enhancements:
- Refine session resolution and cleanup logic so stdio/default sessions bypass bearer-token validation while shared helpers handle existence checks and deletion.
- Track and revoke attachment download tickets minted during get_messages calls when ACL post-filtering later denies access.
- Extend MCP tool registration to apply unified error handling, auth context, ACL enforcement, and optional bot-session allowances.
- Add startup-time ACL validation to server configuration to fail closed on missing or invalid ACL files and log enabled ACL state.
- Update MTProto API handling to respect session ACL decisions for listed tokens and dangerous operations.

Build:
- Bump project version to 0.20.0 and add PyYAML as a dependency for ACL configuration parsing.

Documentation:
- Document session ACL behavior, operator guidance, and threat model updates in SECURITY.md, ADR 0001, an ACL design brief, and additional research notes.
- Add a product roadmap, strategic positioning overview, and ADR index to clarify long-term direction and lane-based development.
- Expand CONTRIBUTING guidance with ACL-focused http-auth dev workflows, testing instructions, and example ACL dev files.

Tests:
- Add unit and integration tests for session ACL rules, MCP tool decorator behavior, MTProto API ACL gating, and attachment ticket cleanup on ACL denial.
- Add tests for stdio default-session handling to ensure reserved session names bypass bearer-token validation and use the configured session path.
- Introduce Gategrid baseline and report artifacts to support future evaluation and gating workflows.

</details>

</details>