### PR TITLE
fix: Sourcery PR #55 second-pass follow-ups

### DIFF
--- a/docs/Strategic-Market-Positioning.md
+++ b/docs/Strategic-Market-Positioning.md
@@ -89,8 +89,6 @@ See [research/acl-design-brief.md](research/acl-design-brief.md) and [Roadmap.md
 | [research/gemini-competitive-analysis.md](research/gemini-competitive-analysis.md) | MCP/Telegram landscape, competitor table, ecosystem risks |
 | [research/gemini-strategy-monetization.md](research/gemini-strategy-monetization.md) | Aspirational positioning and monetization hypotheses |
 | [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md) | Proposed features, phase timeline (planned vs shipped) |
-| [research/gemini-strategy-monetization.md](research/gemini-strategy-monetization.md) | Aspirational positioning and monetization hypotheses |
-| [research/gemini-roadmap-proposal.md](research/gemini-roadmap-proposal.md) | Proposed features, phase timeline (planned vs shipped) |
 
 ## See also
 

--- a/scripts/acl_mcp_smoke.sh
+++ b/scripts/acl_mcp_smoke.sh
@@ -91,7 +91,7 @@ call_tool() {
   local token="$1"
   local label="$2"
   echo "--- ${label} (${token:0:24}...) ---"
-  curl -sS -X POST "${BASE_URL}" \
+  curl -sS --connect-timeout 5 --max-time 15 -X POST "${BASE_URL}" \
     -H "Authorization: Bearer ${token}" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -111,8 +111,9 @@ def mcp_tool_with_restrictions(operation_name: str, *, allow_bot_sessions: bool 
     """
     Combined decorator for MCP tools: error handling, ACL, auth context, bot restrictions.
 
-    Call order (outer → inner): bot → auth → ACL → error → func.
+    Call order (outer → inner): bot → auth → error → ACL → func.
     Auth must run before ACL so get_request_token() is set for pre-checks.
+    ACL wraps the original tool function so signature-based checks remain robust.
 
     Args:
         operation_name: Name of the operation for error reporting and bot restrictions
@@ -120,8 +121,8 @@ def mcp_tool_with_restrictions(operation_name: str, *, allow_bot_sessions: bool 
     """
 
     def decorator(func):
-        decorated_func = server_errors.with_error_handling(operation_name)(func)
-        decorated_func = enforce_session_acl(operation_name)(decorated_func)
+        decorated_func = enforce_session_acl(operation_name)(func)
+        decorated_func = server_errors.with_error_handling(operation_name)(decorated_func)
         decorated_func = server_auth.with_auth_context(decorated_func)
         if allow_bot_sessions:
             return decorated_func

--- a/tests/test_mcp_tool_acl_integration.py
+++ b/tests/test_mcp_tool_acl_integration.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from src.config.server_config import ServerConfig, ServerMode, set_config
 from src.server_components.session_acl import clear_acl_cache
 from src.server_components.tools_register import mcp_tool_with_restrictions
 from tests.conftest import make_access_token
+
+
+async def _await_tool_denial(awaitable):
+    """ACL denials flow through error handling and raise ToolError in the decorator chain."""
+    try:
+        return await awaitable
+    except ToolError as exc:
+        return json.loads(str(exc))
 
 
 @pytest.fixture(autouse=True)
@@ -60,7 +70,7 @@ async def test_read_only_token_blocks_send_message_via_decorator_chain(acl_confi
         "fastmcp.server.dependencies.get_access_token",
         return_value=make_access_token("token-readonly"),
     ):
-        result = await send_message(chat_id="me", message="hello")
+        result = await _await_tool_denial(send_message(chat_id="me", message="hello"))
 
     assert result["ok"] is False
     assert "read-only" in result["error"].lower()
@@ -80,7 +90,7 @@ async def test_chat_whitelist_blocks_forbidden_chat_via_decorator_chain(acl_conf
         "fastmcp.server.dependencies.get_access_token",
         return_value=make_access_token("token-team"),
     ):
-        result = await get_messages(chat_id=-1000000)
+        result = await _await_tool_denial(get_messages(chat_id=-1000000))
 
     assert result["ok"] is False
     assert "not in the allowed list" in result["error"]
@@ -100,7 +110,7 @@ async def test_positional_chat_id_blocked_by_acl_decorator_chain(acl_config):
         "fastmcp.server.dependencies.get_access_token",
         return_value=make_access_token("token-team"),
     ):
-        result = await get_messages(-1000000)
+        result = await _await_tool_denial(get_messages(-1000000))
 
     assert result["ok"] is False
     assert "not in the allowed list" in result["error"]
@@ -154,7 +164,7 @@ async def test_empty_lane_blocks_find_chats_via_decorator_chain(empty_lane_acl_c
         "fastmcp.server.dependencies.get_access_token",
         return_value=make_access_token("empty-lane"),
     ):
-        result = await find_chats(query="work")
+        result = await _await_tool_denial(find_chats(query="work"))
 
     assert result["ok"] is False
     assert "empty chat lane" in result["error"].lower()
@@ -178,9 +188,11 @@ async def test_chat_whitelist_blocks_invoke_mtproto_via_decorator_chain(acl_conf
         "fastmcp.server.dependencies.get_access_token",
         return_value=make_access_token("token-team"),
     ):
-        result = await invoke_mtproto(
-            method_full_name="messages.GetHistory",
-            params_json="{}",
+        result = await _await_tool_denial(
+            invoke_mtproto(
+                method_full_name="messages.GetHistory",
+                params_json="{}",
+            )
         )
 
     assert result["ok"] is False

--- a/tests/test_session_acl.py
+++ b/tests/test_session_acl.py
@@ -28,9 +28,12 @@ from src.server_components.attachment_tickets import (
 
 @pytest.fixture(autouse=True)
 def _reset_acl():
+    """Clear ACL cache and request token between tests (token also reset in conftest)."""
     clear_acl_cache()
+    set_request_token(None)
     yield
     clear_acl_cache()
+    set_request_token(None)
 
 
 @pytest.fixture

--- a/tests/test_stdio_default_session.py
+++ b/tests/test_stdio_default_session.py
@@ -47,10 +47,10 @@ async def test_get_connected_client_stdio_default_session_name(stdio_config):
     mock_client.is_connected.return_value = True
 
     with patch(
-        "src.client.connection._build_telegram_client_for_token",
+        "src.client.connection._get_client_by_token",
         new_callable=AsyncMock,
         return_value=mock_client,
-    ) as build_mock:
+    ) as get_mock:
         with patch(
             "src.client.connection.ensure_connection",
             new_callable=AsyncMock,
@@ -59,6 +59,6 @@ async def test_get_connected_client_stdio_default_session_name(stdio_config):
             client = await get_connected_client()
 
     assert client is mock_client
-    build_mock.assert_awaited_once()
-    session_path_arg = build_mock.await_args[0][0]
-    assert session_path_arg == stdio_config.session_path
+    get_mock.assert_awaited_once()
+    token_arg = get_mock.await_args[0][0]
+    assert token_arg == stdio_config.session_name


### PR DESCRIPTION
## Summary
- Reorder `mcp_tool_with_restrictions` so ACL wraps the raw tool before error handling (robust signature binding for pre-checks)
- Reset request token in `test_session_acl.py` autouse fixture (complements conftest global reset)
- Add `--connect-timeout` / `--max-time` to ACL smoke script tool calls
- Remove duplicate Gemini research rows in Strategic Market Positioning doc
- Update stdio default session test to mock `_get_client_by_token` with session name

## Skipped (per plan)
- TokenAclRule refactor (#4) — merged without; non-trivial refactor
- ContextVar removal (#5) — merged without; non-trivial refactor

## Test plan
- [x] `pytest tests/test_session_acl.py tests/test_mcp_tool_acl_integration.py tests/test_stdio_default_session.py -q` (32 passed)

## Summary by Sourcery

Отрегулирован порядок декораторов ограничения MCP-инструментов, улучшены тесты и фикстуры, связанные с ACL, усилены вызовы скрипта smoke-тестов и очищена документация.

Исправления ошибок:
- Обеспечено применение обёрток ACL до обработчиков ошибок в декораторах MCP-инструментов, чтобы сохранялись надёжные проверки на основе сигнатур.
- Сброс токенов ACL-запросов между тестами ACL-сессий для предотвращения утечки токенов между тестами.
- Обновлён тест stdio default session client для мокирования корректной функции поиска клиента и проверки ожидаемого имени сессии.
- Нормализованы интеграционные тесты ACL, чтобы они проверяли `ToolError`-обёрнутые отказы вместо зависимости от «сырых» результатов.

Улучшения:
- В вызовы `curl` в smoke-скрипте ACL MCP добавлены флаги таймаута соединения и общего таймаута, чтобы сделать smoke-тесты более надёжными при медленных или падающих эндпоинтах.

Документация:
- Удалены дублирующиеся записи о Gemini research-документе из документации по стратегическому позиционированию на рынке.

Тесты:
- Уточнены интеграционные тесты ACL для MCP-инструментов: теперь они используют общий хелпер для проверки ACL-отказов и их тел ошибок.
- Ужесточены тесты stdio default session: теперь они проверяют использование токенов на основе имени сессии, а не пути сессии.
- Усилены тесты ACL-сессий: теперь они явно сбрасывают и кеш ACL, и токен запроса через фикстуру с `autouse`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust MCP tool restriction decorator ordering, improve ACL-related tests and fixtures, harden smoke script calls, and clean up documentation.

Bug Fixes:
- Ensure ACL wrappers are applied before error handling in MCP tool decorators to preserve robust signature-based checks.
- Reset ACL request tokens between ACL session tests to prevent cross-test token leakage.
- Update stdio default session client test to mock the correct client lookup function and validate the expected session name.
- Normalize ACL integration tests to assert on ToolError-wrapped denials instead of relying on raw results.

Enhancements:
- Add connection and total timeout flags to the ACL MCP smoke script curl calls to make smoke tests more robust under slow or failing endpoints.

Documentation:
- Remove duplicate Gemini research document entries from the strategic market positioning documentation.

Tests:
- Refine MCP tool ACL integration tests to use a shared helper for asserting ACL denials and their error payloads.
- Tighten stdio default session tests to assert token usage based on session name instead of session path.
- Strengthen ACL session tests to explicitly reset both ACL cache and request token via an autouse fixture.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Отрегулирован порядок декораторов ограничения MCP-инструментов, улучшены тесты и фикстуры, связанные с ACL, усилены вызовы скрипта smoke-тестов и очищена документация.

Исправления ошибок:
- Обеспечено применение обёрток ACL до обработчиков ошибок в декораторах MCP-инструментов, чтобы сохранялись надёжные проверки на основе сигнатур.
- Сброс токенов ACL-запросов между тестами ACL-сессий для предотвращения утечки токенов между тестами.
- Обновлён тест stdio default session client для мокирования корректной функции поиска клиента и проверки ожидаемого имени сессии.
- Нормализованы интеграционные тесты ACL, чтобы они проверяли `ToolError`-обёрнутые отказы вместо зависимости от «сырых» результатов.

Улучшения:
- В вызовы `curl` в smoke-скрипте ACL MCP добавлены флаги таймаута соединения и общего таймаута, чтобы сделать smoke-тесты более надёжными при медленных или падающих эндпоинтах.

Документация:
- Удалены дублирующиеся записи о Gemini research-документе из документации по стратегическому позиционированию на рынке.

Тесты:
- Уточнены интеграционные тесты ACL для MCP-инструментов: теперь они используют общий хелпер для проверки ACL-отказов и их тел ошибок.
- Ужесточены тесты stdio default session: теперь они проверяют использование токенов на основе имени сессии, а не пути сессии.
- Усилены тесты ACL-сессий: теперь они явно сбрасывают и кеш ACL, и токен запроса через фикстуру с `autouse`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust MCP tool restriction decorator ordering, improve ACL-related tests and fixtures, harden smoke script calls, and clean up documentation.

Bug Fixes:
- Ensure ACL wrappers are applied before error handling in MCP tool decorators to preserve robust signature-based checks.
- Reset ACL request tokens between ACL session tests to prevent cross-test token leakage.
- Update stdio default session client test to mock the correct client lookup function and validate the expected session name.
- Normalize ACL integration tests to assert on ToolError-wrapped denials instead of relying on raw results.

Enhancements:
- Add connection and total timeout flags to the ACL MCP smoke script curl calls to make smoke tests more robust under slow or failing endpoints.

Documentation:
- Remove duplicate Gemini research document entries from the strategic market positioning documentation.

Tests:
- Refine MCP tool ACL integration tests to use a shared helper for asserting ACL denials and their error payloads.
- Tighten stdio default session tests to assert token usage based on session name instead of session path.
- Strengthen ACL session tests to explicitly reset both ACL cache and request token via an autouse fixture.

</details>

</details>