### PR TITLE
fix: bearer tokens rejected after auth refactor — get_http_headers drops Authorization header

### DIFF
--- a/src/server_components/auth.py
+++ b/src/server_components/auth.py
@@ -67,7 +67,7 @@ def _get_bearer_token_from_http() -> str | None:
         # FastMCP exposes HTTP headers via this dependency
         from fastmcp.server.dependencies import get_http_headers
 
-        headers = get_http_headers()
+        headers = get_http_headers(include={"authorization"})
         return _extract_bearer_token_from_headers(headers)
     except Exception:  # pragma: no cover — defensive for stdio / test contexts
         return None
@@ -189,7 +189,7 @@ def extract_bearer_token() -> str | None:
         # Imported lazily to avoid dependency during stdio runs
         from fastmcp.server.dependencies import get_http_headers
 
-        headers = get_http_headers()
+        headers = get_http_headers(include={"authorization"})
         return _extract_bearer_token_from_headers(headers)
     except Exception as e:  # pragma: no cover - defensive
         logger.warning(f"Error extracting bearer token: {e}")
@@ -285,7 +285,7 @@ def extract_bearer_token_from_request(request) -> str | None:
         try:  # pragma: no cover - optional path
             from fastmcp.server.dependencies import get_http_headers
 
-            headers = get_http_headers()
+            headers = get_http_headers(include={"authorization"})
             return _extract_bearer_token_from_headers(headers)
         except Exception:
             return None


### PR DESCRIPTION
## Problem

After the @require_auth refactor (PR #114), all previously working bearer tokens are rejected. The server returns auth guidance for every tool call.

## Root Cause

`get_http_headers()` from FastMCP has `"authorization"` in its **default exclusion set** — it explicitly drops the Authorization header from returned headers. The `@require_auth` decorator calls `get_http_headers()` without `include={"authorization"}`, so it never sees the bearer token.

The old FastMCP transport auth (`SessionFileTokenVerifier`) worked because it intercepted the request before the handler ran and stored the validated token in FastMCP's internal state — `get_access_token()` retrieved it from state, not from headers. The new decorator reads headers directly, exposing this exclusion behavior.

## Fix

Pass `include={"authorization"}` to all three `get_http_headers()` calls in `auth.py`:

- `_get_bearer_token_from_http()` — used by `@require_auth` (main path, this was the bug)
- `extract_bearer_token()` — used by MTProto API routes
- `extract_bearer_token_from_request()` — fallback path for custom routes

## Testing

- 669 unit tests pass (7 skipped — integration)
- All 47 auth/token tests pass
- ruff clean

## Summary by Sourcery

Исправления ошибок:
- Восстановлено извлечение bearer-токена за счёт включения заголовка Authorization во все вызовы get_http_headers(), связанные с аутентификацией.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore bearer token extraction by including the Authorization header in all auth-related get_http_headers() calls.

</details>