### PR TITLE
docs: update published resources with verified MCP.Directory submission

### DIFF
--- a/docs/published-resources.md
+++ b/docs/published-resources.md
@@ -17,15 +17,15 @@ This file tracks where **fast-mcp-telegram** has been published or listed, with 
 | Resource | URL | Status | Notes |
 |----------|-----|--------|-------|
 | **awesome-mcp-servers** | https://github.com/punkpeye/awesome-mcp-servers/pull/7019 | ⏳ PR pending | Awaiting merge by @punkpeye |
-| **MCP.Directory** | https://mcp.directory | ❌ Form failed | Submit form requires authentication (Sign In) |
-| **mcp.so** | https://mcp.so | ❌ Form failed | Submit form requires GitHub login |
-| **MCPMarket** | https://mcpmarket.com/submit | ❌ Form failed | Submit form requires authentication |
-| **MCPFind** | https://mcpfind.org/submit | ❌ Form failed | Submit requires GitHub auth / PR workflow |
+| **MCP.Directory** | https://mcp.directory | ✅ Submitted | "Server Submitted!" — auto-pulls metadata from GitHub, publishes within 24h |
 
 ## Failed — Blocks Automation ❌
 
 | Resource | URL | Status | Notes |
 |----------|-----|--------|-------|
+| **mcp.so** | https://mcp.so | ❌ Submit requires login | Web form at mcp.so/submit — needs GitHub sign-in to submit |
+| **MCPMarket** | https://mcpmarket.com/submit | ❌ Submit requires auth | Form found at mcpmarket.com/submit — filled URL, clicked Submit, page didn't change |
+| **MCPFind** | https://mcpfind.org/submit | ❌ Submit requires auth | Form at mcpfind.org/submit uses "Open GitHub Editor" workflow — needs GitHub auth |
 | **Smithery** | https://smithery.ai/servers/fast-mcp-telegram | ❌ 404 | Was live at sing./server/; needs re-publish via URL or hosted Docker |
 | **PulseMCP** | https://pulsemcp.com/servers | ❌ Blocked | Cloudflare blocks automated checks |
 | **MCPForge** | https://mcpforge.org | ❌ Not a directory | Managed hosting service (like Smithery), not a listing directory |
@@ -34,7 +34,7 @@ This file tracks where **fast-mcp-telegram** has been published or listed, with 
 
 | Resource | URL | Status | Notes |
 |----------|-----|--------|-------|
-| **Official MCP Registry** | https://registry.modelcontextprotocol.io | 🔲 Needs device auth | `mcp-publisher login github` prints device code — user must visit https://github.com/login/device and enter the code |
+| **Official MCP Registry** | https://registry.modelcontextprotocol.io | 🔲 Needs device auth | `mcp-publisher login github` — user must visit https://github.com/login/device and enter device code |
 | **GitHub MCP Registry** | — | 🔲 Needs email | Requires email to `partnerships@github.com` — agent cannot send email |
 
 ## Adding a new listing


### PR DESCRIPTION
Updated `docs/published-resources.md`:
- MCP.Directory: ❌ Form failed → ✅ Submitted (successfully verified)
- Consolidated failed submissions section with clear reasons

## Summary by Sourcery

Обновить документацию опубликованных MCP-директорий и прояснить блокеры автоматизации и требования аутентификации для отправок.

Документация:
- Зафиксировать, что MCP.Directory успешно отправлен и автоматически публикуется на основе метаданных GitHub.
- Уточнить, что mcp.so, MCPMarket и MCPFind требуют аутентифицированных отправок, которые блокируют автоматическую публикацию.
- Уточнить запись в официальном реестре MCP, чтобы лучше описать процесс аутентификации устройства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation of published MCP directories and clarify automation blockers and auth requirements for submissions.

Documentation:
- Record MCP.Directory as successfully submitted and auto-publishing from GitHub metadata.
- Clarify that mcp.so, MCPMarket, and MCPFind require authenticated submissions that block automated publishing.
- Refine Official MCP Registry entry to better describe the device authentication flow.

</details>

Документация:
- Задокументировать недавно отправленные и проверенные записи, такие как MCP.Directory, RemoteMCPList и ToolSDK Registry.
- Реструктурировать страницу опубликованных ресурсов на чёткие разделы для директорий со статусами: опубликовано, ожидает проверки, автоматизация не прошла и требуется действие пользователя.
- Уточнить причины неудачных или заблокированных отправок в директории, включая требования к аутентификации и сервисы, которые не являются каталогами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Обновить документацию опубликованных MCP-директорий и прояснить блокеры автоматизации и требования аутентификации для отправок.

Документация:
- Зафиксировать, что MCP.Directory успешно отправлен и автоматически публикуется на основе метаданных GitHub.
- Уточнить, что mcp.so, MCPMarket и MCPFind требуют аутентифицированных отправок, которые блокируют автоматическую публикацию.
- Уточнить запись в официальном реестре MCP, чтобы лучше описать процесс аутентификации устройства.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation of published MCP directories and clarify automation blockers and auth requirements for submissions.

Documentation:
- Record MCP.Directory as successfully submitted and auto-publishing from GitHub metadata.
- Clarify that mcp.so, MCPMarket, and MCPFind require authenticated submissions that block automated publishing.
- Refine Official MCP Registry entry to better describe the device authentication flow.

</details>

</details>