### PR TITLE
feat: bot_token auto-auth for Try in Browser & ephemeral deployments

### DIFF
--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,6 +1,12 @@
 ## Current Work Focus
 
-**Trust lane — Session ACL (2026-05-27):** Phase 1.5 shipped — release [`0.21.0`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.21.0) (PR #57). Operator `blocked_peers` denylist with dual pre/post enforcement. **Next:** Phase 2 — `ACL_DEFAULT`, `allow_mtproto`, enforcement registry. [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md).
+**Bot token runtime auth (2026-05-28):** PR #62 — `BOT_TOKEN` env var support in `ServerConfig` + auto-auth in `connection.py`. When `BOT_TOKEN` is set and no session file exists, server auto-authenticates via `client.start(bot_token=...)`. No OTP, no interactive setup. Enables Glama "Try in Browser" and simplifies onboarding for bot accounts. Documentation updated (README, Installation.md, .env.example).
+
+**Next:** Trust lane — Session ACL Phase 2: `ACL_DEFAULT`, `allow_mtproto`, enforcement registry. [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md).
+
+**Shipped (2026-05-28):** Bot token runtime auth — PR #62. Docs updated. glama.json already has `BOT_TOKEN` env var (PR #61).
+
+**Trust lane — Session ACL (2026-05-27):** Phase 1.5 shipped — release [`0.21.0`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.21.0) (PR #57). Operator `blocked_peers` denylist with dual pre/post enforcement.
 
 - **Implementation:** [session_acl.py](../src/server_components/session_acl.py), `blocked_peers` in ACL YAML, [acl.yaml.example](../acl.yaml.example), [SECURITY.md](../SECURITY.md)
 - **Design:** [acl-design-brief.md](../docs/research/acl-design-brief.md) (Phases 1–3)

--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -1,10 +1,10 @@
 ## Current Work Focus
 
-**Bot token runtime auth (2026-05-28):** PR #62 — `BOT_TOKEN` env var support in `ServerConfig` + auto-auth in `connection.py`. When `BOT_TOKEN` is set and no session file exists, server auto-authenticates via `client.start(bot_token=...)`. No OTP, no interactive setup. Enables Glama "Try in Browser" and simplifies onboarding for bot accounts. Documentation updated (README, Installation.md, .env.example).
+**Bot token runtime auth (2026-05-28):** PR #62 — `BOT_API_TOKEN` env var support in `ServerConfig` + auto-auth in `connection.py`. When `BOT_API_TOKEN` is set and no session file exists, server auto-authenticates via `client.start(bot_api_token=...)`. No OTP, no interactive setup. Enables Glama "Try in Browser" and simplifies onboarding for bot accounts. Documentation updated (README, Installation.md, .env.example).
 
 **Next:** Trust lane — Session ACL Phase 2: `ACL_DEFAULT`, `allow_mtproto`, enforcement registry. [ADR 0001](../docs/adr/0001-agent-scoped-session-acl.md).
 
-**Shipped (2026-05-28):** Bot token runtime auth — PR #62. Docs updated. glama.json already has `BOT_TOKEN` env var (PR #61).
+**Shipped (2026-05-28):** Bot token runtime auth — PR #62. Docs updated. glama.json already has `BOT_API_TOKEN` env var (PR #61).
 
 **Trust lane — Session ACL (2026-05-27):** Phase 1.5 shipped — release [`0.21.0`](https://github.com/leshchenko1979/fast-mcp-telegram/releases/tag/0.21.0) (PR #57). Operator `blocked_peers` denylist with dual pre/post enforcement.
 

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,5 +1,5 @@
 ### 2026-05-28
-- **Bot Token Runtime Auth (PR #62):** Added `BOT_TOKEN` env var to `ServerConfig`. When `BOT_TOKEN` is set and no session file exists, `connection.py` auto-authenticates via `client.start(bot_token=...)` before `verify_authorized_connection()`. No interactive setup needed — enables Glama "Try in Browser" and simplifies bot account onboarding. Docs updated (README, Installation.md, .env.example, glama.json). Memory bank updated.
+- **Bot Token Runtime Auth (PR #62):** Added `BOT_API_TOKEN` env var to `ServerConfig`. When `BOT_API_TOKEN` is set and no session file exists, `connection.py` auto-authenticates via `client.start(bot_api_token=...)` before `verify_authorized_connection()`. No interactive setup needed — enables Glama "Try in Browser" and simplifies bot account onboarding. Docs updated (README, Installation.md, .env.example, glama.json). Memory bank updated.
 
 ### 2026-05-27
 - **0.21.0 — Session ACL Phase 1.5:** PR #57 merged; optional operator `blocked_peers` YAML list, dual pre/post enforcement (id + username), MTProto param gate; PyPI + GHCR. GitHub release `0.21.0`.

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -1,3 +1,6 @@
+### 2026-05-28
+- **Bot Token Runtime Auth (PR #62):** Added `BOT_TOKEN` env var to `ServerConfig`. When `BOT_TOKEN` is set and no session file exists, `connection.py` auto-authenticates via `client.start(bot_token=...)` before `verify_authorized_connection()`. No interactive setup needed — enables Glama "Try in Browser" and simplifies bot account onboarding. Docs updated (README, Installation.md, .env.example, glama.json). Memory bank updated.
+
 ### 2026-05-27
 - **0.21.0 — Session ACL Phase 1.5:** PR #57 merged; optional operator `blocked_peers` YAML list, dual pre/post enforcement (id + username), MTProto param gate; PyPI + GHCR. GitHub release `0.21.0`.
 - **Phase 1.5 — Session ACL blocked_peers:** Operator-configured deployment denylist; dual pre/post enforcement (id + username post-check); MTProto shallow scan before lane gate; SECURITY.md shared-host checklist; tests in `test_session_acl.py`.

--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,13 @@
 #
 # Two authentication methods (pick one):
 #   1) User account (phone + OTP): API_ID + API_HASH + PHONE_NUMBER (run --setup)
-#   2) Bot account (no phone, no OTP): API_ID + API_HASH + BOT_TOKEN (auto-auth)
+#   2) Bot account (no phone, no OTP): API_ID + API_HASH + BOT_API_TOKEN (auto-auth)
 API_ID=your_api_id
 API_HASH=your_api_hash
 
 # Bot token from @BotFather (alternative to phone-based setup)
 # When set, the server auto-authenticates on startup if no session file exists.
-# BOT_TOKEN=1234567890:ABCdef...GHIjkl
+# BOT_API_TOKEN=1234567890:ABCdef...GHIjkl
 
 # Domain for HTTP mode (required for production)
 # Public host for web setup, MCP URL generation, and attachment_download_url.

--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,16 @@
 
 # Telegram API Credentials (required)
 # Get these from https://my.telegram.org/apps
+#
+# Two authentication methods (pick one):
+#   1) User account (phone + OTP): API_ID + API_HASH + PHONE_NUMBER (run --setup)
+#   2) Bot account (no phone, no OTP): API_ID + API_HASH + BOT_TOKEN (auto-auth)
 API_ID=your_api_id
 API_HASH=your_api_hash
+
+# Bot token from @BotFather (alternative to phone-based setup)
+# When set, the server auto-authenticates on startup if no session file exists.
+# BOT_TOKEN=1234567890:ABCdef...GHIjkl
 
 # Domain for HTTP mode (required for production)
 # Public host for web setup, MCP URL generation, and attachment_download_url.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
 
 Sessions are stored in `~/.config/fast-mcp-telegram/`.
 
+**Bot token alternative (no phone number):** Create a bot via [@BotFather](https://t.me/BotFather) and use `--bot-token` instead of `--phone-number`:
+
+```bash
+uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
+  --api-id="your_api_id" \
+  --api-hash="your_api_hash" \
+  --bot-token="1234567890:ABCdef..."
+```
+
+No OTP, no verification code. Or skip the setup step entirely — just add `BOT_TOKEN` to your env and the server auto-authenticates on startup.
+
 ### 2. Configure MCP Client
 
 **stdio mode (local):**

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
   --bot-token="1234567890:ABCdef..."
 ```
 
-No OTP, no verification code. Or skip the setup step entirely — just add `BOT_TOKEN` to your env and the server auto-authenticates on startup.
+No OTP, no verification code. Or skip the setup step entirely — just add `BOT_API_TOKEN` to your env and the server auto-authenticates on startup.
 
 ### 2. Configure MCP Client
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
 
 Sessions are stored in `~/.config/fast-mcp-telegram/`.
 
-**Bot token alternative (no phone number):** Create a bot via [@BotFather](https://t.me/BotFather) and use `--bot-token` instead of `--phone-number`:
+**Bot token alternative (no phone number):** Create a bot via [@BotFather](https://t.me/BotFather) and use `--bot-api-token` instead of `--phone-number`:
 
 ```bash
 uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
   --api-id="your_api_id" \
   --api-hash="your_api_hash" \
-  --bot-token="1234567890:ABCdef..."
+  --bot-api-token="1234567890:ABCdef..."
 ```
 
 No OTP, no verification code. Or skip the setup step entirely — just add `BOT_API_TOKEN` to your env and the server auto-authenticates on startup.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -15,13 +15,26 @@ Fast MCP Telegram runs in two modes:
 
 ## Local Setup (stdio)
 
-**Step 1 — Authenticate**
+**Step 1 — Authenticate (choose one)**
+
+**Option A: Phone number (full Telegram user access)**
 ```bash
 uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
   --api-id="your_api_id" \
   --api-hash="your_api_hash" \
   --phone-number="+1234567890"
 ```
+
+**Option B: Bot token (simpler, no phone, no OTP)**
+Create a bot via [@BotFather](https://t.me/BotFather), then:
+```bash
+uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
+  --api-id="your_api_id" \
+  --api-hash="your_api_hash" \
+  --bot-token="1234567890:ABCdef..."
+```
+
+Or skip the setup step entirely — just add `BOT_TOKEN` to your env and the server auto-authenticates on startup when no session file exists.
 
 **Step 2 — Configure your MCP client:**
 
@@ -214,9 +227,12 @@ Listed tokens cannot use `invoke_mtproto` or `/mtproto-api/*` in Phase 1.
 ### Environment Variables
 
 ```bash
-# Required
+# Required (pick one auth method)
+# — User account (phone + OTP):
 API_ID=your_api_id
 API_HASH=your_api_hash
+# — Bot account (no phone, no OTP):
+# BOT_TOKEN=1234567890:ABCdef...
 
 # Optional
 SERVER_MODE=http-auth             # stdio (default) or http-auth for remote

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -31,7 +31,7 @@ Create a bot via [@BotFather](https://t.me/BotFather), then:
 uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
   --api-id="your_api_id" \
   --api-hash="your_api_hash" \
-  --bot-token="1234567890:ABCdef..."
+  --bot-api-token="1234567890:ABCdef..."
 ```
 
 Or skip the setup step entirely — just add `BOT_API_TOKEN` to your env and the server auto-authenticates on startup when no session file exists.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -34,7 +34,7 @@ uvx --from fast-mcp-telegram fast-mcp-telegram-setup \
   --bot-token="1234567890:ABCdef..."
 ```
 
-Or skip the setup step entirely — just add `BOT_TOKEN` to your env and the server auto-authenticates on startup when no session file exists.
+Or skip the setup step entirely — just add `BOT_API_TOKEN` to your env and the server auto-authenticates on startup when no session file exists.
 
 **Step 2 — Configure your MCP client:**
 
@@ -232,7 +232,7 @@ Listed tokens cannot use `invoke_mtproto` or `/mtproto-api/*` in Phase 1.
 API_ID=your_api_id
 API_HASH=your_api_hash
 # — Bot account (no phone, no OTP):
-# BOT_TOKEN=1234567890:ABCdef...
+# BOT_API_TOKEN=1234567890:ABCdef...
 
 # Optional
 SERVER_MODE=http-auth             # stdio (default) or http-auth for remote

--- a/docs/MTProto-Bridge.md
+++ b/docs/MTProto-Bridge.md
@@ -380,7 +380,7 @@ Create a bot session using the CLI setup tool:
 
 ```bash
 # Create a bot session (replace with your bot token from BotFather)
-python -m src.cli_setup --api-id <your_api_id> --api-hash <your_api_hash> --bot-api-token <bot_token_from_botfather>
+python -m src.cli_setup --api-id <your_api_id> --api-hash <your_api_hash> --bot-api-token <bot_token_from_BotFather>
 
 # The command will print a Bearer token - this identifies your bot
 # Example output:

--- a/docs/MTProto-Bridge.md
+++ b/docs/MTProto-Bridge.md
@@ -380,7 +380,7 @@ Create a bot session using the CLI setup tool:
 
 ```bash
 # Create a bot session (replace with your bot token from BotFather)
-python -m src.cli_setup --api-id <your_api_id> --api-hash <your_api_hash> --bot-token <bot_token_from_botfather>
+python -m src.cli_setup --api-id <your_api_id> --api-hash <your_api_hash> --bot-api-token <bot_token_from_botfather>
 
 # The command will print a Bearer token - this identifies your bot
 # Example output:
@@ -415,18 +415,18 @@ Bot accounts have the following restrictions:
 
 To use multiple bots:
 
-1. Create a separate session for each bot using `--bot-token`
+1. Create a separate session for each bot using `--bot-api-token`
 2. Each bot gets its own unique Bearer token
 3. Use the appropriate Bearer token for each bot in your requests
 4. Each bot operates independently with its own session
 
 ```bash
 # Bot 1
-python -m src.cli_setup --api-id <id> --api-hash <hash> --bot-token <bot1_token>
+python -m src.cli_setup --api-id <id> --api-hash <hash> --bot-api-token <bot1_token>
 # Bearer Token: token1_abc123...
 
 # Bot 2
-python -m src.cli_setup --api-id <id> --api-hash <hash> --bot-token <bot2_token>
+python -m src.cli_setup --api-id <id> --api-hash <hash> --bot-api-token <bot2_token>
 # Bearer Token: token2_def456...
 
 # Use Bot 1

--- a/glama.json
+++ b/glama.json
@@ -25,7 +25,7 @@
       "description": "Phone number with country code (e.g. +1234567890). Required for user account setup.",
       "required": false
     },
-    "BOT_TOKEN": {
+    "BOT_API_TOKEN": {
       "description": "Bot token from @BotFather. Alternative to phone number for bot account setup. Simpler authentication, limited to bot API features.",
       "required": false
     },

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -45,7 +45,7 @@ class SetupConfig(ServerConfig):
         description="Automatically overwrite existing session without prompting",
     )
 
-    bot_token: str = Field(
+    bot_api_token: str = Field(
         default="",
         description="Bot token from BotFather (for bot account setup)",
     )
@@ -62,7 +62,7 @@ class SetupConfig(ServerConfig):
             )
 
         # Either phone number (for user account) or bot token (for bot account) is required
-        if not self.bot_token and not self.phone_number:
+        if not self.bot_api_token and not self.phone_number:
             raise ValueError(
                 "Either phone number (for user account) or bot token (for bot account) is required. "
                 "Provide via --phone-number or --bot-token argument, or corresponding environment variables."
@@ -135,7 +135,7 @@ async def setup_telegram_session(
     print("\nStarting Telegram session setup...")
     print(f"API ID: {setup_config.api_id}")
 
-    if setup_config.bot_token:
+    if setup_config.bot_api_token:
         print("Bot token: [REDACTED]")
         print("Account type: Bot")
     else:
@@ -180,11 +180,11 @@ async def setup_telegram_session(
     try:
         await client.connect()
 
-        if setup_config.bot_token:
+        if setup_config.bot_api_token:
             # Bot authentication
             print("Authenticating as bot...")
             # Telethon's start() may return coroutine when event loop is running
-            result = client.start(bot_token=setup_config.bot_token)
+            result = client.start(bot_token=setup_config.bot_api_token)
             if asyncio.iscoroutine(result):
                 await result
             print("Successfully authenticated as bot!")
@@ -310,7 +310,7 @@ async def main():
         )
 
         # Display account type specific information
-        if setup_config.bot_token:
+        if setup_config.bot_api_token:
             print("\n🤖 Bot setup complete! You can now use the MTProto bridge:")
             print("   - Use /mtproto-api/... endpoints for bot operations")
             print(

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -65,7 +65,7 @@ class SetupConfig(ServerConfig):
         if not self.bot_api_token and not self.phone_number:
             raise ValueError(
                 "Either phone number (for user account) or bot token (for bot account) is required. "
-                "Provide via --phone-number or --bot-token argument, or corresponding environment variables."
+                "Provide via --phone-number or --bot-api-token argument, or corresponding environment variables."
             )
 
         # Validate session name doesn't contain slashes (would break URL-based auth and file paths)

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -204,6 +204,22 @@ async def _connect_client_and_verify_or_cleanup(
 ) -> None:
     try:
         await client.connect()
+
+        # Auto-authenticate with bot token if no session exists yet.
+        # This enables "Try in Browser" on Glama, ephemeral containers,
+        # and CI runs without a separate setup step.
+        auth_key = getattr(client.session, "auth_key", None)
+        if not auth_key:
+            cfg = get_config()
+            if cfg.bot_token:
+                logger.info(
+                    "No existing session — authenticating with bot token..."
+                )
+                result = client.start(bot_token=cfg.bot_token)
+                if asyncio.iscoroutine(result):
+                    await result
+                logger.info("Bot token authentication succeeded!")
+
         await verify_authorized_connection(client)
     except SessionNotAuthorizedError as e:
         await _safe_disconnect_after_verify_failure(client)

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -201,16 +201,14 @@ async def _safe_disconnect_after_verify_failure(client: TelegramClient) -> None:
 
 
 async def _connect_client_and_verify_or_cleanup(
-    client: TelegramClient, token: str
+    client: TelegramClient, token: str, bot_api_token: str = ""
 ) -> None:
     try:
-        cfg = get_config()
-
         # If bot_api_token is set, client.start() handles both connection
         # and non-interactive authentication (no OTP needed).
         # Otherwise, connect explicitly and verify the existing session.
-        if cfg.bot_api_token:
-            result = client.start(bot_token=cfg.bot_api_token)
+        if bot_api_token:
+            result = client.start(bot_token=bot_api_token)
             if inspect.isawaitable(result):
                 await result
         else:
@@ -218,7 +216,7 @@ async def _connect_client_and_verify_or_cleanup(
 
         await verify_authorized_connection(client)
 
-        if cfg.bot_api_token:
+        if bot_api_token:
             logger.info("Bot API token authentication succeeded!")
     except SessionNotAuthorizedError as e:
         await _safe_disconnect_after_verify_failure(client)
@@ -289,7 +287,7 @@ async def _build_telegram_client_for_token(
     }
     client_kwargs |= build_mtproto_client_args(_cfg.mtproto_proxy, logger.info)
     client = TelegramClient(**client_kwargs)
-    await _connect_client_and_verify_or_cleanup(client, token)
+    await _connect_client_and_verify_or_cleanup(client, token, _cfg.bot_api_token)
     return client
 
 

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -203,24 +203,22 @@ async def _connect_client_and_verify_or_cleanup(
     client: TelegramClient, token: str
 ) -> None:
     try:
-        await client.connect()
+        cfg = get_config()
 
-        # Auto-authenticate with bot token if no session exists yet.
-        # This enables "Try in Browser" on Glama, ephemeral containers,
-        # and CI runs without a separate setup step.
-        auth_key = getattr(client.session, "auth_key", None)
-        if not auth_key:
-            cfg = get_config()
-            if cfg.bot_api_token:
-                logger.info(
-                    "No existing session — authenticating with bot token..."
-                )
-                result = client.start(bot_token=cfg.bot_api_token)
-                if asyncio.iscoroutine(result):
-                    await result
-                logger.info("Bot token authentication succeeded!")
+        # If bot_api_token is set, client.start() handles both connection
+        # and non-interactive authentication (no OTP needed).
+        # Otherwise, connect explicitly and verify the existing session.
+        if cfg.bot_api_token:
+            result = client.start(bot_token=cfg.bot_api_token)
+            if asyncio.iscoroutine(result):
+                await result
+        else:
+            await client.connect()
 
         await verify_authorized_connection(client)
+
+        if cfg.bot_api_token:
+            logger.info("Bot API token authentication succeeded!")
     except SessionNotAuthorizedError as e:
         await _safe_disconnect_after_verify_failure(client)
         logger.error(

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import inspect
 import logging
 import secrets
 import time
@@ -210,7 +211,7 @@ async def _connect_client_and_verify_or_cleanup(
         # Otherwise, connect explicitly and verify the existing session.
         if cfg.bot_api_token:
             result = client.start(bot_token=cfg.bot_api_token)
-            if asyncio.iscoroutine(result):
+            if inspect.isawaitable(result):
                 await result
         else:
             await client.connect()

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -211,11 +211,11 @@ async def _connect_client_and_verify_or_cleanup(
         auth_key = getattr(client.session, "auth_key", None)
         if not auth_key:
             cfg = get_config()
-            if cfg.bot_token:
+            if cfg.bot_api_token:
                 logger.info(
                     "No existing session — authenticating with bot token..."
                 )
-                result = client.start(bot_token=cfg.bot_token)
+                result = client.start(bot_token=cfg.bot_api_token)
                 if asyncio.iscoroutine(result):
                     await result
                 logger.info("Bot token authentication succeeded!")

--- a/src/config/server_config.py
+++ b/src/config/server_config.py
@@ -132,7 +132,7 @@ class ServerConfig(BaseSettings):
         description="Phone number for Telegram authentication (include country code)",
     )
 
-    bot_token: str = Field(
+    bot_api_token: str = Field(
         default="",
         description=(
             "Bot token from @BotFather. Alternative to phone+OTP setup. "

--- a/src/config/server_config.py
+++ b/src/config/server_config.py
@@ -132,6 +132,16 @@ class ServerConfig(BaseSettings):
         description="Phone number for Telegram authentication (include country code)",
     )
 
+    bot_token: str = Field(
+        default="",
+        description=(
+            "Bot token from @BotFather. Alternative to phone+OTP setup. "
+            "When set, the server authenticates automatically on startup "
+            "without interactive setup — ideal for Glama Try in Browser, "
+            "CI/CD, and ephemeral deployments."
+        ),
+    )
+
     # Web setup, MCP URL generation, and attachment_download_url base (HTTP transport).
     domain: str = Field(
         default="your-domain.com",

--- a/tests/test_unified_session_config.py
+++ b/tests/test_unified_session_config.py
@@ -83,7 +83,7 @@ class TestUnifiedSessionConfig:
         setup_config = SetupConfig(_cli_parse_args=[])
         # Should have setup-specific fields
         assert hasattr(setup_config, "overwrite")
-        assert hasattr(setup_config, "bot_token")
+        assert hasattr(setup_config, "bot_api_token")
         # Should also have all ServerConfig fields
         assert hasattr(setup_config, "session_name")
         assert hasattr(setup_config, "session_directory")


### PR DESCRIPTION
## What

Adds `BOT_API_TOKEN` env var support to `ServerConfig` and the runtime connection flow. When `BOT_API_TOKEN` is set and no session file exists, the server auto-authenticates via Telegram bot token on startup — no interactive `--setup` step required.

## Why

Enables "Try in Browser" on Glama, ephemeral Docker containers, CI/CD, and any deployment where interactive setup is not possible. Users simply:

1. Create a bot via @BotFather → get token
2. Set `API_ID`, `API_HASH`, `BOT_API_TOKEN` as env vars
3. Server starts and authenticates automatically

## Changes

| File | Change |
|---|---|
| `src/config/server_config.py` | Add `bot_api_token` field to `ServerConfig` |
| `src/client/connection.py` | If `bot_api_token` is set → `client.start(bot_token=...)` instead of `client.connect()` |
| `src/cli_setup.py` | Rename `bot_token` → `bot_api_token`, align CLI flag `--bot-api-token` |
| `glama.json` | Rename `BOT_TOKEN` → `BOT_API_TOKEN` |
| `docs/Installation.md` | Document `BOT_API_TOKEN` setup as alternative to phone/OTP |
| `docs/MTProto-Bridge.md` | Align CLI flag references |
| `.env.example` | Add `BOT_API_TOKEN` |
| `README.md` | Bot token Quick Start section, badge fixes |

## Notes

- Bot token auth is fully non-interactive (no OTP, no SMS)
- Falls back to existing session file behaviour when `BOT_API_TOKEN` is empty (existing users unaffected)

## Summary by Sourcery

Добавлена неинтерактивная аутентификация с помощью bot token через новый путь конфигурации BOT_API_TOKEN и обновлены инструменты и документация для поддержки настройки на основе бота наряду с аутентификацией по номеру телефона.

Новые возможности:
- Добавлен `bot_api_token` в `ServerConfig`, чтобы разрешить аутентификацию при запуске сервера через `BOT_API_TOKEN` без интерактивной настройки.
- Включена автоаутентификация Telegram-клиента с использованием bot API token, когда отсутствует файл сессии.

Улучшения:
- Унифицированы и переименованы параметры CLI-настройки для использования `--bot-api-token` и соответствующих полей конфигурации при настройке аккаунта бота.

Документация:
- Описана аутентификация по bot token как альтернатива телефону/OTP в `Installation.md`, `README.md` и `MTProto-Bridge.md`, включая использование переменных окружения и флагов CLI.

Тесты:
- Обновлены тесты объединённой конфигурации сессий для покрытия нового поля `bot_api_token` в `SetupConfig`.

Обслуживание:
- Обновлён внутренний memory bank и рабочие заметки, чтобы отразить новую реализацию аутентификации во время выполнения с использованием bot token.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add non-interactive bot token authentication via a new BOT_API_TOKEN configuration path and update tooling and docs to support bot-based setup alongside phone-based auth.

New Features:
- Introduce bot_api_token in ServerConfig to allow server startup authentication via BOT_API_TOKEN without interactive setup.
- Enable Telegram client auto-authentication using a bot API token when no session file exists.

Enhancements:
- Unify and rename CLI setup options to use --bot-api-token and corresponding config fields for bot account setup.

Documentation:
- Document bot token authentication as an alternative to phone/OTP in Installation.md, README.md, and MTProto-Bridge.md, including environment variable usage and CLI flags.

Tests:
- Update unified session config tests to cover the new bot_api_token field on SetupConfig.

Chores:
- Refresh internal memory bank and progress notes to reflect the new bot token runtime authentication work.

</details>