### PR TITLE
feat(acl): Phase 1.5 blocked_peers denylist

### DIFF
--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,8 +1,8 @@
 ## Current Work Focus
 
-**Trust lane — Session ACL (2026-05-27):** Phase 1 **closed** on `master` — release [`0.20.0`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.20.0), PR #55+#56, post-release CI/test hygiene. **Next: Phase 1.5** — sensitive peer denylist. [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md).
+**Trust lane — Session ACL (2026-05-27):** Phase 1 **closed** on `master` — release [`0.20.0`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.20.0). **Phase 1.5 shipped in branch** — operator `blocked_peers` denylist with dual pre/post enforcement. [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md).
 
-- **Implementation:** [session_acl.py](../src/server_components/session_acl.py), `ACL_ENABLED`, [acl.yaml.example](../acl.yaml.example), [SECURITY.md](../SECURITY.md)
+- **Implementation:** [session_acl.py](../src/server_components/session_acl.py), `blocked_peers` in ACL YAML, [acl.yaml.example](../acl.yaml.example), [SECURITY.md](../SECURITY.md)
 - **Design:** [acl-design-brief.md](../docs/research/acl-design-brief.md) (Phases 1–3)
 - **Phase 2 (deferred):** `ACL_DEFAULT`, `allow_mtproto`, enforcement registry
 - **Other lanes:** Telemetry `feature/telemetry` *(planned)*; QA / Gategrid `feature/evals`

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,6 +1,7 @@
 ### 2026-05-27
