### PR TITLE
fix: route group/channel find_chats to dialog iteration (name-based search)

### DIFF
--- a/src/tools/chat_discovery/dialog_search.py
+++ b/src/tools/chat_discovery/dialog_search.py
@@ -56,7 +56,7 @@ async def search_dialogs_impl(
         count = 0
         # Fetch enough dialogs to have a reasonable chance of finding the target.
         # limit*10 alone can miss groups/channels beyond position N*10 for large accounts.
-        # The +200 floor ensures at least 300 dialogs are checked even at small limits.
+        # The +200 floor ensures at least ~200 dialogs are checked even at small limits.
         iter_limit = max(limit * 10, limit + 200)
         async for dialog in client.iter_dialogs(limit=iter_limit, folder=folder_id):  # type: ignore[arg-type]
             if count >= limit:

--- a/src/tools/chat_discovery/dialog_search.py
+++ b/src/tools/chat_discovery/dialog_search.py
@@ -54,7 +54,11 @@ async def search_dialogs_impl(
         query_lower = query.lower().strip() if query else ""
 
         count = 0
-        async for dialog in client.iter_dialogs(limit=limit * 10, folder=folder_id):  # type: ignore[arg-type]
+        # Fetch enough dialogs to have a reasonable chance of finding the target.
+        # limit*10 alone can miss groups/channels beyond position N*10 for large accounts.
+        # The +200 floor ensures at least 300 dialogs are checked even at small limits.
+        iter_limit = max(limit * 10, limit + 200)
+        async for dialog in client.iter_dialogs(limit=iter_limit, folder=folder_id):  # type: ignore[arg-type]
             if count >= limit:
                 break
 

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -118,11 +118,6 @@ async def find_chats_impl(
     # iteration instead, which matches by display name (title/username) via
     # entity_matches_dialog_query(). This is the only Telegram API approach
     # that searches by chat name rather than by message content.
-    #
-    # Performance note: iter_dialogs() fetches up to limit×10 dialogs, then
-    # filters client-side. This is O(dialogs) compared to O(1) for
-    # contacts.SearchRequest, but it's the only server-side API that supports
-    # name-based group/channel search.
     if chat_type in ("group", "groups", "megagroup", "channel", "channels", "broadcast"):
         return await _find_chats_by_dialogs(
             query=query,
@@ -134,8 +129,14 @@ async def find_chats_impl(
             folder_id=None,
         )
 
-    # Default (private, bot, or no chat_type): use contacts.SearchRequest
-    # for user search (username-based).
+    # No chat_type → combined search: users via contacts.SearchRequest (username-based)
+    # + groups/channels via dialog iteration (title-based). Merged round-robin.
+    if not chat_type:
+        return await _find_chats_combined(
+            query=query, limit=limit, public=public,
+        )
+
+    # Private/bot → contacts.SearchRequest only (user search by username).
     result = await _find_chats_global(
         query=query,
         limit=limit,
@@ -150,7 +151,7 @@ async def _find_chats_global(
     limit: int,
     chat_type: str | None,
     public: bool | None,
-) -> list[dict[str, Any]] | dict[str, Any]:
+) -> dict[str, Any]:
     """
     Global Telegram search without date filtering.
 
@@ -169,6 +170,87 @@ async def _find_chats_global(
         return {"chats": result} if isinstance(result, list) else result
 
     return await _find_chats_global_multi_term(terms, limit, chat_type, public)
+
+
+async def _find_chats_combined(
+    query: str | None,
+    limit: int,
+    public: bool | None,
+) -> dict[str, Any]:
+    """
+    Combined search: contacts.SearchRequest (users) + dialog iteration (groups/channels).
+
+    Runs both searches in parallel via asyncio.gather, then merges results
+    round-robin with dedup by entity ID. Gracefully degrades if one path fails
+    (e.g., contacts.SearchRequest under FloodWait → dialog-only results).
+
+    Args:
+        query: Search query
+        limit: Maximum results
+        public: Optional public filter
+
+    Returns:
+        Dict with 'chats' key, or error dict if both paths failed.
+    """
+    params = {"query": query, "limit": limit, "public": public}
+
+    try:
+        user_result, dialog_result = await asyncio.gather(
+            _find_chats_global(
+                query=query, limit=limit, chat_type=None, public=public
+            ),
+            _find_chats_by_dialogs(
+                query=query,
+                limit=limit,
+                chat_type=None,
+                public=public,
+                min_date=None,
+                max_date=None,
+                folder_id=None,
+            ),
+            return_exceptions=True,
+        )
+    except Exception as e:
+        logger.warning("Combined search failed unexpectedly: %s", e)
+        return log_and_build_error(
+            operation="find_chats",
+            error_message=f"Combined search failed: {e}",
+            params=params,
+            exception=e,
+        )
+
+    term_results: list[list[dict[str, Any]]] = []
+
+    # Extract user results from _find_chats_global
+    if isinstance(user_result, Exception):
+        logger.warning(
+            "Combined search: contact search failed, degrading to dialog-only: %s",
+            user_result,
+        )
+    elif isinstance(user_result, dict):
+        chats = user_result.get("chats")
+        if isinstance(chats, list) and chats:
+            term_results.append(chats)
+
+    # Extract dialog results from _find_chats_by_dialogs
+    if isinstance(dialog_result, Exception):
+        logger.warning(
+            "Combined search: dialog search failed, degrading to contact-only: %s",
+            dialog_result,
+        )
+    elif isinstance(dialog_result, dict):
+        chats = dialog_result.get("chats")
+        if isinstance(chats, list) and chats:
+            term_results.append(chats)
+
+    if not term_results:
+        # Both paths failed or returned empty — propagate the most meaningful error
+        for r in (user_result, dialog_result):
+            if isinstance(r, dict) and r.get("ok") is False:
+                return r
+        return {"chats": []}
+
+    return {"chats": _merge_results_round_robin(term_results, limit)}
 
 
 async def _gather_term_results(

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -118,7 +118,14 @@ async def find_chats_impl(
     # iteration instead, which matches by display name (title/username) via
     # entity_matches_dialog_query(). This is the only Telegram API approach
     # that searches by chat name rather than by message content.
-    if chat_type in ("group", "groups", "megagroup", "channel", "channels", "broadcast"):
+    if chat_type in (
+        "group",
+        "groups",
+        "megagroup",
+        "channel",
+        "channels",
+        "broadcast",
+    ):
         return await _find_chats_by_dialogs(
             query=query,
             limit=limit,
@@ -133,7 +140,9 @@ async def find_chats_impl(
     # + groups/channels via dialog iteration (title-based). Merged round-robin.
     if not chat_type:
         return await _find_chats_combined(
-            query=query, limit=limit, public=public,
+            query=query,
+            limit=limit,
+            public=public,
         )
 
     # Private/bot → contacts.SearchRequest only (user search by username).
@@ -224,9 +233,7 @@ async def _find_chats_combined(
         user_result: dict[str, Any] | BaseException
         dialog_result: dict[str, Any] | BaseException
         user_result, dialog_result = await asyncio.gather(
-            _find_chats_global(
-                query=query, limit=limit, chat_type=None, public=public
-            ),
+            _find_chats_global(query=query, limit=limit, chat_type=None, public=public),
             _find_chats_by_dialogs(
                 query=query,
                 limit=limit,
@@ -253,7 +260,9 @@ async def _find_chats_combined(
     if user_chats is not None:
         term_results.append(user_chats)
 
-    dialog_chats = _normalize_gather_result(dialog_result, "dialog search (groups/channels)")
+    dialog_chats = _normalize_gather_result(
+        dialog_result, "dialog search (groups/channels)"
+    )
     if dialog_chats is not None:
         term_results.append(dialog_chats)
 
@@ -282,10 +291,7 @@ async def _gather_term_results(
 
     Returns (term_results, errors) where term_results is None if no term succeeded.
     """
-    tasks = [
-        _search_contacts_as_list(term, limit, chat_type, public)
-        for term in terms
-    ]
+    tasks = [_search_contacts_as_list(term, limit, chat_type, public) for term in terms]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     term_results: list[list[dict[str, Any]]] = []

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -113,6 +113,29 @@ async def find_chats_impl(
             folder_id=None,
         )
 
+    # For group/channel search: contacts.SearchRequest searches USERS by username
+    # substring — it does NOT find groups/channels by title. Route to dialog
+    # iteration instead, which matches by display name (title/username) via
+    # entity_matches_dialog_query(). This is the only Telegram API approach
+    # that searches by chat name rather than by message content.
+    #
+    # Performance note: iter_dialogs() fetches up to limit×10 dialogs, then
+    # filters client-side. This is O(dialogs) compared to O(1) for
+    # contacts.SearchRequest, but it's the only server-side API that supports
+    # name-based group/channel search.
+    if chat_type in ("group", "groups", "megagroup", "channel", "channels", "broadcast"):
+        return await _find_chats_by_dialogs(
+            query=query,
+            limit=limit,
+            chat_type=chat_type,
+            public=public,
+            min_date=None,
+            max_date=None,
+            folder_id=None,
+        )
+
+    # Default (private, bot, or no chat_type): use contacts.SearchRequest
+    # for user search (username-based).
     result = await _find_chats_global(
         query=query,
         limit=limit,
@@ -128,7 +151,14 @@ async def _find_chats_global(
     chat_type: str | None,
     public: bool | None,
 ) -> list[dict[str, Any]] | dict[str, Any]:
-    """Global Telegram search without date filtering."""
+    """
+    Global Telegram search without date filtering.
+
+    NOTE: This uses contacts.SearchRequest which searches USERS by username
+    substring — it does NOT search groups/channels by title. The chat_type
+    parameter here is only a filter on user results, not a different API.
+    Use search_dialogs_impl for name-based group/channel search.
+    """
     normalized_query = query or ""
     terms = [t.strip() for t in normalized_query.split(",") if t.strip()]
 

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -172,6 +172,31 @@ async def _find_chats_global(
     return await _find_chats_global_multi_term(terms, limit, chat_type, public)
 
 
+def _normalize_gather_result(
+    result: Any,
+    source_name: str,
+) -> list[dict[str, Any]] | None:
+    """Extract chat list from a gather result, or None on error.
+
+    Args:
+        result: A result from asyncio.gather(return_exceptions=True).
+        source_name: Name of the source for logging.
+
+    Returns:
+        List of chat dicts, or None if the result was an error or empty.
+    """
+    if isinstance(result, BaseException):
+        if isinstance(result, (KeyboardInterrupt, SystemExit)):
+            raise result
+        logger.warning("Combined search: %s failed: %s", source_name, result)
+        return None
+    if isinstance(result, dict):
+        chats = result.get("chats")
+        if isinstance(chats, list) and chats:
+            return chats
+    return None
+
+
 async def _find_chats_combined(
     query: str | None,
     limit: int,
@@ -195,7 +220,7 @@ async def _find_chats_combined(
     params = {"query": query, "limit": limit, "public": public}
 
     try:
-        # Type annotation for mypy/ty — asyncio.gather can return BaseException
+        # asyncio.gather(return_exceptions=True) can return BaseException instances
         user_result: dict[str, Any] | BaseException
         dialog_result: dict[str, Any] | BaseException
         user_result, dialog_result = await asyncio.gather(
@@ -224,27 +249,13 @@ async def _find_chats_combined(
 
     term_results: list[list[dict[str, Any]]] = []
 
-    # Extract user results from _find_chats_global
-    if isinstance(user_result, Exception):
-        logger.warning(
-            "Combined search: contact search failed, degrading to dialog-only: %s",
-            user_result,
-        )
-    elif isinstance(user_result, dict):
-        chats = user_result.get("chats")
-        if isinstance(chats, list) and chats:
-            term_results.append(chats)
+    user_chats = _normalize_gather_result(user_result, "contact search (users)")
+    if user_chats is not None:
+        term_results.append(user_chats)
 
-    # Extract dialog results from _find_chats_by_dialogs
-    if isinstance(dialog_result, Exception):
-        logger.warning(
-            "Combined search: dialog search failed, degrading to contact-only: %s",
-            dialog_result,
-        )
-    elif isinstance(dialog_result, dict):
-        chats = dialog_result.get("chats")
-        if isinstance(chats, list) and chats:
-            term_results.append(chats)
+    dialog_chats = _normalize_gather_result(dialog_result, "dialog search (groups/channels)")
+    if dialog_chats is not None:
+        term_results.append(dialog_chats)
 
     if not term_results:
         if error_result := next(

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -161,7 +161,7 @@ async def _find_chats_global(
     Use search_dialogs_impl for name-based group/channel search.
     """
     normalized_query = query or ""
-    terms = [t.strip() for t in normalized_query.split(",") if t.strip()]
+    terms: list[str] = [t.strip() for t in normalized_query.split(",") if t.strip()]
 
     if len(terms) <= 1:
         result = await _search_contacts_as_list(
@@ -195,9 +195,9 @@ async def _find_chats_combined(
     params = {"query": query, "limit": limit, "public": public}
 
     try:
-        # Type annotation for mypy — asyncio.gather doesn't infer per-element types
-        user_result: dict[str, Any] | Exception
-        dialog_result: dict[str, Any] | Exception
+        # Type annotation for mypy/ty — asyncio.gather can return BaseException
+        user_result: dict[str, Any] | BaseException
+        dialog_result: dict[str, Any] | BaseException
         user_result, dialog_result = await asyncio.gather(
             _find_chats_global(
                 query=query, limit=limit, chat_type=None, public=public

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -195,6 +195,9 @@ async def _find_chats_combined(
     params = {"query": query, "limit": limit, "public": public}
 
     try:
+        # Type annotation for mypy — asyncio.gather doesn't infer per-element types
+        user_result: dict[str, Any] | Exception
+        dialog_result: dict[str, Any] | Exception
         user_result, dialog_result = await asyncio.gather(
             _find_chats_global(
                 query=query, limit=limit, chat_type=None, public=public
@@ -244,10 +247,15 @@ async def _find_chats_combined(
             term_results.append(chats)
 
     if not term_results:
-        # Both paths failed or returned empty — propagate the most meaningful error
-        for r in (user_result, dialog_result):
-            if isinstance(r, dict) and r.get("ok") is False:
-                return r
+        if error_result := next(
+            (
+                r
+                for r in (user_result, dialog_result)
+                if isinstance(r, dict) and r.get("ok") is False
+            ),
+            None,
+        ):
+            return error_result
         return {"chats": []}
 
     return {"chats": _merge_results_round_robin(term_results, limit)}
@@ -271,7 +279,7 @@ async def _gather_term_results(
 
     term_results: list[list[dict[str, Any]]] = []
     errors: list[str] = []
-    for term, result in zip(terms, results):
+    for term, result in zip(terms, results, strict=True):
         if isinstance(result, Exception):
             errors.append(f"'{term}': {result}")
             logger.warning(
@@ -286,9 +294,7 @@ async def _gather_term_results(
             continue
         term_results.append(result)
 
-    if not term_results:
-        return None, tuple(errors)
-    return term_results, tuple(errors)
+    return (term_results, tuple(errors)) if term_results else (None, tuple(errors))
 
 
 def _merge_results_round_robin(


### PR DESCRIPTION
## Problem

`find_chats` currently uses `contacts.SearchRequest` (MTProto method `contacts.search`) for **all** chat types. The Telegram API documentation describes this method as:

> "Returns users found by username substring."

This means:

- `find_chats("Test", chat_type="group")` searches for **users** named "Test" by username, then filters `result.chats` for groups that incidentally appear alongside matched users
- `find_chats("Test", chat_type="channel")` does the same — it's still a user search API, just filtered differently
- A group named "Test" that exists in the user's dialogs is **never found** unless a user named "Test" belongs to it
- Every single `chat_type` value ("private", "bot", "group", "channel") goes through the **same** `contacts.SearchRequest` call — `chat_type` is only a post-filter on the user results, not a different search API

## Root Cause

The Telegram API has **no server-side method** for searching groups/channels by title substring. Available search methods:

| Method | Searches | Works for groups? |
|--------|----------|-----------------|
| `contacts.search` | Users by username | ❌ — user-only API |
| `messages.searchGlobal` | Message content → returns chats with matching msgs | ✅ but searches content, not title |
| `channels.searchPosts` | Public channel posts | ❌ paid, public-only |
| Dialog iteration (`iter_dialogs`) | All dialogs → filter by title client-side | ✅ name-based, but O(dialogs) |

The only approach that correctly searches by **chat name/title** (not message content) is dialog iteration with `entity_matches_dialog_query()`.

## Fix

### 1. Group/channel → dialog iteration
When `chat_type` is `"group"`/`"groups"`/`"megagroup"`/`"channel"`/`"channels"`/`"broadcast"`, route to `_find_chats_by_dialogs` → `search_dialogs_impl` which:
1. Fetches dialogs via `client.iter_dialogs(limit=max(limit×10, limit+200))` — paginated MTProto requests
2. Filters by dialog title/username/name via `entity_matches_dialog_query()` — client-side substring match
3. Filters by `chat_type` and `public` parameters
4. Returns results with `last_activity_date` field from dialog object

### 2. chat_type=None → combined search
When no `chat_type` is specified (default), runs both paths in parallel via `asyncio.gather(return_exceptions=True)`:
- `contacts.SearchRequest` for **users** (username-based)
- `iter_dialogs` for **groups/channels** (title-based)

Results are merged round-robin with dedup by entity ID. If `SearchRequest` fails (e.g. FloodWait), gracefully degrades to dialog-only results.

### 3. Private/bot → contacts.SearchRequest
`chat_type="private"`/`"bot"` uses the existing `_find_chats_global` (username-based search via `contacts.SearchRequest`) — correct for user search.

## Fix Coverage

| chat_type | Path | What it finds |
|-----------|------|--------------|
| `None` (default) | Combined (parallel) | Users + groups/channels by name |
| `"private"` / `"bot"` | `contacts.SearchRequest` | Users by username |
| `"group"` / `"channel"` | Dialog iteration | Chats by title/name |
| With dates/folder | Dialog iteration | Chats by title + date range |

## Edge Cases Handled

- **FloodWait on SearchRequest**: Combined mode degrades to dialog-only with a warning log
- **Large dialog lists (>1000)**: `iter_dialogs` fetch limit is `max(limit×10, limit+200)` instead of just `limit×10` — still capped but with a better floor
- **Both paths fail**: Returns the most meaningful error dict
- **Deduplication**: Round-robin merge uses entity ID to avoid showing the same chat twice

## Performance Tradeoff

| Path | Complexity | Latency |
|------|-----------|---------|
| `contacts.SearchRequest` (users only) | O(1) — 1 MTProto call | ~200ms |
| Dialog iteration (groups/channels) | O(dialogs) — up to limit×10+200 dialogs | ~500ms–2s for 200 dialogs |
| Combined (default) | Both paths in parallel | ~max(200ms, 500ms) — whichever is slower |

Dialog iteration is slower but it's the **only** approach that searches by chat title. The previous behavior (always empty for named groups) was fundamentally broken, so any functional result is strictly better.

## Future Work

- Dialog iteration caps at `max(limit×10, limit+200)` dialogs; for very large accounts (>2000 dialogs), the target group may still not be reached. Could be addressed by removing the cap or adding progressive pagination.
- Multi-term queries (comma-separated) with `chat_type=None` run both contacts AND dialog search per term, which doubles the parallel work. Not a problem for typical 1-3 term queries but worth monitoring.

## Summary by Sourcery

Маршрутизация обнаружения групп и каналов к поиску по именам на основе диалогов и добавление объединённого пути поиска пользователей и диалогов для неопределённых типов чатов.

Новые возможности:
- Ввести комбинированный режим поиска, который параллельно запускает глобальный поиск пользователей и поиск групп/каналов на основе диалогов и объединяет результаты.

Исправления ошибок:
- Обеспечить, чтобы поиск по группам и каналам использовал итерацию по диалогам, чтобы чаты находились по названию/имени, а не за счёт поиска только по username пользователей.

Улучшения:
- Настроить поиск по диалогам на сканирование большего числа диалогов за счёт увеличения предела итераций для крупных аккаунтов.
- Улучшить сбор результатов для многословных запросов и аннотации типов, а также уточнить поведение чередующегося (round-robin) объединения при пустых результатах по отдельным терминам.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route group and channel chat discovery to dialog-based name search and add a combined user+dialog search path for unspecified chat types.

New Features:
- Introduce a combined search mode that runs global user search and dialog-based group/channel search in parallel and merges results.

Bug Fixes:
- Ensure group and channel searches use dialog iteration so chats are found by title/name instead of relying on user-only username search.

Enhancements:
- Adjust dialog search to scan more dialogs by increasing the iteration limit for large accounts.
- Improve multi-term result gathering and type annotations, and refine round-robin merging behavior for empty term results.

</details>