### PR TITLE
fix: replace failure-based session cleanup with 30-day inactivity cleanup

### DIFF
--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -1,9 +1,12 @@
 import asyncio
 import base64
+import contextlib
 import inspect
 import json
 import logging
+import os
 import secrets
+import tempfile
 import time
 import traceback
 from contextvars import ContextVar
@@ -496,27 +499,58 @@ def _tracking_file_path() -> Path:
 
 
 def _load_session_tracking() -> dict:
-    """Load session tracking data from disk. Returns empty dict if file doesn't exist or is corrupt."""
+    """Load session tracking data from disk. Returns empty dict if file doesn't exist, is corrupt, or has unexpected structure."""
     tracking_path = _tracking_file_path()
     if not tracking_path.is_file():
         return {}
     try:
         with open(tracking_path, encoding="utf-8") as f:
             data: dict = json.load(f)
-        return data
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(f"Failed to read session tracking file: {e}")
         return {}
 
+    # Validate top-level structure: must be a dict of token -> tracking info
+    if not isinstance(data, dict):
+        logger.warning(
+            f"Session tracking file has invalid structure: expected object at top level, "
+            f"got {type(data).__name__}. Ignoring file."
+        )
+        return {}
+    if invalid := {
+        key: type(value).__name__
+        for key, value in data.items()
+        if not isinstance(value, dict)
+    }:
+        logger.warning(
+            f"Session tracking file has invalid value types; expected dict values. "
+            f"Invalid entries: {invalid}. Ignoring file."
+        )
+        return {}
+
+    return data
+
 
 def _save_session_tracking(data: dict) -> None:
-    """Save session tracking data to disk."""
+    """Save session tracking data to disk atomically."""
     tracking_path = _tracking_file_path()
+    tracking_dir = os.path.dirname(os.fspath(tracking_path))
+    tmp_path: str | None = None
     try:
-        with open(tracking_path, "w", encoding="utf-8") as f:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=tracking_dir,
+            delete=False,
+        ) as f:
+            tmp_path = f.name
             json.dump(data, f, indent=2)
+        os.replace(tmp_path, tracking_path)
     except OSError as e:
         logger.warning(f"Failed to write session tracking file: {e}")
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
 
 
 async def _update_last_active(token: str) -> None:
@@ -531,11 +565,28 @@ async def _update_last_active(token: str) -> None:
         _save_session_tracking(tracking)
 
 
-_INACTIVE_SESSION_DAYS = 30
+def _session_file_last_modified(session_path: Path) -> float | None:
+    """Return the mtime of the session file, checking both .session and no-suffix variants.
+
+    Returns None if neither variant exists.
+    """
+    candidates = []
+    if session_path.suffix != ".session":
+        candidates.append(session_path.with_suffix(".session"))
+    candidates.append(session_path)
+    for candidate in candidates:
+        try:
+            return candidate.stat().st_mtime
+        except OSError:
+            continue
+    return None
+
+
+_INACTIVE_SESSION_DAYS = int(os.environ.get("TELEGRAM_INACTIVE_SESSION_DAYS", "30"))
 
 
 async def _cleanup_inactive_sessions() -> int:
-    """Delete session files for tokens with no activity in >30 days.
+    """Delete session files for tokens with no activity in >N days (default 30).
 
     Uses `last_active` from the tracking file. Falls back to file mtime
     for tokens without a tracking entry (legacy). Returns count of deleted sessions.
@@ -553,31 +604,39 @@ async def _cleanup_inactive_sessions() -> int:
             if last_active is not None and last_active > cutoff:
                 continue  # Still active
 
-            # Check file mtime as fallback for tokens without last_active
-            if last_active is None:
-                try:
-                    session_path = _resolve_session_path_for_token(token)
-                    if _session_file_exists(session_path):
-                        mtime = session_path.with_suffix(".session").stat().st_mtime
-                        if mtime > cutoff:
-                            continue  # File was modified recently
-                except (InvalidSessionTokenError, OSError):
-                    pass  # Can't determine activity — will delete
-
-            # Delete session file
             try:
                 session_path = _resolve_session_path_for_token(token)
