### PR TITLE
docs: document TELEGRAM_INACTIVE_SESSION_DAYS env var

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -243,6 +243,7 @@ LOG_LEVEL=INFO                    # Logging verbosity
 SESSION_NAME=telegram             # Session file name (stdio mode only)
 SESSION_DIR=~/.config/fast-mcp-telegram  # Custom session directory
 MTPROTO_PROXY=tg://proxy?server=your-proxy.com&port=443&secret=your-secret  # Firewall proxy
+TELEGRAM_INACTIVE_SESSION_DAYS=30 # Auto-delete .session files unused >N days (0 = disable)
 
 # Session ACL (http-auth only) — see #session-acl-http-auth
 ACL_ENABLED=false                  # Opt-in per-principal MCP limits (http-auth)


### PR DESCRIPTION
Document the new env var for configuring session inactivity period (30-day default, 0 to disable).

## Summary by Sourcery

Документация:
- Описать переменную окружения `TELEGRAM_INACTIVE_SESSION_DAYS` и её влияние на автоматическое удаление неактивных файлов Telegram `.session` в руководстве по установке.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Describe the TELEGRAM_INACTIVE_SESSION_DAYS environment variable and its effect on auto-deleting inactive Telegram .session files in the installation guide.

</details>