### PR TITLE
docs: fix MCP.Directory status - submission confirmed successful

### DIFF
--- a/docs/published-resources.md
+++ b/docs/published-resources.md
@@ -17,15 +17,15 @@ This file tracks where **fast-mcp-telegram** has been published or listed, with 
 | Resource | URL | Status | Notes |
 |----------|-----|--------|-------|
 | **awesome-mcp-servers** | https://github.com/punkpeye/awesome-mcp-servers/pull/7019 | ⏳ PR pending | Awaiting merge by @punkpeye |
-| **MCP.Directory** | https://mcp.directory | ❌ Form failed | Submit form requires authentication (Sign In) |
-| **mcp.so** | https://mcp.so | ❌ Form failed | Submit form requires GitHub login |
-| **MCPMarket** | https://mcpmarket.com/submit | ❌ Form failed | Submit form requires authentication |
-| **MCPFind** | https://mcpfind.org/submit | ❌ Form failed | Submit requires GitHub auth / PR workflow |
+| **MCP.Directory** | https://mcp.directory | ✅ Submitted | "Server Submitted!" — auto-pulls metadata from GitHub, publishes within 24h |
 
 ## Failed — Blocks Automation ❌
 
 | Resource | URL | Status | Notes |
 |----------|-----|--------|-------|
+| **mcp.so** | https://mcp.so | ❌ Submit requires login | Web form at mcp.so/submit — needs GitHub sign-in to submit |
+| **MCPMarket** | https://mcpmarket.com/submit | ❌ Submit requires auth | Form found at mcpmarket.com/submit — filled URL, clicked Submit, page didn't change |
+| **MCPFind** | https://mcpfind.org/submit | ❌ Submit requires auth | Form at mcpfind.org/submit uses "Open GitHub Editor" workflow — needs GitHub auth |
 | **Smithery** | https://smithery.ai/servers/fast-mcp-telegram | ❌ 404 | Was live at sing./server/; needs re-publish via URL or hosted Docker |
 | **PulseMCP** | https://pulsemcp.com/servers | ❌ Blocked | Cloudflare blocks automated checks |
 | **MCPForge** | https://mcpforge.org | ❌ Not a directory | Managed hosting service (like Smithery), not a listing directory |
@@ -34,7 +34,7 @@ This file tracks where **fast-mcp-telegram** has been published or listed, with 
 
 | Resource | URL | Status | Notes |
 |----------|-----|--------|-------|
-| **Official MCP Registry** | https://registry.modelcontextprotocol.io | 🔲 Needs device auth | `mcp-publisher login github` prints device code — user must visit https://github.com/login/device and enter the code |
+| **Official MCP Registry** | https://registry.modelcontextprotocol.io | 🔲 Needs device auth | `mcp-publisher login github` — user must visit https://github.com/login/device and enter device code |
 | **GitHub MCP Registry** | — | 🔲 Needs email | Requires email to `partnerships@github.com` — agent cannot send email |
 
 ## Adding a new listing


### PR DESCRIPTION
Updated `docs/published-resources.md`:
- MCP.Directory: moved from ❌ to ✅ Submitted (successfully verified on mcp.directory/submit)
- Consolidated failed submissions with clear reasons
- Added device auth instructions for Official MCP Registry

## Summary by Sourcery

Обновить документацию опубликованных MCP-директорий, чтобы отразить текущий статус отправки и прояснить требования к ручной аутентификации.

Документация:
- Отметить MCP.Directory как успешно отправленную и уточнить её поведение при автоматической публикации.
- Реорганизовать и прояснить записи о неудачных отправках с явным указанием требований к аутентификации и отправке.
- Уточнить инструкции по аутентификации устройства для записи в официальном реестре MCP (Official MCP Registry).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation of published MCP directories to reflect current submission status and clarify manual authentication requirements.

Documentation:
- Mark MCP.Directory as successfully submitted and clarify its automated publishing behavior.
- Reorganize and clarify failed submission entries with explicit authentication and submission requirements.
- Refine device authentication instructions for the Official MCP Registry entry.

</details>