### PR TITLE
Simplify: use mtime-only for session cleanup, remove tracking file

### DIFF
--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -1,12 +1,8 @@
 import asyncio
 import base64
-import contextlib
 import inspect
-import json
 import logging
-import os
 import secrets
-import tempfile
 import time
 import traceback
 from contextvars import ContextVar
@@ -91,10 +87,6 @@ _connection_failures: dict[
     str, tuple[int, float]
 ] = {}  # token -> (failure_count, last_failure_time)
 _failure_lock = asyncio.Lock()
-
-# Disk-based session tracking (for inactivity-based cleanup)
-_SESSION_TRACKING_FILE = "session_tracking.json"
-_tracking_lock = asyncio.Lock()
 
 # Idle session cleanup
 MAX_IDLE_TIME = 1800  # 30 minutes in seconds
@@ -415,9 +407,6 @@ async def ensure_connection(client: TelegramClient, token: str) -> bool:
             async with _failure_lock:
                 _connection_failures.pop(token, None)
 
-            # Track last successful activity for inactivity-based cleanup
-            await _update_last_active(token)
-
         return client.is_connected()
     except SessionNotAuthorizedError:
         logger.error(f"Client reconnected but not authorized for token {token[:8]}...")
@@ -472,7 +461,7 @@ async def ensure_connection(client: TelegramClient, token: str) -> bool:
 
 
 async def _record_connection_failure(token: str) -> None:
-    """Record a connection failure for backoff and circuit breaker logic (persisted to disk)."""
+    """Record a connection failure for backoff and circuit breaker logic."""
     async with _failure_lock:
         current_time = time.time()
         failure_count, _ = _connection_failures.get(token, (0, 0))
@@ -481,168 +470,40 @@ async def _record_connection_failure(token: str) -> None:
             f"Recorded connection failure #{failure_count + 1} for token {token[:8]}..."
         )
 
-    # Persist to disk for session tracking
-    async with _tracking_lock:
-        tracking = _load_session_tracking()
-        tracking.setdefault(
-            token,
-            {"last_active": None, "failure_count": 0, "last_failure": None},
-        )
-        tracking[token]["failure_count"] = failure_count + 1
-        tracking[token]["last_failure"] = current_time
-        _save_session_tracking(tracking)
 
-
-def _tracking_file_path() -> Path:
-    """Path to the session tracking JSON file."""
-    return SESSION_DIR / _SESSION_TRACKING_FILE
-
-
-def _load_session_tracking() -> dict:
-    """Load session tracking data from disk. Returns empty dict if file doesn't exist, is corrupt, or has unexpected structure."""
-    tracking_path = _tracking_file_path()
-    if not tracking_path.is_file():
-        return {}
-    try:
-        with open(tracking_path, encoding="utf-8") as f:
-            data: dict = json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
-        logger.warning(f"Failed to read session tracking file: {e}")
-        return {}
-
-    # Validate top-level structure: must be a dict of token -> tracking info
-    if not isinstance(data, dict):
-        logger.warning(
-            f"Session tracking file has invalid structure: expected object at top level, "
-            f"got {type(data).__name__}. Ignoring file."
-        )
-        return {}
-    if invalid := {
-        key: type(value).__name__
-        for key, value in data.items()
-        if not isinstance(value, dict)
-    }:
-        logger.warning(
-            f"Session tracking file has invalid value types; expected dict values. "
-            f"Invalid entries: {invalid}. Ignoring file."
-        )
-        return {}
-
-    return data
-
-
-def _save_session_tracking(data: dict) -> None:
-    """Save session tracking data to disk atomically."""
-    tracking_path = _tracking_file_path()
-    tracking_dir = os.path.dirname(os.fspath(tracking_path))
-    tmp_path: str | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=tracking_dir,
-            delete=False,
-        ) as f:
-            tmp_path = f.name
-            json.dump(data, f, indent=2)
-        os.replace(tmp_path, tracking_path)
-    except OSError as e:
-        logger.warning(f"Failed to write session tracking file: {e}")
-        if tmp_path is not None:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_path)
-
-
-async def _update_last_active(token: str) -> None:
-    """Update last_active timestamp for a token on successful connection."""
-    async with _tracking_lock:
-        tracking = _load_session_tracking()
-        tracking.setdefault(
-            token,
-            {"last_active": None, "failure_count": 0, "last_failure": None},
-        )
-        tracking[token]["last_active"] = time.time()
-        _save_session_tracking(tracking)
-
-
-def _session_file_last_modified(session_path: Path) -> float | None:
-    """Return the mtime of the session file, checking both .session and no-suffix variants.
-
-    Returns None if neither variant exists.
-    """
-    candidates = []
-    if session_path.suffix != ".session":
-        candidates.append(session_path.with_suffix(".session"))
-    candidates.append(session_path)
-    for candidate in candidates:
-        try:
-            return candidate.stat().st_mtime
-        except OSError:
-            continue
-    return None
-
-
-_INACTIVE_SESSION_DAYS = int(os.environ.get("TELEGRAM_INACTIVE_SESSION_DAYS", "30"))
+_INACTIVE_SESSION_DAYS = 30
 
 
 async def _cleanup_inactive_sessions() -> int:
