### PR TITLE
fix: address Sourcery review findings — exception exposure, HTMX dup, error handling, test coverage

### DIFF
--- a/src/server_components/auth.py
+++ b/src/server_components/auth.py
@@ -117,7 +117,7 @@ def require_auth(func: Callable) -> Callable:
             except ToolError:
                 raise
             except Exception:
-                pass
+                logger.debug("FastMCP get_access_token fallback unavailable", exc_info=True)
 
         if token is None:
             logger.info("Unauthenticated tool call — returning auth guidance")

--- a/src/server_components/qr_login.py
+++ b/src/server_components/qr_login.py
@@ -92,10 +92,23 @@ class QrLoginManager:
         Returns:
             Tuple of (session_id, qr_url). The QR URL is a ``tg://login?token=...``
             link that the user scans from Telegram mobile, or shows as a QR code.
+
+        Raises:
+            QrLoginError: If Telethon fails to create a QR login or returns no URL.
         """
         # Telethon's qr_login() returns a QRLogin object
-        qr_login = telethon_client.qr_login()
-        qr_url = str(getattr(qr_login, "url", ""))
+        try:
+            qr_login = telethon_client.qr_login()
+        except Exception as exc:
+            raise QrLoginError(
+                "Failed to create Telegram QR login session"
+            ) from exc
+
+        qr_url = str(getattr(qr_login, "url", "")).strip()
+        if not qr_url:
+            raise QrLoginError(
+                "Telethon QR login did not return a valid QR URL"
+            )
 
         session_id = uuid.uuid4().hex[:16]
         state = SessionState(telethon_client, qr_url)
@@ -214,8 +227,16 @@ class QrLoginManager:
             await state.telethon_client.disconnect()
 
         # Create new QR login
-        qr_login = telethon_client.qr_login()
-        new_url = str(getattr(qr_login, "url", ""))
+        try:
+            qr_login = telethon_client.qr_login()
+        except Exception as exc:
+            logger.warning("QR session %s regenerate failed: %s", session_id, exc)
+            return None
+
+        new_url = str(getattr(qr_login, "url", "")).strip()
+        if not new_url:
+            logger.warning("QR session %s regenerate: invalid URL from Telethon", session_id)
+            return None
         state.qr_url = new_url
         state.telethon_client = telethon_client
         state._qr_login_obj = qr_login

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -21,7 +21,7 @@ from telethon.tl.functions.account import GetPasswordRequest
 from src.client.connection import _cache_lock, _session_cache, generate_bearer_token
 from src.config.server_config import ServerMode, cfg
 from src.server_components.auth_middleware import generate_url_based_config
-from src.server_components.qr_login import QrLoginManager
+from src.server_components.qr_login import QrLoginError, QrLoginManager
 from src.server_components.session_token_validation import (
     InvalidSessionTokenError,
     session_file_path,
@@ -250,22 +250,25 @@ async def _complete_qr_login(
     authorized_client = qr_mgr.get_client(qr_session_id)
     temp_path = Path(state["session_path"])
 
-    token = generate_bearer_token()
-    session_dir = cfg().session_directory
-    dst = session_file_path(session_dir, token)
-
+    token: str | None = None
+    dst: Path | None = None
     try:
         with contextlib.suppress(Exception):
             if authorized_client:
                 await authorized_client.send_read_acknowledge(None)
                 await authorized_client.disconnect()
 
+        session_dir = cfg().session_directory
+        token = generate_bearer_token()
+        dst = session_file_path(session_dir, token)
+
         if temp_path.exists():
             temp_path.rename(dst)
-    except Exception as e:
+    except Exception:
+        logger.exception("Failed to persist QR session")
         return _fragment(
             request, "fragments/error.html",
-            {"error": f"Failed to persist session: {e}"},
+            {"error": "Failed to persist session. Please try again."},
         )
 
     domain = cfg().domain
@@ -859,7 +862,12 @@ def register_web_setup_routes(mcp_app):
             return _setup_error_fragment(request, f"Failed to connect: {e}")
 
         qr_mgr = _get_qr_manager()
-        qr_session_id, qr_url = qr_mgr.create_session(client)
+        try:
+            qr_session_id, qr_url = qr_mgr.create_session(client)
+        except QrLoginError as e:
+            await client.disconnect()
+            temp_session_path.unlink(missing_ok=True)
+            return _setup_error_fragment(request, str(e))
 
         # Generate QR code image as base64 PNG
         qr = qrcode.QRCode(box_size=10, border=2)

--- a/src/templates/fragments/qr_display.html
+++ b/src/templates/fragments/qr_display.html
@@ -6,7 +6,7 @@
         <img src="data:image/png;base64,{{ qr_image }}" alt="QR Code" class="qr-code" />
     </div>
 
-    <div id="qr-status-wrapper" hx-get="/setup/qr/status?setup_id={{ setup_id }}" hx-trigger="load delay:3s" hx-swap="innerHTML">
+    <div id="qr-status-wrapper">
         {% include "fragments/qr_polling.html" %}
     </div>
 

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.server_components.qr_login import QrLoginManager
+from src.server_components.qr_login import QrLoginError, QrLoginManager
 
 
 @pytest.fixture
@@ -52,6 +52,24 @@ def test_create_session_generates_unique_ids(manager, mock_telethon_client):
     id2, _ = manager.create_session(mock_telethon_client)
 
     assert id1 != id2
+
+
+def test_create_session_raises_qr_login_error_on_failure(manager, mock_telethon_client):
+    """create_session raises QrLoginError when Telethon qr_login() fails."""
+    mock_telethon_client.qr_login.side_effect = RuntimeError("Telethon error")
+
+    with pytest.raises(QrLoginError, match="Failed to create Telegram QR login session"):
+        manager.create_session(mock_telethon_client)
+
+
+def test_create_session_raises_qr_login_error_on_empty_url(manager, mock_telethon_client):
+    """create_session raises QrLoginError when Telethon returns empty URL."""
+    mock_qr_login = MagicMock()
+    mock_qr_login.url = ""
+    mock_telethon_client.qr_login.return_value = mock_qr_login
+
+    with pytest.raises(QrLoginError, match="did not return a valid QR URL"):
+        manager.create_session(mock_telethon_client)
 
 
 @pytest.mark.asyncio
@@ -113,6 +131,29 @@ async def test_poll_status_expired(manager, mock_telethon_client):
 
     status = await manager.poll_status(session_id)
     assert status == "expired"
+    mock_telethon_client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_status_non_timeout_error(manager, mock_telethon_client):
+    """poll_status returns 'expired' when qr_login.wait() raises a non-timeout error."""
+    mock_qr_login = MagicMock()
+    mock_qr_login.url = "tg://login?token=abc"
+    mock_qr_login.wait = AsyncMock(side_effect=RuntimeError("Unexpected error"))
+    mock_telethon_client.qr_login.return_value = mock_qr_login
+
+    session_id, _ = manager.create_session(mock_telethon_client)
+    status = await manager.poll_status(session_id)
+
+    # First poll kicks off background task, may still be pending
+    assert status in ("pending", "expired")
+
+    # Yield so the background task finishes
+    await asyncio.sleep(0)
+
+    status = await manager.poll_status(session_id)
+    assert status == "expired"
+    mock_telethon_client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -183,6 +224,13 @@ async def test_regenerate_qr(manager, mock_telethon_client):
     assert second_url is not None
     assert second_url != first_url
     mock_telethon_client.qr_login.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_regenerate_qr_unknown_session_returns_none(manager, mock_telethon_client):
+    """regenerate_qr returns None when called with an unknown session id."""
+    result = await manager.regenerate_qr("non-existent-session", mock_telethon_client)
+    assert result is None
 
 
 def test_cleanup_expired(manager, mock_telethon_client):


### PR DESCRIPTION
## Summary

Addresses 6 of 9 issues raised by Sourcery GH app review on PR #114 (which was merged before all comments were resolved).

### Changes

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | 🔴 Security | Raw exception `{e}` leaked to user in `_complete_qr_login` | Log exception server-side with `logger.exception()`, return generic message |
| 2 | 🟡 Bug risk | Nested duplicate HTMX polling IDs in `qr_display.html` / `qr_polling.html` | Removed HTMX attributes from outer wrapper — polling is now single-source-of-truth in `qr_polling.html` |
| 3 | 🟡 Bug risk | Broad `except Exception: pass` around `get_access_token()` fallback | Added debug logging so unexpected errors are visible during debugging |
| 4 | 🟡 Bug risk | `telethon_client.qr_login()` failure yields empty URL silently | Added `QrLoginError` propagation with validation, handled in `/setup/qr` route |
| 5-7 | 🟢 Testing | Missing test coverage for error paths, disconnect assertion, unknown session | 3 new tests covering `QrLoginError` on failure/empty URL, non-timeout errors, unknown session regenerate |
| 8-9 | ⏳ | Shared token-resolution helper, SessionState dataclass | Marked as future refactors (no behavioral impact) |

### Files changed
```
 src/server_components/auth.py           |  2 +-
 src/server_components/qr_login.py       | 29 ++++++++++++++++---
 src/server_components/web_setup.py      | 24 ++++++++++------
 src/templates/fragments/qr_display.html |  2 +-
 tests/test_qr_login.py                  | 50 ++++++++++++++++++++++++++++++++-
 5 files changed, 92 insertions(+), 15 deletions(-)
```

All 669 unit tests pass, ruff clean.