+- **Phase 1.5 — Session ACL blocked_peers:** Operator-configured deployment denylist; dual pre/post enforcement (id + username post-check); MTProto shallow scan before lane gate; SECURITY.md shared-host checklist; tests in `test_session_acl.py`.
 - **Phase 1 closeout (`master`):** Post-release fixes — CI voice-transcription test client pass-through (`4f76129`), Sourcery follow-ups (PR #56), release CI gate in skill docs, test mock `sender_id`/`forward` defaults (~141s → ~1s local full suite).
-- **0.20.0 — Session ACL Phase 1:** GitHub release `0.20.0`; opt-in `ACL_ENABLED` / `ACL_CONFIG_PATH` on http-auth, per-token chat lanes, `read_only`, empty-lane hard deny, listed-token MTProto block, fail-closed startup, SECURITY.md + Installation docs. Phase 1.5 (sensitive peer denylist) next.
+- **0.20.0 — Session ACL Phase 1:** GitHub release `0.20.0`; opt-in `ACL_ENABLED` / `ACL_CONFIG_PATH` on http-auth, per-token chat lanes, `read_only`, empty-lane hard deny, listed-token MTProto block, fail-closed startup, SECURITY.md + Installation docs.
 - **Session ACL Phase 1 closed (`master`, PR #56):** Empty-lane hard deny (pre-check + post-filter), listed-token MTProto block, startup validation (`read_only` requires `chats`, malformed token entries), SECURITY.md operator runbook, integration tests.
 - **Roadmap lanes (`master`):** Trust / Telemetry / QA-Gategrid — telemetry informs QA triage, GG benchmark validates, GG gating enforces on PR.
 - **Session ACL MVP on `master`:** opt-in `ACL_ENABLED`, static `acl.yaml`, MCP + MTProto enforcement. Direction: agent guardrails — [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md); Phase 1.5 sensitive peer denylist next.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,36 @@ Treat the ACL file like a secret (contains bearer token strings). Restrict file 
 - **`read_only`**: blocks send, edit, `invoke_mtproto`, and the HTTP MTProto bridge.
 - **`allow_global_search`**: when false, blocks `search_messages_globally` pre-check.
 
+### Sensitive peer denylist (`blocked_peers`, Phase 1.5)
+
+When **`blocked_peers`** is configured (non-empty list in the ACL file), those peers are **denied for every Bearer token** — listed and unlisted. Deny wins over a token’s `chats` lane.
+
+| Config | Behavior |
+| --- | --- |
+| **`blocked_peers` omitted** | No sensitive blocking; lane ACL only |
+| **`blocked_peers: []`** | Explicit empty — no sensitive blocking |
+| **Non-empty list** | Enforced exactly as configured (operators own the full list) |
+
+**Recommended defaults** (copy from [`acl.yaml.example`](acl.yaml.example) for shared hosts):
+
+| Peer id | Handle | Why block |
+| --- | --- | --- |
+| `777000` | Telegram service | Login codes, security alerts |
+| `93372553` | @BotFather | Bot tokens, settings |
+| `178220800` | @SpamBot | Spam/limit appeals |
+
+**Numeric ids in YAML** give the best coverage (including shallow MTProto param scans). Optional `@username` entries help **pre-check** raw tool input. **Post-check** on `get_chat_info` and `get_messages` matches **both** resolved numeric `id` and `username` from the tool result — so numeric-only YAML still blocks `@BotFather` input after Telegram resolves the peer, and `@username` YAML still blocks numeric input after resolution.
+
+**Pre-check limitation:** raw tool input is matched without entity lookup. Username-only YAML does not block numeric input until post-check (if the tool succeeds).
+
+**MTProto:** shallow scan of merged `params` / `params_json` for numeric blocked ids only (no TL schema walker). Invalid non-empty `params_json` when `blocked_peers` is configured → fail-closed deny. Residual risk: deeply nested or list params — document and accept for Phase 1.5.
+
+**List post-filter:** `find_chats` and `search_messages_globally` drop blocked peers from results; an empty list after filtering is success (not an error).
+
+**Error:** `Session ACL: blocked peer (<ref>) is denied for this deployment. See SECURITY.md.` (MCP `error_code` `-32007`).
+
+**Shared-host footgun:** `ACL_ENABLED=true` without `blocked_peers` leaves BotFather and login-code chats reachable via MCP — use the checklist above and uncomment the example block.
+
 ### What is blocked for listed tokens
 
 | Surface | Behavior |
@@ -81,7 +111,7 @@ ACL lanes reduce **accidental** cross-chat access and **in-server** tool abuse w
 - Replace Telegram account security (2FA, session revocation in official clients)
 - Apply to stdio or http-no-auth deployments
 
-Phase 1.5 (planned) adds a **sensitive peer denylist** (e.g. login-code user `777000`, BotFather) for shared-team blast radius — see [acl-design-brief.md](docs/research/acl-design-brief.md).
+When **`blocked_peers`** is configured, the denylist applies on http-auth for **all** tokens (see above).
 
 ### Troubleshooting denials
 
@@ -92,7 +122,9 @@ Phase 1.5 (planned) adds a **sensitive peer denylist** (e.g. login-code user `77
 | “read-only” | `read_only: true` on the token | Set `read_only: false` or use a write-capable profile |
 | “global message search” | `allow_global_search: false` | Set `allow_global_search: true` or use `get_messages` in-lane |
 | “listed in the ACL config” on MTProto | Listed tokens cannot use raw MTProto in Phase 1 | Remove token from ACL for full access, or wait for Phase 2 `allow_mtproto` |
-| Server refuses to start | Missing ACL file or invalid YAML | Create file; fix malformed token entries; ensure `read_only` has `chats` |
+| “blocked peer … denied for this deployment” | Peer is on `blocked_peers` denylist | Remove peer from tool args; adjust denylist if policy allows; see numeric-id guidance above |
+| “invalid params_json” with blocked_peers | Malformed JSON when denylist is active | Fix JSON or omit `params_json` |
+| Server refuses to start | Missing ACL file or invalid YAML | Create file; fix malformed token entries; ensure `read_only` has `chats`; fix `blocked_peers` list shape |
 
 No MCP tool mutates ACL in v1 — edit the file on the server and restart.
 

--- a/acl.yaml.example
+++ b/acl.yaml.example
@@ -3,14 +3,20 @@
 # Set ACL_ENABLED=true; default path {session_directory}/acl.yaml or ACL_CONFIG_PATH.
 # See docs/adr/0001-agent-scoped-session-acl.md and docs/research/acl-design-brief.md.
 #
-# Sensitive peers (Phase 1.5, planned): when ACL is enabled, the server always blocks MCP
-# access to built-in security peers (e.g. 777000 login codes, BotFather) — even if listed
-# under a token's chats. Operators cannot disable those defaults; optional deployment-wide
-# extension only:
+# Shared-host checklist: when ACL_ENABLED=true on a shared http-auth host, uncomment
+# blocked_peers below (or define your own list). Without blocked_peers, lane ACL alone
+# does not block login-code chats or BotFather — teammates with the same Bearer token
+# can still reach those peers via MCP tools.
+#
+# Recommend numeric ids first for MTProto coverage; optional @handle lines help pre-check.
+# Post-check on chat tools matches both resolved numeric id and username from results.
 #
 # blocked_peers:
-#   extend:
-#     - 1234567890
+#   - 777000          # Telegram service — login codes, security alerts
+#   - 93372553        # @BotFather — bot tokens, settings
+#   - 178220800       # @SpamBot — spam/limit appeals
+#   - "@BotFather"    # optional pre-check alias
+#   - "@SpamBot"
 
 tokens:
   # Agent profile: analyst (read-only lane — Saved Messages only)

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -104,7 +104,7 @@ Operator-facing enhancements beyond ACL enforcement (not implemented):
 
 | Item | Purpose |
 | --- | --- |
-| **Sensitive peer denylist (Phase 1.5)** | Server-enforced block on security-sensitive peers (`777000` login codes, BotFather, etc.) for **all** tokens when `ACL_ENABLED` — independent of `chats` allowlist. Addresses **shared-team human threat** (same Bearer token) reading PINs or managing bots via MCP. Optional `blocked_peers.extend` in `acl.yaml`. See [ADR 0001](adr/0001-agent-scoped-session-acl.md), [acl-design-brief.md](research/acl-design-brief.md). |
+| **Sensitive peer denylist (Phase 1.5)** | Operator-configured `blocked_peers` denylist for **all** tokens when non-empty — independent of `chats` allowlist. Dual pre/post enforcement; recommended defaults in `acl.yaml.example` + SECURITY.md. See [ADR 0001](adr/0001-agent-scoped-session-acl.md), [acl-design-brief.md](research/acl-design-brief.md). |
 | **Chat metadata registry** | Operator-curated metadata for whitelisted/shared chats so team agents can navigate `find_chats` results — human titles, descriptions, tags, and “look here for X” hints. Complements ACL **workspace lanes** (which chats a token may use) with **navigation hints** (what each chat is for); does not replace lane allowlists. Likely config alongside `acl.yaml` or a sibling file; enrichment at the tool boundary (e.g. post-filter on `find_chats`). |
 
 See [acl-design-brief.md](research/acl-design-brief.md) Phase 1.5 and Phase 3 for related ACL work.
@@ -138,7 +138,7 @@ See [evals/README.md](../evals/README.md) on branch `feature/evals`.
 
 | Item | Lane | Notes |
 | --- | --- | --- |
-| Sensitive peer denylist | Trust | Phase 1.5 — server defaults + `blocked_peers.extend`; see Trust lane planned scope |
+| Sensitive peer denylist | Trust | Phase 1.5 — operator `blocked_peers` list + dual enforcement; see Trust lane planned scope |
 | Per-token rate limits | Trust / ops | Complements telemetry FLOOD_WAIT signals |
 | SQLite read cache | Performance | Pairs with ACL whitelists |
 | ACL v2 permission matrix | Trust | Prgebish-style read/send per chat |

--- a/docs/adr/0001-agent-scoped-session-acl.md
+++ b/docs/adr/0001-agent-scoped-session-acl.md
@@ -28,7 +28,7 @@ ACL applies only when **`ACL_ENABLED=true`** on **http-auth**. No ACL on stdio o
 
 Human operators continue to use Telegram normally; guardrails reduce **accidental** cross-lane data mixup and **inadvertent** destructive tool actions by agents connected through this server, and — for shared tokens — **intentional** reads of security-sensitive peers via MCP tools.
 
-**Sensitive peer denylist:** When ACL is enabled, a server-maintained set of peer ids (login/service notifications, BotFather, etc.) is **always denied** for MCP tool access, even if a token’s `chats` allowlist would otherwise include them. Operators may **extend** the denylist per deployment; they cannot disable built-in defaults. This is guardrails for **blast radius on shared tokens**, not a substitute for rotating compromised tokens or Telegram-side 2FA.
+**Sensitive peer denylist:** When ACL is enabled and **`blocked_peers`** is configured (non-empty deployment list), those peers are **denied for all MCP tool access** for every Bearer token, even if a token’s `chats` allowlist would otherwise include them. Operators **own the full denylist** (add/remove any peer); recommended defaults live in [`acl.yaml.example`](../acl.yaml.example) and SECURITY.md only — not hardcoded at enforcement time. Omitting `blocked_peers` keeps lane-only ACL. This is guardrails for **blast radius on shared tokens**, not a substitute for rotating compromised tokens or Telegram-side 2FA.
 
 ## Consequences
 
@@ -41,7 +41,7 @@ Human operators continue to use Telegram normally; guardrails reduce **accidenta
 ### Defaults and phases
 
 - **Phase 1 (merge blockers):** correctness and operator docs — empty `chats` leak fix, malformed token handling, `read_only` requires `chats` validation, SECURITY.md runbook, alignment with this ADR.
-- **Phase 1.5 (Trust lane):** **sensitive peer denylist** — server defaults always on when `ACL_ENABLED`; optional operator `blocked_peers.extend`; enforced on chat-scoped tools, `find_chats` / global search post-filters, and `invoke_mtproto` / MTProto bridge (no bypass). See [acl-design-brief.md](../research/acl-design-brief.md).
+- **Phase 1.5 (Trust lane):** **sensitive peer denylist** — operator-configured `blocked_peers` list when present; dual pre/post enforcement (including resolved id + username post-check); MTProto shallow param scan before lane gates; recommended defaults in example + SECURITY.md only. See [acl-design-brief.md](../research/acl-design-brief.md).
 - **Phase 2 (v1.5):** `ACL_DEFAULT` env (default `full_access`), `allow_mtproto` default false for listed tokens, `allow_global_search` blocks MTProto for agent profiles, enforcement registry, config warnings.
 - **Phase 3 (roadmap, deferred):** file-watch reload, external ACL store, per-chat permission matrix — lower priority than agent-profile guardrails.
 

--- a/docs/research/acl-design-brief.md
+++ b/docs/research/acl-design-brief.md
@@ -51,30 +51,35 @@ Expressed as flags today; named profiles for operators:
 
 Phase 2 adds `**allow_mtproto`** (default **false** for listed tokens). When `allow_global_search` is false, MTProto remains blocked for that profile even if `read_only` is false.
 
-### Sensitive peers = server denylist (Phase 1.5)
-
-Orthogonal to **workspace lane** (`chats` allowlist):
+### Sensitive peers = deployment denylist (Phase 1.5)
 
 
 | Dimension           | `chats` (lane)                                               | `blocked_peers` (sensitive)                                          |
 | ------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------- |
 | **Question**        | Which chats may this token use?                              | Which peers must **never** be reachable via MCP tools?               |
-| **Default**         | Unlisted token → all chats; listed empty → deny all chat ops | **Built-in server list always applied** when `ACL_ENABLED`           |
-| **Operator config** | Per-token `chats`                                            | Optional **deployment-wide** `blocked_peers.extend` only             |
-| **Override**        | Per-token allowlist can include work ids                     | Operators **cannot** remove built-in sensitive ids                   |
+| **Default**         | Unlisted token → all chats; listed empty → deny all chat ops | **Omitted** → no sensitive blocking; lane ACL only                   |
+| **Operator config** | Per-token `chats`                                            | Optional **deployment-wide** list (operators own full denylist)      |
+| **Override**        | Per-token allowlist can include work ids                     | **Deny wins** if peer is both in `chats` and on `blocked_peers`      |
 | **Threat**          | Agent crosses work/personal boundary                         | Malicious teammate reads login PINs or revokes bots via shared token |
 
 
-Built-in defaults (see [Suggested default denylist](#suggested-default-denylist-research)) target account takeover and bot credential exposure. Human operators still use Telegram clients normally.
+Recommended defaults for shared hosts (example + SECURITY.md only — not enforced unless copied into config):
 
-**Minimal config shape (planned):**
+| Peer id | Handle | Why block |
+| ------- | ------ | --------- |
+| `777000` | Telegram service | Login codes, security alerts |
+| `93372553` | @BotFather | Bot tokens, settings |
+| `178220800` | @SpamBot | Spam/limit appeals |
+
+Human operators still use Telegram clients normally.
+
+**Minimal config shape:**
 
 ```yaml
-# Top-level — applies to every token when ACL_ENABLED=true
 blocked_peers:
-  extend:
-    - 1234567890          # optional numeric peer ids
-    # - "@SomeOfficialBot"  # deferred: resolve at enforcement like chats
+  - 777000
+  - 93372553
+  - "@BotFather"
 
 tokens:
   "<bearer-token>":
@@ -82,23 +87,24 @@ tokens:
     read_only: false
 ```
 
-- `**blocked_peers.extend**`: optional operator additions merged **on top of** immutable server defaults (not per-token in v1 — keeps shared-team policy consistent across tokens on one host).
-- **Env alternative (optional implementation):** `ACL_BLOCKED_PEERS_EXTEND` as comma-separated ids for containers without editing YAML.
-- **No `blocked_peers.defaults` in file** — defaults live in code + SECURITY.md; document ids and rationale there.
+- **`blocked_peers` omitted:** no sensitive blocking.
+- **`blocked_peers: []`:** explicit empty.
+- **Non-empty list:** enforced exactly as configured (int, numeric string, `@username` via same normalization as `chats`).
+- **Rejected:** `blocked_peers.extend`, per-token blocked lists, runtime MCP mutation.
 
-**Enforcement (when implemented):** same central checks as lane ACL; deny must win if a peer is both in `chats` and on the sensitive list.
+**Enforcement:** blocked-peer checks run **before** lane ACL for all tokens when the list is non-empty. Post-check on `get_chat_info` / `get_messages` matches resolved **numeric id and username**. Shallow MTProto param scan for numeric ids; invalid non-empty `params_json` → fail-closed when denylist is active.
 
 
 | Tool / route                            | Behavior                                                                                                                   |
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `get_messages`, `get_chat_info`         | Pre-check: `chat_id` not in sensitive set                                                                                  |
-| `send_message`, `edit_message`          | Pre-check: target chat not sensitive                                                                                       |
-| `find_chats`                            | Post-filter: drop sensitive peers from `chats[]`                                                                           |
-| `search_messages_globally`              | Post-filter: drop messages whose peer is sensitive                                                                         |
-| `invoke_mtproto`, `POST /mtproto-api/`* | Pre-check peer/chat/user id arguments where applicable; block TL methods whose target is a sensitive peer (no lane bypass) |
+| `get_messages`, `get_chat_info`         | Pre-check: input `chat_id`; post-check: resolved `id` / `username` (and message `chat` fallback for `get_messages`)      |
+| `send_message`, `edit_message`          | Pre-check: target chat not blocked                                                                                         |
+| `find_chats`                            | Post-filter: drop blocked peers from `chats[]`                                                                           |
+| `search_messages_globally`              | Post-filter: drop messages whose peer is blocked                                                                         |
+| `invoke_mtproto`, `POST /mtproto-api/*` | Blocked-peer param scan **before** listed-token gate; shallow numeric id keys only                                       |
 
 
-Errors should name the peer class (“sensitive peer blocked”) and point to SECURITY.md, not imply the operator can allowlist BotFather via `chats`.
+Errors: `Session ACL: blocked peer (<ref>) is denied for this deployment. See SECURITY.md.`
 
 ### Environment defaults (Phase 2)
 
@@ -115,10 +121,10 @@ Enable with `ACL_ENABLED=true`. Path: `ACL_CONFIG_PATH` or `{session_directory}/
 
 ```yaml
 # Agent guardrails: per-token lane + profile. Unlisted tokens = full_access.
-# When ACL is enabled, server-built-in sensitive peers are always blocked via MCP;
-# optional deployment extension (Phase 1.5):
+# Optional deployment denylist (shared hosts — see SECURITY.md):
 # blocked_peers:
-#   extend: []
+#   - 777000
+#   - 93372553
 
 tokens:
   "<bearer-token>":
@@ -179,11 +185,11 @@ Errors: MCP `ok: false` with actionable text; HTTP 403 on MTProto bridge.
 
 | Item                       | Rationale                                              |
 | -------------------------- | ------------------------------------------------------ |
-| Server default denylist    | `777000`, BotFather, etc. — not removable by operators |
-| `blocked_peers.extend`     | Optional deployment-wide extras                        |
-| Tool + MTProto enforcement | No bypass via `invoke_mtproto` or global search        |
-| SECURITY.md section        | List defaults, shared-team threat, extend syntax       |
-| Tests                      | Deny read/send/search for built-in ids; extend merges  |
+| Operator `blocked_peers` list | Deployment-owned denylist; recommended defaults in example + SECURITY.md |
+| Dual pre/post enforcement  | Closes @username ↔ numeric id bypass on chat tools     |
+| Tool + MTProto enforcement | Blocked scan before lane gate; shallow MTProto ids     |
+| SECURITY.md section        | Shared-host checklist, numeric-id rule, post-check behavior |
+| Tests                      | Deny/filter matrix in `test_session_acl.py`            |
 
 
 **Placement:** After Phase 1 merge blockers, **before** Phase 2 `allow_mtproto` / registry — so raw MTProto cannot read login-code chats while profile flags are still catching up.

--- a/src/server_components/mtproto_api.py
+++ b/src/server_components/mtproto_api.py
@@ -68,9 +68,38 @@ def register_mtproto_api_routes(mcp_app) -> None:
         allow_dangerous = bool(body.get("allow_dangerous", False))
 
         if config.require_auth:
-            from src.server_components.session_acl import check_mtproto_api_access
+            import json
+
+            from src.server_components.session_acl import (
+                _load_blocked_peers,
+                check_blocked_peer_mtproto_params,
+                check_mtproto_api_access,
+                merge_mtproto_request_params,
+            )
 
             token = extract_bearer_token_from_request(request)
+            if _load_blocked_peers():
+                try:
+                    merged_params = merge_mtproto_request_params(
+                        params if isinstance(params, dict) else {},
+                        params_json,
+                    )
+                except json.JSONDecodeError:
+                    error = log_and_build_error(
+                        operation="mtproto_api",
+                        error_message=(
+                            "Session ACL: invalid params_json when blocked_peers is configured. "
+                            "Provide valid JSON or omit params_json. See SECURITY.md."
+                        ),
+                        params={"params_json": params_json[:80] if params_json else ""},
+                        error_code=-32007,
+                    )
+                    return JSONResponse(error, status_code=403)
+                if blocked_denial := check_blocked_peer_mtproto_params(
+                    merged_params, operation="mtproto_api"
+                ):
+                    return JSONResponse(blocked_denial, status_code=403)
+
             if acl_denial := check_mtproto_api_access(token, allow_dangerous=allow_dangerous):
                 return JSONResponse(acl_denial, status_code=403)
 

--- a/src/server_components/mtproto_api.py
+++ b/src/server_components/mtproto_api.py
@@ -71,14 +71,14 @@ def register_mtproto_api_routes(mcp_app) -> None:
             import json
 
             from src.server_components.session_acl import (
-                _load_blocked_peers,
+                blocked_peers_configured,
                 check_blocked_peer_mtproto_params,
                 check_mtproto_api_access,
                 merge_mtproto_request_params,
             )
 
             token = extract_bearer_token_from_request(request)
-            if _load_blocked_peers():
+            if blocked_peers_configured():
                 try:
                     merged_params = merge_mtproto_request_params(
                         params if isinstance(params, dict) else {},

--- a/src/server_components/session_acl.py
+++ b/src/server_components/session_acl.py
@@ -45,6 +45,17 @@ _LISTED_TOKEN_MTPROTO_DENY_MSG = (
 _LISTED_TOKEN_MTPROTO_API_DENY_MSG = (
     "Session ACL: HTTP MTProto bridge is not permitted for tokens listed in the ACL config."
 )
+_BLOCKED_PEER_DENY_MSG = (
+    "Session ACL: blocked peer ({ref}) is denied for this deployment. See SECURITY.md."
+)
+_INVALID_MTPROTO_JSON_DENY_MSG = (
+    "Session ACL: invalid params_json when blocked_peers is configured. "
+    "Provide valid JSON or omit params_json. See SECURITY.md."
+)
+_MTPROTO_PEER_ID_KEYS = frozenset({"user_id", "chat_id", "channel_id", "peer_id", "id"})
+_CHAT_SCOPED_OPERATIONS = frozenset(
+    {"get_messages", "get_chat_info", "send_message", "edit_message"}
+)
 
 _acl_cache: dict[str, Any] | None = None
 _acl_cache_path: Path | None = None
@@ -106,6 +117,31 @@ def _validate_acl_document(doc: dict[str, Any], path: Path) -> None:
                 f"ACL token prefix {prefix}... has read_only: true but empty or missing "
                 f"chats. Analyst profile requires a non-empty chat lane: {path}"
             )
+
+    blocked = doc.get("blocked_peers")
+    if blocked is None:
+        return
+    if not isinstance(blocked, list):
+        raise AclConfigError(
+            f"ACL config 'blocked_peers' must be a list when present: {path}"
+        )
+    for index, item in enumerate(blocked):
+        if not _is_valid_blocked_peer_entry(item):
+            raise AclConfigError(
+                f"ACL config blocked_peers[{index}] is invalid (expected int, numeric "
+                f"string, or @username): {path}"
+            )
+
+
+def _is_valid_blocked_peer_entry(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    if not isinstance(value, str):
+        return False
+    normalized = _normalize_chat_ref(value)
+    return normalized != ""
 
 
 def validate_acl_config() -> None:
@@ -214,6 +250,194 @@ def _chat_ref_matches(allowed: str | int, candidate: str | int) -> bool:
     return False
 
 
+def _load_blocked_peers() -> frozenset[str | int]:
+    config = get_config()
+    if not config.acl_enabled or config.disable_auth:
+        return frozenset()
+    doc = _load_acl_document()
+    raw = doc.get("blocked_peers")
+    if raw is None:
+        return frozenset()
+    if not isinstance(raw, list):
+        return frozenset()
+    peers: set[str | int] = set()
+    for item in raw:
+        peers.add(_normalize_chat_ref(item))
+    return frozenset(peers)
+
+
+def _blocked_peers_active() -> bool:
+    return bool(_load_blocked_peers())
+
+
+def _is_blocked_peer(ref: Any) -> bool:
+    normalized = _normalize_chat_ref(ref)
+    if normalized == "":
+        return False
+    return any(_chat_ref_matches(blocked, normalized) for blocked in _load_blocked_peers())
+
+
+def _deny_blocked_peer(
+    operation: str, ref: str | int, params: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    return _deny(
+        operation,
+        _BLOCKED_PEER_DENY_MSG.format(ref=ref),
+        params=params,
+    )
+
+
+def _first_blocked_ref(refs: list[str | int]) -> str | int | None:
+    for ref in refs:
+        if _is_blocked_peer(ref):
+            return ref
+    return None
+
+
+def _peer_refs_from_result(operation: str, result: dict[str, Any]) -> list[str | int]:
+    refs: list[str | int] = []
+
+    def _append_ref(value: Any) -> None:
+        if value is None:
+            return
+        normalized = _normalize_chat_ref(value)
+        if normalized != "":
+            refs.append(normalized)
+
+    if operation == "get_chat_info":
+        _append_ref(result.get("id"))
+        _append_ref(result.get("username"))
+        return refs
+
+    if operation == "get_messages":
+        _append_ref(result.get("chat_id"))
+        chat = result.get("chat")
+        if isinstance(chat, dict):
+            _append_ref(chat.get("id"))
+            _append_ref(chat.get("username"))
+        messages = result.get("messages")
+        if isinstance(messages, list):
+            for message in messages:
+                if not isinstance(message, dict):
+                    continue
+                msg_chat = message.get("chat")
+                if isinstance(msg_chat, dict):
+                    _append_ref(msg_chat.get("id"))
+                    _append_ref(msg_chat.get("username"))
+                    break
+        return refs
+
+    return refs
+
+
+def merge_mtproto_request_params(params: dict[str, Any], params_json: str) -> dict[str, Any]:
+    """Merge HTTP/tool MTProto params dict with optional params_json string."""
+    merged = dict(params) if isinstance(params, dict) else {}
+    if not params_json:
+        return merged
+    parsed = json.loads(params_json)
+    if not isinstance(parsed, dict):
+        raise json.JSONDecodeError("params_json must decode to a JSON object", params_json, 0)
+    merged.update(parsed)
+    return merged
+
+
+def _extract_peer_ids_from_mtproto_params(params: dict[str, Any]) -> set[int]:
+    ids: set[int] = set()
+    if not isinstance(params, dict):
+        return ids
+    for key, value in params.items():
+        if key in _MTPROTO_PEER_ID_KEYS and isinstance(value, int) and not isinstance(value, bool):
+            ids.add(value)
+        elif isinstance(value, dict):
+            for nested_key, nested_value in value.items():
+                if (
+                    nested_key in _MTPROTO_PEER_ID_KEYS
+                    and isinstance(nested_value, int)
+                    and not isinstance(nested_value, bool)
+                ):
+                    ids.add(nested_value)
+    return ids
+
+
+def check_blocked_peer_mtproto_params(
+    params: dict[str, Any], *, operation: str = "invoke_mtproto"
+) -> dict[str, Any] | None:
+    """Return denial when merged MTProto params reference a numeric blocked peer id."""
+    blocked = _load_blocked_peers()
+    if not blocked:
+        return None
+    numeric_blocked = {peer for peer in blocked if isinstance(peer, int)}
+    if not numeric_blocked:
+        return None
+    for peer_id in _extract_peer_ids_from_mtproto_params(params):
+        if peer_id in numeric_blocked:
+            return _deny_blocked_peer(operation, peer_id, params=params)
+    return None
+
+
+def _check_blocked_peer_pre(
+    operation: str, kwargs: dict[str, Any]
+) -> dict[str, Any] | None:
+    if operation == "invoke_mtproto":
+        params_json = kwargs.get("params_json") or ""
+        raw_params = kwargs.get("params")
+        params = raw_params if isinstance(raw_params, dict) else {}
+        if params_json:
+            try:
+                merged = merge_mtproto_request_params(params, params_json)
+            except json.JSONDecodeError:
+                return _deny(
+                    operation,
+                    _INVALID_MTPROTO_JSON_DENY_MSG,
+                    params=kwargs,
+                )
+        else:
+            merged = params
+        return check_blocked_peer_mtproto_params(merged)
+
+    chat_id = kwargs.get("chat_id")
+    if chat_id is not None and operation in _CHAT_SCOPED_OPERATIONS:
+        if _is_blocked_peer(chat_id):
+            return _deny_blocked_peer(operation, _normalize_chat_ref(chat_id), {"chat_id": chat_id})
+    return None
+
+
+def _filter_blocked_peers_from_result(operation: str, result: dict[str, Any]) -> Any:
+    if operation in {"get_chat_info", "get_messages"}:
+        blocked_ref = _first_blocked_ref(_peer_refs_from_result(operation, result))
+        if blocked_ref is not None:
+            return _deny_blocked_peer(operation, blocked_ref)
+
+    if operation == "find_chats" and isinstance(result.get("chats"), list):
+        filtered = [
+            chat
+            for chat in result["chats"]
+            if isinstance(chat, dict)
+            and _first_blocked_ref(
+                [
+                    _normalize_chat_ref(chat.get("id")),
+                    _normalize_chat_ref(chat.get("chat_id")),
+                    _normalize_chat_ref(chat.get("username")),
+                ]
+            )
+            is None
+        ]
+        return {**result, "chats": filtered}
+
+    if operation == "search_messages_globally" and isinstance(result.get("messages"), list):
+        filtered = [
+            msg
+            for msg in result["messages"]
+            if isinstance(msg, dict)
+            and (cid := _message_chat_id(msg)) is not None
+            and not _is_blocked_peer(cid)
+        ]
+        return {**result, "messages": filtered}
+
+    return result
+
+
 def _is_empty_lane(rule: TokenAclRule) -> bool:
     return not rule.chats
 
@@ -246,6 +470,14 @@ def _bind_tool_kwargs(
 def check_pre_tool_access(operation_name: str, kwargs: dict[str, Any]) -> dict[str, Any] | None:
     """Return an error dict when the tool call must be blocked, else None."""
     from src.client.connection import get_request_token
+
+    config = get_config()
+    if not config.acl_enabled or config.disable_auth:
+        return None
+
+    if _blocked_peers_active():
+        if blocked_denial := _check_blocked_peer_pre(operation_name, kwargs):
+            return blocked_denial
 
     rule = _rules_for_token(get_request_token())
     if rule is None:
@@ -325,8 +557,19 @@ def filter_tool_result(operation_name: str, result: Any) -> Any:
     """Post-filter tool results to enforce chat whitelist on list payloads."""
     from src.client.connection import get_request_token
 
+    if not isinstance(result, dict):
+        return result
+    if result.get("ok") is False:
+        return result
+
+    config = get_config()
+    if config.acl_enabled and not config.disable_auth and _blocked_peers_active():
+        result = _filter_blocked_peers_from_result(operation_name, result)
+        if isinstance(result, dict) and result.get("ok") is False:
+            return result
+
     rule = _rules_for_token(get_request_token())
-    if rule is None or not isinstance(result, dict):
+    if rule is None:
         return result
 
     if _is_empty_lane(rule):

--- a/src/server_components/session_acl.py
+++ b/src/server_components/session_acl.py
@@ -59,6 +59,7 @@ _CHAT_SCOPED_OPERATIONS = frozenset(
 
 _acl_cache: dict[str, Any] | None = None
 _acl_cache_path: Path | None = None
+_blocked_peers_cache: frozenset[str | int] | None = None
 
 
 @dataclass(frozen=True)
@@ -82,9 +83,10 @@ class TokenAclRule:
 
 def clear_acl_cache() -> None:
     """Reset loaded ACL config (for tests)."""
-    global _acl_cache, _acl_cache_path
+    global _acl_cache, _acl_cache_path, _blocked_peers_cache
     _acl_cache = None
     _acl_cache_path = None
+    _blocked_peers_cache = None
 
 
 def _configured_acl_path() -> Path | None:
@@ -158,12 +160,23 @@ def validate_acl_config() -> None:
     _load_acl_document()
 
 
+def _blocked_peers_from_doc(doc: dict[str, Any]) -> frozenset[str | int]:
+    raw = doc.get("blocked_peers")
+    if not isinstance(raw, list):
+        return frozenset()
+    peers: set[str | int] = set()
+    for item in raw:
+        peers.add(_normalize_chat_ref(item))
+    return frozenset(peers)
+
+
 def _load_acl_document() -> dict[str, Any]:
-    global _acl_cache, _acl_cache_path
+    global _acl_cache, _acl_cache_path, _blocked_peers_cache
     path = _configured_acl_path()
     if path is None:
         _acl_cache = {}
         _acl_cache_path = None
+        _blocked_peers_cache = frozenset()
         return _acl_cache
 
     if not path.is_file():
@@ -193,6 +206,7 @@ def _load_acl_document() -> dict[str, Any]:
 
     _acl_cache = doc
     _acl_cache_path = path
+    _blocked_peers_cache = _blocked_peers_from_doc(doc)
     logger.info("Loaded session ACL config from %s", path)
     return _acl_cache
 
@@ -254,16 +268,16 @@ def _load_blocked_peers() -> frozenset[str | int]:
     config = get_config()
     if not config.acl_enabled or config.disable_auth:
         return frozenset()
-    doc = _load_acl_document()
-    raw = doc.get("blocked_peers")
-    if raw is None:
-        return frozenset()
-    if not isinstance(raw, list):
-        return frozenset()
-    peers: set[str | int] = set()
-    for item in raw:
-        peers.add(_normalize_chat_ref(item))
-    return frozenset(peers)
+    global _blocked_peers_cache
+    if _blocked_peers_cache is not None:
+        return _blocked_peers_cache
+    _load_acl_document()
+    return _blocked_peers_cache if _blocked_peers_cache is not None else frozenset()
+
+
+def blocked_peers_configured() -> bool:
+    """True when ACL is on and blocked_peers is a non-empty deployment list."""
+    return bool(_load_blocked_peers())
 
 
 def _blocked_peers_active() -> bool:
@@ -324,7 +338,6 @@ def _peer_refs_from_result(operation: str, result: dict[str, Any]) -> list[str |
                 if isinstance(msg_chat, dict):
                     _append_ref(msg_chat.get("id"))
                     _append_ref(msg_chat.get("username"))
-                    break
         return refs
 
     return refs

--- a/tests/test_session_acl.py
+++ b/tests/test_session_acl.py
@@ -11,11 +11,13 @@ from src.client.connection import set_request_token
 from src.config.server_config import ServerConfig, ServerMode, set_config
 from src.server_components.session_acl import (
     TokenAclRule,
+    check_blocked_peer_mtproto_params,
     check_mtproto_api_access,
     check_pre_tool_access,
     clear_acl_cache,
     enforce_session_acl,
     filter_tool_result,
+    merge_mtproto_request_params,
     validate_acl_config,
     AclConfigError,
 )
@@ -358,3 +360,270 @@ def test_validate_acl_rejects_malformed_token_entry(tmp_path):
     set_config(config)
     with pytest.raises(AclConfigError, match="must be a mapping"):
         validate_acl_config()
+
+
+# --- Phase 1.5: blocked_peers denylist ---
+
+BOTFATHER_ID = 93372553
+LOGIN_SERVICE_ID = 777000
+
+
+def _write_acl_config(tmp_path: Path, body: str) -> Path:
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(body, encoding="utf-8")
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = True
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    return acl_file
+
+
+@pytest.fixture
+def blocked_peers_base_config(tmp_path: Path):
+    return _write_acl_config(
+        tmp_path,
+        f"""
+blocked_peers:
+  - {BOTFATHER_ID}
+tokens:
+  token-team:
+    chats:
+      - {BOTFATHER_ID}
+      - -1001234567890
+    read_only: false
+""",
+    )
+
+
+def test_blocked_peers_omitted_no_blocking(tmp_path):
+    _write_acl_config(
+        tmp_path,
+        f"""
+tokens:
+  t:
+    chats:
+      - {BOTFATHER_ID}
+""",
+    )
+    set_request_token("unlisted-token")
+    assert check_pre_tool_access("get_messages", {"chat_id": BOTFATHER_ID}) is None
+
+
+def test_blocked_peers_numeric_input_pre_check_deny(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    denial = check_pre_tool_access("get_messages", {"chat_id": BOTFATHER_ID})
+    assert denial is not None
+    assert denial["error_code"] == -32007
+    assert "blocked peer" in denial["error"]
+    assert str(BOTFATHER_ID) in denial["error"]
+
+
+def test_blocked_peers_numeric_yaml_at_username_input_post_check_deny(
+    blocked_peers_base_config,
+):
+    set_request_token("unlisted-token")
+    assert check_pre_tool_access("get_chat_info", {"chat_id": "@BotFather"}) is None
+    denial = filter_tool_result(
+        "get_chat_info",
+        {"ok": True, "id": BOTFATHER_ID, "title": "BotFather"},
+    )
+    assert denial["ok"] is False
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_at_username_yaml_numeric_input_post_check_deny(tmp_path):
+    _write_acl_config(
+        tmp_path,
+        """
+blocked_peers:
+  - "@BotFather"
+tokens: {}
+""",
+    )
+    set_request_token("unlisted-token")
+    assert check_pre_tool_access("get_chat_info", {"chat_id": BOTFATHER_ID}) is None
+    denial = filter_tool_result(
+        "get_chat_info",
+        {"ok": True, "id": BOTFATHER_ID, "username": "BotFather"},
+    )
+    assert denial["ok"] is False
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_at_username_input_pre_check_deny(tmp_path):
+    _write_acl_config(
+        tmp_path,
+        """
+blocked_peers:
+  - "@BotFather"
+tokens: {}
+""",
+    )
+    set_request_token("unlisted-token")
+    denial = check_pre_tool_access("get_chat_info", {"chat_id": "@BotFather"})
+    assert denial is not None
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_omitted_id_allowed(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    assert check_pre_tool_access("get_messages", {"chat_id": LOGIN_SERVICE_ID}) is None
+
+
+def test_blocked_peers_deny_wins_over_token_lane(blocked_peers_base_config):
+    set_request_token("token-team")
+    denial = check_pre_tool_access("get_messages", {"chat_id": BOTFATHER_ID})
+    assert denial is not None
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_find_chats_post_filter_unlisted_token(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    result = filter_tool_result(
+        "find_chats",
+        {
+            "ok": True,
+            "chats": [
+                {"id": BOTFATHER_ID, "title": "BotFather"},
+                {"id": -1001234567890, "title": "Work"},
+            ],
+        },
+    )
+    assert len(result["chats"]) == 1
+    assert result["chats"][0]["id"] == -1001234567890
+
+
+def test_blocked_peers_global_search_post_filter_unlisted_token(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    result = filter_tool_result(
+        "search_messages_globally",
+        {
+            "ok": True,
+            "messages": [
+                {"id": 1, "chat_id": BOTFATHER_ID},
+                {"id": 2, "chat_id": -1001234567890},
+            ],
+        },
+    )
+    assert len(result["messages"]) == 1
+    assert result["messages"][0]["chat_id"] == -1001234567890
+
+
+def test_blocked_peers_get_chat_info_post_check_id_only(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    denial = filter_tool_result(
+        "get_chat_info",
+        {"ok": True, "id": BOTFATHER_ID, "title": "BotFather"},
+    )
+    assert denial["ok"] is False
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_get_chat_info_post_check_username_only(tmp_path):
+    _write_acl_config(
+        tmp_path,
+        """
+blocked_peers:
+  - "@BotFather"
+tokens: {}
+""",
+    )
+    set_request_token("unlisted-token")
+    denial = filter_tool_result(
+        "get_chat_info",
+        {"ok": True, "id": 999, "username": "BotFather"},
+    )
+    assert denial["ok"] is False
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_get_chat_info_post_check_id_and_username(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    denial = filter_tool_result(
+        "get_chat_info",
+        {"ok": True, "id": BOTFATHER_ID, "username": "BotFather"},
+    )
+    assert denial["ok"] is False
+
+
+def test_blocked_peers_get_messages_post_check_message_chat_fallback(
+    blocked_peers_base_config,
+):
+    set_request_token("unlisted-token")
+    assert check_pre_tool_access("get_messages", {"chat_id": "@BotFather"}) is None
+    denial = filter_tool_result(
+        "get_messages",
+        {
+            "ok": True,
+            "messages": [
+                {"id": 1, "chat": {"id": BOTFATHER_ID, "username": "BotFather"}},
+            ],
+        },
+    )
+    assert denial["ok"] is False
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_invoke_mtproto_param_scan(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    denial = check_pre_tool_access(
+        "invoke_mtproto",
+        {"params_json": json.dumps({"peer": {"user_id": BOTFATHER_ID}})},
+    )
+    assert denial is not None
+    assert "blocked peer" in denial["error"]
+
+
+def test_blocked_peers_invoke_mtproto_invalid_json_fail_closed(blocked_peers_base_config):
+    set_request_token("unlisted-token")
+    denial = check_pre_tool_access(
+        "invoke_mtproto",
+        {"params_json": "{not-json"},
+    )
+    assert denial is not None
+    assert "invalid params_json" in denial["error"].lower()
+
+
+def test_blocked_peers_mtproto_http_merge_and_scan(blocked_peers_base_config):
+    merged = merge_mtproto_request_params(
+        {"peer": {"user_id": BOTFATHER_ID}},
+        json.dumps({"limit": 10}),
+    )
+    denial = check_blocked_peer_mtproto_params(merged, operation="mtproto_api")
+    assert denial is not None
+    assert denial["operation"] == "mtproto_api"
+    assert "blocked peer" in denial["error"]
+
+
+def test_validate_acl_rejects_malformed_blocked_peers(tmp_path):
+    _write_acl_config(
+        tmp_path,
+        """
+blocked_peers:
+  extend:
+    - 123
+tokens: {}
+""",
+    )
+    with pytest.raises(AclConfigError, match="blocked_peers"):
+        validate_acl_config()
+
+
+def test_blocked_peers_skipped_when_acl_disabled(tmp_path):
+    acl_file = tmp_path / "acl.yaml"
+    acl_file.write_text(
+        f"""
+blocked_peers:
+  - {BOTFATHER_ID}
+tokens: {{}}
+""",
+        encoding="utf-8",
+    )
+    config = ServerConfig(_cli_parse_args=[])
+    config.server_mode = ServerMode.HTTP_AUTH
+    config.acl_enabled = False
+    config.acl_config_path = str(acl_file)
+    set_config(config)
+    set_request_token("any")
+    assert check_pre_tool_access("get_messages", {"chat_id": BOTFATHER_ID}) is None


### PR DESCRIPTION
## Summary
- Operator-authoritative optional `blocked_peers` list in `acl.yaml` (recommended defaults in example only; omit section for lanes-only ACL)
- Dual pre/post enforcement for all tokens when list is non-empty: pre-check on tool input, post-check on resolved id + username from tool results
- MTProto param scan before listed-token gate; fail-closed invalid JSON when blocked peers configured
- Docs: SECURITY.md shared-host checklist, ADR 0001, acl-design-brief, Roadmap

## Test plan
- [x] `uv run pytest tests/test_session_acl.py tests/test_mcp_tool_acl_integration.py -q`
- [x] `uv run pytest -q --tb=short`

## Summary by Sourcery

Ввести настраиваемый оператором, действующий на весь деплоймент denylist `blocked_peers` для ACL сессии с двойным (pre/post) механизмом принудительного применения для инструментов MCP и MTProto, а также задокументировать его поведение и рекомендованное использование для деплойментов на общих хостах.

New Features:
- Добавить необязательный список `blocked_peers` в конфиг ACL как denylist на уровне всего деплоймента, применяемый ко всем bearer-токенам, независимо от чат-лейнов отдельных токенов.
- Применять блокировку peers через предварительные проверки (pre-checks) для инструментов с областью действия чата и параметров MTProto, а также через пост-фильтрацию (post-filtering) результатов работы инструментов, включая разрешение id/username и списковые payload’ы.
- Предоставить помощники (helpers) для слияния параметров MTProto с `params_json` и сканирования на заблокированные peer ID как в слое MCP, так и в HTTP-мосте MTProto.

Enhancements:
- Обновить загрузку, валидацию и кэширование ACL сессии для поддержки `blocked_peers`, включая fail-closed старт при некорректной конфигурации denylist и приоритет denylist над лейнами токенов.
- Уточнить дизайн-документацию по ACL, ADR 0001, roadmap и активный контекст, чтобы отразить модель `blocked_peers`, семантику принудительного применения и фазовый статус.

Documentation:
- Расширить SECURITY.md рекомендациями, рекомендуемыми значениями по умолчанию и разделом по устранению неполадок для `blocked_peers` в деплойментах на общих хостах.
- Переработать краткий дизайн-док по ACL и roadmap, чтобы описать denylist уровня деплоймента, матрицу применения и ответственность оператора за конфигурацию чувствительных peers.

Tests:
- Добавить комплексные тесты ACL, покрывающие поведение `blocked_peers` для pre/post-применения, сканирование параметров MTProto, валидацию конфигурации и поведение при отключённом ACL.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an operator-configured deployment-wide `blocked_peers` denylist to the session ACL with dual pre/post enforcement across MCP tools and MTProto, and document its behavior and recommended usage for shared-host deployments.

New Features:
- Add optional `blocked_peers` list in the ACL config as a deployment-wide denylist applied to all bearer tokens, independent of per-token chat lanes.
- Enforce blocked peers via pre-checks on chat-scoped tools and MTProto parameters plus post-filtering of tool results, including id/username resolution and list payloads.
- Expose helpers for merging MTProto params with `params_json` and scanning for blocked peer IDs in both the MCP layer and HTTP MTProto bridge.

Enhancements:
- Update session ACL loading, validation, and caching to support `blocked_peers`, including fail-closed startup on malformed denylist config and priority of denylist over token lanes.
- Refine ACL design docs, ADR 0001, roadmap, and active context to reflect the `blocked_peers` model, enforcement semantics, and phase status.

Documentation:
- Extend SECURITY.md with guidance, recommended defaults, and troubleshooting for `blocked_peers` on shared-host deployments.
- Revise the ACL design brief and roadmap to describe the deployment denylist, enforcement matrix, and operator ownership of sensitive peer configuration.

Tests:
- Add comprehensive ACL tests covering `blocked_peers` behavior for pre/post enforcement, MTProto param scanning, config validation, and disabled-ACL behavior.

</details>

Новые возможности:
- Ввод необязательного списка `blocked_peers` в конфиг ACL, применяемого ко всем токенам как деплоймент‑wide denylist, независимый от chat lanes.
- Принудительное применение блокировки пиров через предварительные проверки для инструментов с областью видимости чата и запросов MTProto, а также пост‑фильтрацию результатов инструментов, включая разрешённые ids и usernames.

Улучшения:
- Обновить поведение ACL сессии и MTProto bridge так, чтобы при активном denylist происходил отказ по принципу «fail closed» при некорректном MTProto JSON, и чтобы заблокированные пиры имели приоритет над chat lanes, задаваемыми на уровне отдельных токенов.
- Уточнить дизайн‑документацию ACL, ADR, roadmap и активный контекст, чтобы описать модель denylist `blocked_peers` и семантику её применения.

Документация:
- Расширить SECURITY.md рекомендациями, рекомендуемыми значениями по умолчанию и советами по устранению неполадок для denylist `blocked_peers` и деплойментов на shared‑host.

Тесты:
- Добавить комплексные тесты ACL, покрывающие предварительное/последующее применение блокировки пиров, сканирование параметров MTProto, валидацию конфига и поведение при отключённом ACL.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести настраиваемый оператором, действующий на весь деплоймент denylist `blocked_peers` для ACL сессии с двойным (pre/post) механизмом принудительного применения для инструментов MCP и MTProto, а также задокументировать его поведение и рекомендованное использование для деплойментов на общих хостах.

New Features:
- Добавить необязательный список `blocked_peers` в конфиг ACL как denylist на уровне всего деплоймента, применяемый ко всем bearer-токенам, независимо от чат-лейнов отдельных токенов.
- Применять блокировку peers через предварительные проверки (pre-checks) для инструментов с областью действия чата и параметров MTProto, а также через пост-фильтрацию (post-filtering) результатов работы инструментов, включая разрешение id/username и списковые payload’ы.
- Предоставить помощники (helpers) для слияния параметров MTProto с `params_json` и сканирования на заблокированные peer ID как в слое MCP, так и в HTTP-мосте MTProto.

Enhancements:
- Обновить загрузку, валидацию и кэширование ACL сессии для поддержки `blocked_peers`, включая fail-closed старт при некорректной конфигурации denylist и приоритет denylist над лейнами токенов.
- Уточнить дизайн-документацию по ACL, ADR 0001, roadmap и активный контекст, чтобы отразить модель `blocked_peers`, семантику принудительного применения и фазовый статус.

Documentation:
- Расширить SECURITY.md рекомендациями, рекомендуемыми значениями по умолчанию и разделом по устранению неполадок для `blocked_peers` в деплойментах на общих хостах.
- Переработать краткий дизайн-док по ACL и roadmap, чтобы описать denylist уровня деплоймента, матрицу применения и ответственность оператора за конфигурацию чувствительных peers.

Tests:
- Добавить комплексные тесты ACL, покрывающие поведение `blocked_peers` для pre/post-применения, сканирование параметров MTProto, валидацию конфигурации и поведение при отключённом ACL.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an operator-configured deployment-wide `blocked_peers` denylist to the session ACL with dual pre/post enforcement across MCP tools and MTProto, and document its behavior and recommended usage for shared-host deployments.

New Features:
- Add optional `blocked_peers` list in the ACL config as a deployment-wide denylist applied to all bearer tokens, independent of per-token chat lanes.
- Enforce blocked peers via pre-checks on chat-scoped tools and MTProto parameters plus post-filtering of tool results, including id/username resolution and list payloads.
- Expose helpers for merging MTProto params with `params_json` and scanning for blocked peer IDs in both the MCP layer and HTTP MTProto bridge.

Enhancements:
- Update session ACL loading, validation, and caching to support `blocked_peers`, including fail-closed startup on malformed denylist config and priority of denylist over token lanes.
- Refine ACL design docs, ADR 0001, roadmap, and active context to reflect the `blocked_peers` model, enforcement semantics, and phase status.

Documentation:
- Extend SECURITY.md with guidance, recommended defaults, and troubleshooting for `blocked_peers` on shared-host deployments.
- Revise the ACL design brief and roadmap to describe the deployment denylist, enforcement matrix, and operator ownership of sensitive peer configuration.

Tests:
- Add comprehensive ACL tests covering `blocked_peers` behavior for pre/post enforcement, MTProto param scanning, config validation, and disabled-ACL behavior.

</details>

</details>