-    """Delete session files for tokens with no activity in >N days (default 30).
+    """Delete .session files not modified in >INACTIVE_SESSION_DAYS days.
 
-    Uses `last_active` from the tracking file. Falls back to file mtime
-    for tokens without a tracking entry (legacy). Returns count of deleted sessions.
+    Uses file mtime to determine inactivity. Returns count of deleted sessions.
     """
-    async with _tracking_lock:
-        tracking = _load_session_tracking()
+    cutoff = time.time() - _INACTIVE_SESSION_DAYS * 86400
+    deleted = 0
 
-        cutoff = time.time() - _INACTIVE_SESSION_DAYS * 86400
-        deleted = 0
+    for session_file in SESSION_DIR.glob("*.session"):
+        if not session_file.is_file():
+            continue
+        try:
+            mtime = session_file.stat().st_mtime
+        except OSError:
+            continue
 
-        for token in list(tracking.keys()):
-            entry = tracking[token]
-            last_active = entry.get("last_active")
+        if mtime > cutoff:
+            continue
 
-            if last_active is not None and last_active > cutoff:
-                continue  # Still active
-
-            try:
-                session_path = _resolve_session_path_for_token(token)
-            except InvalidSessionTokenError:
-                continue  # Can't resolve — skip
-
-            # Check file mtime as fallback for tokens without last_active
-            if last_active is None:
-                session_file_mtime = _session_file_last_modified(session_path)
-                if session_file_mtime is not None and session_file_mtime > cutoff:
-                    continue  # File was modified recently
-
-            # TOCTOU guard: re-check last_active from disk in case a concurrent
-            # ensure_connection updated it after our initial load
-            fresh_tracking = _load_session_tracking()
-            fresh_entry = fresh_tracking.get(token)
-            if fresh_entry is not None:
-                fresh_last_active = fresh_entry.get("last_active")
-                if fresh_last_active is not None and fresh_last_active > cutoff:
-                    continue  # Became active since we started checking
-
-            # Delete session file
-            if _session_file_exists(session_path):
-                try:
-                    _unlink_session_file(session_path)
-                    logger.info(
-                        f"Deleted inactive session file for token {token[:8]}... "
-                        f"(last_active: {'never' if last_active is None else time.ctime(last_active)})"
-                    )
-                except OSError as e:
-                    logger.warning(
-                        f"Error deleting session file for token {token[:8]}...: {e}"
-                    )
-                    continue  # Don't remove tracking entry if deletion failed
-
-            # Remove tracking entry
-            del tracking[token]
+        try:
+            session_file.unlink()
+            logger.info(
+                f"Deleted inactive session file: {session_file.name} "
+                f"(mtime: {time.ctime(mtime)})"
+            )
             deleted += 1
-
-        _save_session_tracking(tracking)
+        except OSError as e:
+            logger.warning(
+                f"Error deleting inactive session file {session_file.name}: {e}"
+            )
 
     if deleted:
         logger.info(f"Cleaned up {deleted} inactive session(s)")

--- a/tests/unit/client/test_session_cleanup.py
+++ b/tests/unit/client/test_session_cleanup.py
@@ -1,132 +1,20 @@
-"""Tests for inactivity-based session cleanup."""
+"""Tests for mtime-based inactivity session cleanup."""
 
-import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from src.client.connection import (
-    _INACTIVE_SESSION_DAYS,
-    _SESSION_TRACKING_FILE,
-    _cleanup_inactive_sessions,
-    _load_session_tracking,
-    _record_connection_failure,
-    _save_session_tracking,
-    _tracking_file_path,
-    _update_last_active,
-)
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def tracking_path(tmp_path):
-    """Return the expected tracking file path inside tmp_path."""
-    return tmp_path / _SESSION_TRACKING_FILE
-
+from src.client.connection import _INACTIVE_SESSION_DAYS, _cleanup_inactive_sessions
 
 _TOKEN = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFg"  # 43-char valid token
-_TOKEN_B = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFh"  # 43-char variant
 
 
-def make_session_file(session_dir: Path, token: str):
-    """Create a fake Telethon .session file for *token*."""
+def make_session_file(session_dir: Path, token: str) -> Path:
+    """Create a fake Telethon .session file for *token* with known mtime."""
     path = session_dir / f"{token}.session"
     path.write_text("fake session data")
     return path
-
-
-# ---------------------------------------------------------------------------
-# _tracking_file_path
-# ---------------------------------------------------------------------------
-
-
-class TestTrackingFilePath:
-    """Path construction for the tracking file."""
-
-    def test_returns_session_dir_plus_filename(self, tmp_path):
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            result = _tracking_file_path()
-        assert result == tmp_path / "session_tracking.json"
-
-
-# ---------------------------------------------------------------------------
-# _load_session_tracking
-# ---------------------------------------------------------------------------
-
-
-class TestLoadSessionTracking:
-    """Loading tracking data from disk."""
-
-    def test_returns_empty_dict_when_file_missing(self, tmp_path):
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            data = _load_session_tracking()
-        assert data == {}
-
-    def test_returns_empty_dict_when_file_corrupt(self, tmp_path, tracking_path):
-        tracking_path.write_text("not json", encoding="utf-8")
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            data = _load_session_tracking()
-        assert data == {}
-
-    def test_loads_valid_json(self, tmp_path, tracking_path):
-        expected = {"tok_a": {"last_active": 100.0}}
-        tracking_path.write_text(json.dumps(expected), encoding="utf-8")
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            data = _load_session_tracking()
-        assert data == expected
-
-
-# ---------------------------------------------------------------------------
-# _save_session_tracking
-# ---------------------------------------------------------------------------
-
-
-class TestSaveSessionTracking:
-    """Persisting tracking data to disk."""
-
-    def test_writes_json_file(self, tmp_path, tracking_path):
-        data = {"tok_a": {"last_active": 100.0, "failure_count": 0}}
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            _save_session_tracking(data)
-        assert tracking_path.is_file()
-        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
-        assert loaded == data
-
-
-# ---------------------------------------------------------------------------
-# _update_last_active
-# ---------------------------------------------------------------------------
-
-
-class TestUpdateLastActive:
-    """Updating the last_active timestamp for a token."""
-
-    @pytest.mark.asyncio
-    async def test_sets_timestamp_on_existing_entry(self, tmp_path, tracking_path):
-        token = "tok_a"
-        initial = {
-            token: {"last_active": 42.0, "failure_count": 0, "last_failure": None}
-        }
-        tracking_path.write_text(json.dumps(initial), encoding="utf-8")
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            await _update_last_active(token)
-        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
-        assert loaded[token]["last_active"] > 42.0  # advanced
-        assert loaded[token]["failure_count"] == 0
-
-    @pytest.mark.asyncio
-    async def test_creates_new_entry_when_missing(self, tmp_path, tracking_path):
-        token = "tok_new"
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            await _update_last_active(token)
-        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
-        assert loaded[token]["last_active"] is not None
-        assert loaded[token]["failure_count"] == 0
-        assert loaded[token]["last_failure"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -135,107 +23,22 @@ class TestUpdateLastActive:
 
 
 class TestCleanupInactiveSessions:
-    """Main cleanup function — deletes session files older than 30 days."""
+    """Main cleanup — deletes .session files with old mtime."""
 
     @pytest.mark.asyncio
-    async def test_deletes_session_when_last_active_older_than_cutoff(self, tmp_path):
-        """Session with last_active >30 days ago is deleted."""
+    async def test_deletes_when_mtime_older_than_cutoff(self, tmp_path):
+        """Session file with mtime >30 days ago is deleted."""
         now = 1_000_000_000.0
-        cutoff_secs = _INACTIVE_SESSION_DAYS * 86400
-        old_time = now - cutoff_secs - 100  # well before cutoff
+        cutoff_days = _INACTIVE_SESSION_DAYS
+        old_mtime = now - cutoff_days * 86400 - 100  # well before cutoff
 
-        token = _TOKEN
-        tracking = {
-            token: {"last_active": old_time, "failure_count": 0, "last_failure": None}
-        }
-        tracking_path = tmp_path / "session_tracking.json"
-        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
-        session_file = make_session_file(tmp_path, token)
-
-        assert session_file.is_file()  # sanity
-
-        with (
-            patch("src.client.connection.SESSION_DIR", tmp_path),
-            patch("src.client.connection.time.time", return_value=now),
-        ):
-            deleted = await _cleanup_inactive_sessions()
-
-        assert deleted == 1
-        assert not session_file.is_file()  # removed
-
-    @pytest.mark.asyncio
-    async def test_keeps_session_when_last_active_recent(self, tmp_path):
-        """Session with last_active <30 days ago is kept."""
-        now = 1_000_000_000.0
-        recent_time = now - 1  # 1 second ago
-
-        token = _TOKEN
-        tracking = {
-            token: {
-                "last_active": recent_time,
-                "failure_count": 0,
-                "last_failure": None,
-            }
-        }
-        tracking_path = tmp_path / "session_tracking.json"
-        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
-        session_file = make_session_file(tmp_path, token)
-
-        with (
-            patch("src.client.connection.SESSION_DIR", tmp_path),
-            patch("src.client.connection.time.time", return_value=now),
-        ):
-            deleted = await _cleanup_inactive_sessions()
-
-        assert deleted == 0
-        assert session_file.is_file()  # still there
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_file_mtime_when_last_active_is_none(self, tmp_path):
-        """Token with last_active=None checks file mtime.
-
-        If mtime is recent, session is kept.
-        """
-        now = 1_000_000_000.0
-
-        token = _TOKEN
-        tracking = {
-            token: {"last_active": None, "failure_count": 0, "last_failure": None}
-        }
-        tracking_path = tmp_path / "session_tracking.json"
-        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
-        session_file = make_session_file(tmp_path, token)
-        # Touch file to have recent mtime
-        session_file.touch()
-
-        with (
-            patch("src.client.connection.SESSION_DIR", tmp_path),
-            patch("src.client.connection.time.time", return_value=now),
-        ):
-            deleted = await _cleanup_inactive_sessions()
-
-        assert deleted == 0, "Should keep session with recent mtime"
-        assert session_file.is_file()
-
-    @pytest.mark.asyncio
-    async def test_deletes_when_no_last_active_and_old_mtime(self, tmp_path):
-        """Token with last_active=None and old file mtime is deleted."""
-        now = 1_000_000_000.0
-        cutoff_secs = _INACTIVE_SESSION_DAYS * 86400
-        old_mtime = now - cutoff_secs - 1000
-
-        token = _TOKEN
-        tracking = {
-            token: {"last_active": None, "failure_count": 0, "last_failure": None}
-        }
-        tracking_path = tmp_path / "session_tracking.json"
-        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
-        session_file = make_session_file(tmp_path, token)
-
-        # Set old mtime using os.utime to avoid patching Path.stat
+        session_file = make_session_file(tmp_path, _TOKEN)
+        # Set old mtime
         import os as _os
 
         _os.utime(str(session_file), (old_mtime, old_mtime))
+
+        assert session_file.is_file()
 
         with (
             patch("src.client.connection.SESSION_DIR", tmp_path),
@@ -247,31 +50,43 @@ class TestCleanupInactiveSessions:
         assert not session_file.is_file()
 
     @pytest.mark.asyncio
-    async def test_mixed_tokens_active_and_inactive(self, tmp_path):
-        """Multiple tokens: some kept, some deleted."""
+    async def test_keeps_when_mtime_recent(self, tmp_path):
+        """Session file with mtime <30 days ago is kept."""
         now = 1_000_000_000.0
-        cutoff_secs = _INACTIVE_SESSION_DAYS * 86400
+        recent_mtime = now - 10  # 10 seconds ago
 
-        active_token = _TOKEN
-        inactive_token = _TOKEN_B
+        session_file = make_session_file(tmp_path, _TOKEN)
+        import os as _os
 
-        tracking = {
-            active_token: {
-                "last_active": now - 10,
-                "failure_count": 0,
-                "last_failure": None,
-            },  # 10s ago
-            inactive_token: {
-                "last_active": now - cutoff_secs - 500,
-                "failure_count": 5,
-                "last_failure": None,
-            },  # well before cutoff
-        }
-        tracking_path = tmp_path / "session_tracking.json"
-        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+        _os.utime(str(session_file), (recent_mtime, recent_mtime))
 
-        active_file = make_session_file(tmp_path, active_token)
-        inactive_file = make_session_file(tmp_path, inactive_token)
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path),
+            patch("src.client.connection.time.time", return_value=now),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+
+        assert deleted == 0
+        assert session_file.is_file()
+
+    @pytest.mark.asyncio
+    async def test_mixed_old_and_recent(self, tmp_path):
+        """Multiple session files: old ones deleted, recent kept."""
+        now = 1_000_000_000.0
+        cutoff_days = _INACTIVE_SESSION_DAYS
+        old_mtime = now - cutoff_days * 86400 - 500
+        recent_mtime = now - 10
+
+        token_a = _TOKEN
+        token_b = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFh"  # different token
+
+        old_file = make_session_file(tmp_path, token_a)
+        recent_file = make_session_file(tmp_path, token_b)
+
+        import os as _os
+
+        _os.utime(str(old_file), (old_mtime, old_mtime))
+        _os.utime(str(recent_file), (recent_mtime, recent_mtime))
 
         with (
             patch("src.client.connection.SESSION_DIR", tmp_path),
@@ -280,73 +95,28 @@ class TestCleanupInactiveSessions:
             deleted = await _cleanup_inactive_sessions()
 
         assert deleted == 1
-        assert active_file.is_file()  # kept
-        assert not inactive_file.is_file()  # deleted
-
-
-# ---------------------------------------------------------------------------
-# _record_connection_failure — disk persistence
-# ---------------------------------------------------------------------------
-
-
-class TestRecordConnectionFailurePersistence:
-    """_record_connection_failure also persists to the tracking file."""
+        assert not old_file.is_file()  # deleted
+        assert recent_file.is_file()  # kept
 
     @pytest.mark.asyncio
-    async def test_persists_failure_count_to_disk(self, tmp_path, tracking_path):
-        """Failure count and timestamp are written to disk."""
-        token = "tok_fail"
-        # Pre-populate tracking entry
-        tracking = {
-            token: {"last_active": None, "failure_count": 0, "last_failure": None}
-        }
-        tracking_path.write_text(json.dumps(tracking), encoding="utf-8")
+    async def test_skips_nonexistent_file(self, tmp_path):
+        """Non-existent directory doesn't crash."""
+        with (
+            patch("src.client.connection.SESSION_DIR", tmp_path / "does-not-exist"),
+            patch("src.client.connection.time.time", return_value=1_000_000_000.0),
+        ):
+            deleted = await _cleanup_inactive_sessions()
+        assert deleted == 0
 