-                if _session_file_exists(session_path):
+            except InvalidSessionTokenError:
+                continue  # Can't resolve — skip
+
+            # Check file mtime as fallback for tokens without last_active
+            if last_active is None:
+                session_file_mtime = _session_file_last_modified(session_path)
+                if session_file_mtime is not None and session_file_mtime > cutoff:
+                    continue  # File was modified recently
+
+            # TOCTOU guard: re-check last_active from disk in case a concurrent
+            # ensure_connection updated it after our initial load
+            fresh_tracking = _load_session_tracking()
+            fresh_entry = fresh_tracking.get(token)
+            if fresh_entry is not None:
+                fresh_last_active = fresh_entry.get("last_active")
+                if fresh_last_active is not None and fresh_last_active > cutoff:
+                    continue  # Became active since we started checking
+
+            # Delete session file
+            if _session_file_exists(session_path):
+                try:
                     _unlink_session_file(session_path)
                     logger.info(
                         f"Deleted inactive session file for token {token[:8]}... "
                         f"(last_active: {'never' if last_active is None else time.ctime(last_active)})"
                     )
-            except (InvalidSessionTokenError, OSError) as e:
-                logger.warning(
-                    f"Error deleting session file for token {token[:8]}...: {e}"
-                )
-                continue  # Don't remove tracking entry if deletion failed
+                except OSError as e:
+                    logger.warning(
+                        f"Error deleting session file for token {token[:8]}...: {e}"
+                    )
+                    continue  # Don't remove tracking entry if deletion failed
 
             # Remove tracking entry
             del tracking[token]

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import inspect
+import json
 import logging
 import secrets
 import time
@@ -87,6 +88,10 @@ _connection_failures: dict[
     str, tuple[int, float]
 ] = {}  # token -> (failure_count, last_failure_time)
 _failure_lock = asyncio.Lock()
+
+# Disk-based session tracking (for inactivity-based cleanup)
+_SESSION_TRACKING_FILE = "session_tracking.json"
+_tracking_lock = asyncio.Lock()
 
 # Idle session cleanup
 MAX_IDLE_TIME = 1800  # 30 minutes in seconds
@@ -407,6 +412,9 @@ async def ensure_connection(client: TelegramClient, token: str) -> bool:
             async with _failure_lock:
                 _connection_failures.pop(token, None)
 
+            # Track last successful activity for inactivity-based cleanup
+            await _update_last_active(token)
+
         return client.is_connected()
     except SessionNotAuthorizedError:
         logger.error(f"Client reconnected but not authorized for token {token[:8]}...")
@@ -461,7 +469,7 @@ async def ensure_connection(client: TelegramClient, token: str) -> bool:
 
 
 async def _record_connection_failure(token: str) -> None:
-    """Record a connection failure for backoff and circuit breaker logic."""
+    """Record a connection failure for backoff and circuit breaker logic (persisted to disk)."""
     async with _failure_lock:
         current_time = time.time()
         failure_count, _ = _connection_failures.get(token, (0, 0))
@@ -469,6 +477,117 @@ async def _record_connection_failure(token: str) -> None:
         logger.warning(
             f"Recorded connection failure #{failure_count + 1} for token {token[:8]}..."
         )
+
+    # Persist to disk for session tracking
+    async with _tracking_lock:
+        tracking = _load_session_tracking()
+        tracking.setdefault(
+            token,
+            {"last_active": None, "failure_count": 0, "last_failure": None},
+        )
+        tracking[token]["failure_count"] = failure_count + 1
+        tracking[token]["last_failure"] = current_time
+        _save_session_tracking(tracking)
+
+
+def _tracking_file_path() -> Path:
+    """Path to the session tracking JSON file."""
+    return SESSION_DIR / _SESSION_TRACKING_FILE
+
+
+def _load_session_tracking() -> dict:
+    """Load session tracking data from disk. Returns empty dict if file doesn't exist or is corrupt."""
+    tracking_path = _tracking_file_path()
+    if not tracking_path.is_file():
+        return {}
+    try:
+        with open(tracking_path, encoding="utf-8") as f:
+            data: dict = json.load(f)
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to read session tracking file: {e}")
+        return {}
+
+
+def _save_session_tracking(data: dict) -> None:
+    """Save session tracking data to disk."""
+    tracking_path = _tracking_file_path()
+    try:
+        with open(tracking_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError as e:
+        logger.warning(f"Failed to write session tracking file: {e}")
+
+
+async def _update_last_active(token: str) -> None:
+    """Update last_active timestamp for a token on successful connection."""
+    async with _tracking_lock:
+        tracking = _load_session_tracking()
+        tracking.setdefault(
+            token,
+            {"last_active": None, "failure_count": 0, "last_failure": None},
+        )
+        tracking[token]["last_active"] = time.time()
+        _save_session_tracking(tracking)
+
+
+_INACTIVE_SESSION_DAYS = 30
+
+
+async def _cleanup_inactive_sessions() -> int:
+    """Delete session files for tokens with no activity in >30 days.
+
+    Uses `last_active` from the tracking file. Falls back to file mtime
+    for tokens without a tracking entry (legacy). Returns count of deleted sessions.
+    """
+    async with _tracking_lock:
+        tracking = _load_session_tracking()
+
+        cutoff = time.time() - _INACTIVE_SESSION_DAYS * 86400
+        deleted = 0
+
+        for token in list(tracking.keys()):
+            entry = tracking[token]
+            last_active = entry.get("last_active")
+
+            if last_active is not None and last_active > cutoff:
+                continue  # Still active
+
+            # Check file mtime as fallback for tokens without last_active
+            if last_active is None:
+                try:
+                    session_path = _resolve_session_path_for_token(token)
+                    if _session_file_exists(session_path):
+                        mtime = session_path.with_suffix(".session").stat().st_mtime
+                        if mtime > cutoff:
+                            continue  # File was modified recently
+                except (InvalidSessionTokenError, OSError):
+                    pass  # Can't determine activity — will delete
+
+            # Delete session file
+            try:
+                session_path = _resolve_session_path_for_token(token)
+                if _session_file_exists(session_path):
+                    _unlink_session_file(session_path)
+                    logger.info(
+                        f"Deleted inactive session file for token {token[:8]}... "
+                        f"(last_active: {'never' if last_active is None else time.ctime(last_active)})"
+                    )
+            except (InvalidSessionTokenError, OSError) as e:
+                logger.warning(
+                    f"Error deleting session file for token {token[:8]}...: {e}"
+                )
+                continue  # Don't remove tracking entry if deletion failed
+
+            # Remove tracking entry
+            del tracking[token]
+            deleted += 1
+
+        _save_session_tracking(tracking)
+
+    if deleted:
+        logger.info(f"Cleaned up {deleted} inactive session(s)")
+    return deleted
 
 
 async def cleanup_session_cache():
@@ -485,51 +604,6 @@ async def cleanup_session_cache():
 
     _session_cache.clear()
     logger.info("Cleaned up all session cache entries")
-
-
-async def cleanup_failed_sessions():
-    """Clean up sessions that have too many connection failures."""
-    async with _failure_lock:
-        current_time = time.time()
-        failed_tokens = []
-
-        for token, (failure_count, last_failure_time) in _connection_failures.items():
-            # If more than 10 failures and last failure was more than 1 hour ago, clean up
-            if failure_count >= 10 and (current_time - last_failure_time) > 3600:
-                failed_tokens.append(token)
-
-        for token in failed_tokens:
-            # Remove from failure tracking
-            _connection_failures.pop(token, None)
-
-            # Remove from session cache and disconnect
-            if token in _session_cache:
-                client, _ = _session_cache.pop(token)
-                try:
-                    await client.disconnect()
-                    logger.info(f"Disconnected failed session for token {token[:8]}...")
-                except Exception as e:
-                    logger.warning(
-                        f"Error disconnecting failed session {token[:8]}...: {e}"
-                    )
-
-            # Remove session file
-            try:
-                session_path = _resolve_session_path_for_token(token)
-            except InvalidSessionTokenError:
-                continue
-            if _session_file_exists(session_path):
-                try:
-                    _unlink_session_file(session_path)
-                    logger.info(f"Removed failed session file for token {token[:8]}...")
-                except Exception as e:
-                    logger.warning(
-                        f"Error removing failed session file {token[:8]}...: {e}"
-                    )
-
-            logger.info(
-                f"Cleaned up failed session for token {token[:8]}... (had {failure_count} failures)"
-            )
 
 
 async def get_session_health_stats() -> dict:

--- a/src/server.py
+++ b/src/server.py
@@ -12,7 +12,7 @@ from typing import Literal
 from fastmcp import FastMCP
 
 from src.client.connection import (
-    cleanup_failed_sessions,
+    _cleanup_inactive_sessions,
     cleanup_idle_sessions,
     cleanup_session_cache,
 )
@@ -37,12 +37,21 @@ _cleanup_task = None
 
 
 async def cleanup_loop():
-    """Background task to clean up failed and idle sessions."""
+    """Background task: inactivity cleanup once at startup, then idle session disconnect periodically."""
     logger.info("Starting background cleanup task")
+
+    # One-shot inactivity cleanup (30-day tolerance, startup enough)
+    try:
+        deleted = await _cleanup_inactive_sessions()
+        if deleted:
+            logger.info(f"Inactivity cleanup: removed {deleted} session(s)")
+    except Exception as e:
+        logger.error(f"Error in inactivity cleanup: {e}")
+
+    # Periodic idle session disconnect
     while True:
         try:
             await asyncio.sleep(60)  # Check every minute
-            await cleanup_failed_sessions()
             await cleanup_idle_sessions()
         except asyncio.CancelledError:
             logger.info("Background cleanup task cancelled")

--- a/src/server.py
+++ b/src/server.py
@@ -21,8 +21,8 @@ from src.config.server_config import get_config
 from src.server_components.attachment_routes import register_attachment_routes
 from src.server_components.auth_middleware import UrlTokenMiddleware
 from src.server_components.health import register_health_routes
-from src.server_components.mtproto_api import register_mtproto_api_routes
 from src.server_components.middleware_register import register_mcp_middleware
+from src.server_components.mtproto_api import register_mtproto_api_routes
 from src.server_components.server_card import register_server_card_route
 from src.server_components.tools_register import register_tools
 from src.server_components.web_setup import register_web_setup_routes
@@ -37,21 +37,32 @@ _cleanup_task = None
 
 
 async def cleanup_loop():
-    """Background task: inactivity cleanup once at startup, then idle session disconnect periodically."""
+    """Background task: inactivity and idle session cleanup every 60 seconds."""
     logger.info("Starting background cleanup task")
 
-    # One-shot inactivity cleanup (30-day tolerance, startup enough)
+    # On startup, run an immediate inactivity cleanup
     try:
-        deleted = await _cleanup_inactive_sessions()
-        if deleted:
-            logger.info(f"Inactivity cleanup: removed {deleted} session(s)")
+        await _run_inactivity_cleanup()
     except Exception as e:
-        logger.error(f"Error in inactivity cleanup: {e}")
+        logger.error(f"Error in startup inactivity cleanup: {e}")
 
-    # Periodic idle session disconnect
+    cleanup_cycle = 0
+    inactivity_check_interval = 1440  # every 24 hours (1440 iterations * 60s)
+
+    # Periodic cleanup loop
     while True:
         try:
             await asyncio.sleep(60)  # Check every minute
+            cleanup_cycle += 1
+
+            # Run daily inactivity cleanup
+            if cleanup_cycle % inactivity_check_interval == 0:
+                try:
+                    await _run_inactivity_cleanup()
+                except Exception as e:
+                    logger.error(f"Error in periodic inactivity cleanup: {e}")
+
+            # Disconnect idle cached sessions
             await cleanup_idle_sessions()
         except asyncio.CancelledError:
             logger.info("Background cleanup task cancelled")
@@ -59,6 +70,13 @@ async def cleanup_loop():
         except Exception as e:
             logger.error(f"Error in cleanup task: {e}")
             await asyncio.sleep(60)  # Wait before retrying
+
+
+async def _run_inactivity_cleanup():
+    """Run inactivity-based session file cleanup and log results."""
+    deleted = await _cleanup_inactive_sessions()
+    if deleted:
+        logger.info(f"Inactivity cleanup: removed {deleted} session(s)")
 
 
 @asynccontextmanager

--- a/tests/unit/client/test_session_cleanup.py
+++ b/tests/unit/client/test_session_cleanup.py
@@ -1,0 +1,352 @@
+"""Tests for inactivity-based session cleanup."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.client.connection import (
+    _INACTIVE_SESSION_DAYS,
+    _SESSION_TRACKING_FILE,
+    _cleanup_inactive_sessions,
+    _load_session_tracking,
+    _record_connection_failure,
+    _save_session_tracking,
+    _tracking_file_path,
+    _update_last_active,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tracking_path(tmp_path):
+    """Return the expected tracking file path inside tmp_path."""
+    return tmp_path / _SESSION_TRACKING_FILE
+
+
+_TOKEN = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFg"  # 43-char valid token
+_TOKEN_B = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFh"  # 43-char variant
+
+
+def make_session_file(session_dir: Path, token: str):
+    """Create a fake Telethon .session file for *token*."""
+    path = session_dir / f"{token}.session"
+    path.write_text("fake session data")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _tracking_file_path
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingFilePath:
+    """Path construction for the tracking file."""
+
+    def test_returns_session_dir_plus_filename(self, tmp_path):
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            result = _tracking_file_path()
+        assert result == tmp_path / "session_tracking.json"
+
+
+# ---------------------------------------------------------------------------
+# _load_session_tracking
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSessionTracking:
+    """Loading tracking data from disk."""
+
+    def test_returns_empty_dict_when_file_missing(self, tmp_path):
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            data = _load_session_tracking()
+        assert data == {}
+
+    def test_returns_empty_dict_when_file_corrupt(self, tmp_path, tracking_path):
+        tracking_path.write_text("not json", encoding="utf-8")
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            data = _load_session_tracking()
+        assert data == {}
+
+    def test_loads_valid_json(self, tmp_path, tracking_path):
+        expected = {"tok_a": {"last_active": 100.0}}
+        tracking_path.write_text(json.dumps(expected), encoding="utf-8")
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            data = _load_session_tracking()
+        assert data == expected
+
+
+# ---------------------------------------------------------------------------
+# _save_session_tracking
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSessionTracking:
+    """Persisting tracking data to disk."""
+
+    def test_writes_json_file(self, tmp_path, tracking_path):
+        data = {"tok_a": {"last_active": 100.0, "failure_count": 0}}
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            _save_session_tracking(data)
+        assert tracking_path.is_file()
+        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert loaded == data
+
+
+# ---------------------------------------------------------------------------
+# _update_last_active
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLastActive:
+    """Updating the last_active timestamp for a token."""
+
+    @pytest.mark.asyncio
+    async def test_sets_timestamp_on_existing_entry(self, tmp_path, tracking_path):
+        token = "tok_a"
+        initial = {
+            token: {"last_active": 42.0, "failure_count": 0, "last_failure": None}
+        }
+        tracking_path.write_text(json.dumps(initial), encoding="utf-8")
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            await _update_last_active(token)
+        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert loaded[token]["last_active"] > 42.0  # advanced
+        assert loaded[token]["failure_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_creates_new_entry_when_missing(self, tmp_path, tracking_path):
+        token = "tok_new"
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            await _update_last_active(token)
+        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert loaded[token]["last_active"] is not None
+        assert loaded[token]["failure_count"] == 0
+        assert loaded[token]["last_failure"] is None
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_inactive_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupInactiveSessions:
+    """Main cleanup function — deletes session files older than 30 days."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_session_when_last_active_older_than_cutoff(self, tmp_path):
+        """Session with last_active >30 days ago is deleted."""
+        now = 1_000_000_000.0
+        cutoff_secs = _INACTIVE_SESSION_DAYS * 86400
+        old_time = now - cutoff_secs - 100  # well before cutoff
+
+        token = _TOKEN
+        tracking = {
+            token: {"last_active": old_time, "failure_count": 0, "last_failure": None}
+        }
+        tracking_path = tmp_path / "session_tracking.json"
+        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+        session_file = make_session_file(tmp_path, token)
+
+        assert session_file.is_file()  # sanity
+
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection.time.time", return_value=now),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+
+        assert deleted == 1
+        assert not session_file.is_file()  # removed
+
+    @pytest.mark.asyncio
+    async def test_keeps_session_when_last_active_recent(self, tmp_path):
+        """Session with last_active <30 days ago is kept."""
+        now = 1_000_000_000.0
+        recent_time = now - 1  # 1 second ago
+
+        token = _TOKEN
+        tracking = {
+            token: {
+                "last_active": recent_time,
+                "failure_count": 0,
+                "last_failure": None,
+            }
+        }
+        tracking_path = tmp_path / "session_tracking.json"
+        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+        session_file = make_session_file(tmp_path, token)
+
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection.time.time", return_value=now),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+
+        assert deleted == 0
+        assert session_file.is_file()  # still there
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_file_mtime_when_last_active_is_none(self, tmp_path):
+        """Token with last_active=None checks file mtime.
+
+        If mtime is recent, session is kept.
+        """
+        now = 1_000_000_000.0
+
+        token = _TOKEN
+        tracking = {
+            token: {"last_active": None, "failure_count": 0, "last_failure": None}
+        }
+        tracking_path = tmp_path / "session_tracking.json"
+        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+        session_file = make_session_file(tmp_path, token)
+        # Touch file to have recent mtime
+        session_file.touch()
+
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection.time.time", return_value=now),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+
+        assert deleted == 0, "Should keep session with recent mtime"
+        assert session_file.is_file()
+
+    @pytest.mark.asyncio
+    async def test_deletes_when_no_last_active_and_old_mtime(self, tmp_path):
+        """Token with last_active=None and old file mtime is deleted."""
+        now = 1_000_000_000.0
+        cutoff_secs = _INACTIVE_SESSION_DAYS * 86400
+        old_mtime = now - cutoff_secs - 1000
+
+        token = _TOKEN
+        tracking = {
+            token: {"last_active": None, "failure_count": 0, "last_failure": None}
+        }
+        tracking_path = tmp_path / "session_tracking.json"
+        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+        session_file = make_session_file(tmp_path, token)
+
+        # Set old mtime using os.utime to avoid patching Path.stat
+        import os as _os
+
+        _os.utime(str(session_file), (old_mtime, old_mtime))
+
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection.time.time", return_value=now),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+
+        assert deleted == 1
+        assert not session_file.is_file()
+
+    @pytest.mark.asyncio
+    async def test_mixed_tokens_active_and_inactive(self, tmp_path):
+        """Multiple tokens: some kept, some deleted."""
+        now = 1_000_000_000.0
+        cutoff_secs = _INACTIVE_SESSION_DAYS * 86400
+
+        active_token = _TOKEN
+        inactive_token = _TOKEN_B
+
+        tracking = {
+            active_token: {
+                "last_active": now - 10,
+                "failure_count": 0,
+                "last_failure": None,
+            },  # 10s ago
+            inactive_token: {
+                "last_active": now - cutoff_secs - 500,
+                "failure_count": 5,
+                "last_failure": None,
+            },  # well before cutoff
+        }
+        tracking_path = tmp_path / "session_tracking.json"
+        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+
+        active_file = make_session_file(tmp_path, active_token)
+        inactive_file = make_session_file(tmp_path, inactive_token)
+
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection.time.time", return_value=now),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+
+        assert deleted == 1
+        assert active_file.is_file()  # kept
+        assert not inactive_file.is_file()  # deleted
+
+
+# ---------------------------------------------------------------------------
+# _record_connection_failure — disk persistence
+# ---------------------------------------------------------------------------
+
+
+class TestRecordConnectionFailurePersistence:
+    """_record_connection_failure also persists to the tracking file."""
+
+    @pytest.mark.asyncio
+    async def test_persists_failure_count_to_disk(self, tmp_path, tracking_path):
+        """Failure count and timestamp are written to disk."""
+        token = "tok_fail"
+        # Pre-populate tracking entry
+        tracking = {
+            token: {"last_active": None, "failure_count": 0, "last_failure": None}
+        }
+        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+
+        # Mock both thread/lock objects for the asyncio context
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection._failure_lock"),
+            patch("src.client.connection._connection_failures", {token: (0, 0.0)}),
+        ):
+            await _record_connection_failure(token)
+
+        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert loaded[token]["failure_count"] == 1
+        assert loaded[token]["last_failure"] is not None
+
+    @pytest.mark.asyncio
+    async def test_creates_tracking_entry_when_missing(self, tmp_path, tracking_path):
+        """Token not yet in tracking file gets a new entry."""
+        token = "tok_new_fail"
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection._failure_lock"),
+            patch("src.client.connection._connection_failures", {token: (0, 0.0)}),
+        ):
+            await _record_connection_failure(token)
+
+        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert loaded[token]["failure_count"] == 1
+        assert loaded[token]["last_active"] is None
+        assert loaded[token]["last_failure"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Tracking file — round trip
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingRoundTrip:
+    """Disk persistence round trip for tracking data."""
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_preserves_data(self, tmp_path, tracking_path):
+        """Data saved via _save_session_tracking is readable by _load_session_tracking."""
+        data = {
+            "tok_a": {"last_active": 100.0, "failure_count": 2, "last_failure": 95.0},
+            "tok_b": {"last_active": 200.0, "failure_count": 0, "last_failure": None},
+        }
+        with patch("src.client.connection.SESSION_DIR", tmp_path):
+            _save_session_tracking(data)
+            loaded = _load_session_tracking()
+        assert loaded == data


### PR DESCRIPTION
## Summary by Sourcery

Заменить очистку сессий, основанную на количестве ошибок, на очистку по неактивности с использованием постоянных данных отслеживания сессий.

Новые возможности:
- Добавить отслеживание сессий с хранением на диске для записи времени последней активности на токен и метаданных об ошибках подключения.
- Добавить фоновую очистку по неактивности, которая удаляет файлы сессий без активности более 30 дней, с запасным вариантом использования времени модификации файла для устаревших записей.

Исправления ошибок:
- Обеспечить очистку устаревших файлов сессий на основе реальной неактивности, а не накопленных ошибок подключения, что сокращает количество долго живущих «мертвых» сессий.

Улучшения:
- Сохранять количество и временные метки ошибок подключения в файл отслеживания, чтобы унифицировать метаданные о состоянии сессий.
- Обновить цикл очистки на сервере так, чтобы при запуске выполнялась однократная очистка по неактивности, а периодическая работа ограничивалась отключением неактивных сессий.

Тесты:
- Добавить новый набор тестов для отслеживания сессий и очистки по неактивности, покрывающий ввод-вывод файла отслеживания, обновления времени последней активности, логику удаления по неактивности и сохранение данных об ошибках.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace failure-count-based session cleanup with inactivity-based cleanup using persisted session tracking data.

New Features:
- Introduce disk-backed session tracking to record per-token last activity and connection failure metadata.
- Add a background inactivity cleanup that removes session files with no activity for more than 30 days, with a fallback to file modification time for legacy entries.

Bug Fixes:
- Ensure stale session files are cleaned up based on real inactivity rather than accumulated connection failures, reducing long-lived dead sessions.

Enhancements:
- Persist connection failure counts and timestamps to the tracking file to unify session health metadata.
- Update the server cleanup loop to run a one-time inactivity cleanup on startup and limit periodic work to idle session disconnection.

Tests:
- Add a new test suite for session tracking and inactivity cleanup, covering tracking file IO, last-active updates, inactivity deletion logic, and failure persistence.

</details>