-        # Mock both thread/lock objects for the asyncio context
+    @pytest.mark.asyncio
+    async def test_skips_non_session_files(self, tmp_path):
+        """Files without .session suffix are ignored."""
+        (tmp_path / "not_a_session.txt").write_text("ignore me")
+
         with (
             patch("src.client.connection.SESSION_DIR", tmp_path),
-            patch("src.client.connection._failure_lock"),
-            patch("src.client.connection._connection_failures", {token: (0, 0.0)}),
+            patch("src.client.connection.time.time", return_value=1_000_000_000.0),
         ):
-            await _record_connection_failure(token)
-
-        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
-        assert loaded[token]["failure_count"] == 1
-        assert loaded[token]["last_failure"] is not None
-
-    @pytest.mark.asyncio
-    async def test_creates_tracking_entry_when_missing(self, tmp_path, tracking_path):
-        """Token not yet in tracking file gets a new entry."""
-        token = "tok_new_fail"
-        with (
-            patch("src.client.connection.SESSION_DIR", tmp_path),
-            patch("src.client.connection._failure_lock"),
-            patch("src.client.connection._connection_failures", {token: (0, 0.0)}),
-        ):
-            await _record_connection_failure(token)
-
-        loaded = json.loads(tracking_path.read_text(encoding="utf-8"))
-        assert loaded[token]["failure_count"] == 1
-        assert loaded[token]["last_active"] is None
-        assert loaded[token]["last_failure"] is not None
-
-
-# ---------------------------------------------------------------------------
-# Tracking file — round trip
-# ---------------------------------------------------------------------------
-
-
-class TestTrackingRoundTrip:
-    """Disk persistence round trip for tracking data."""
-
-    @pytest.mark.asyncio
-    async def test_save_and_load_preserves_data(self, tmp_path, tracking_path):
-        """Data saved via _save_session_tracking is readable by _load_session_tracking."""
-        data = {
-            "tok_a": {"last_active": 100.0, "failure_count": 2, "last_failure": 95.0},
-            "tok_b": {"last_active": 200.0, "failure_count": 0, "last_failure": None},
-        }
-        with patch("src.client.connection.SESSION_DIR", tmp_path):
-            _save_session_tracking(data)
-            loaded = _load_session_tracking()
-        assert loaded == data
+            deleted = await _cleanup_inactive_sessions()
+        assert deleted == 0
+        assert (tmp_path / "not_a_session.txt").is_file()


### PR DESCRIPTION
- Remove _SESSION_TRACKING_FILE, _tracking_lock, _tracking_file_path,
  _load_session_tracking, _save_session_tracking, _update_last_active,
  _session_file_last_modified, _INACTIVE_SESSION_DAYS env var
- Remove disk-persist from _record_connection_failure
- Remove _update_last_active call from ensure_connection
- Rewrite _cleanup_inactive_sessions() to iterate SESSION_DIR/*.session
  and check file mtime directly (no tracking file, no JSON, no atomic write)
- Rewrite tests: 5 mtime-based tests, 0 tracking file tests
- Remove unused imports: contextlib, json, os, tempfile
