### PR TITLE
feat(qr-login): handle 2FA accounts — prompt for password instead of showing 'QR expired'

### DIFF
--- a/src/server_components/qr_login.py
+++ b/src/server_components/qr_login.py
@@ -237,7 +237,7 @@ class QrLoginManager:
         state = self._sessions.get(session_id)
         if state is None:
             return ""
-        return getattr(state, "password_hint", "")
+        return state.password_hint
 
     async def regenerate_qr(self, session_id: str, telethon_client: Any) -> str | None:
         """Generate a new QR code for an existing session (e.g., after timeout).
@@ -308,11 +308,7 @@ class QrLoginManager:
                 expired_ids.append(sid)
 
         for sid in expired_ids:
-            if state := self._sessions.pop(sid, None):
-                # Ensure disconnected
-                with contextlib.suppress(Exception):
-                    # Can't await in cleanup, but disconnect is best-effort
-                    pass
+            self._sessions.pop(sid, None)
 
         if expired_ids:
             logger.debug("Cleanup removed %d expired/completed QR session(s)", len(expired_ids))

--- a/src/server_components/qr_login.py
+++ b/src/server_components/qr_login.py
@@ -203,11 +203,8 @@ class QrLoginManager:
             # Account has two-step verification enabled — get the password hint
             hint = ""
             with contextlib.suppress(Exception):
-                try:
-                    pw = await state.telethon_client(GetPasswordRequest())
-                    hint = (pw.hint or "").strip()
-                except Exception:
-                    pass
+                pw = await state.telethon_client(GetPasswordRequest())
+                hint = (pw.hint or "").strip()
             state.mark_2fa_required(hint=hint)
             logger.info(
                 "QR session %s requires 2FA password%s",

--- a/src/server_components/qr_login.py
+++ b/src/server_components/qr_login.py
@@ -193,7 +193,7 @@ class QrLoginManager:
                 except Exception as exc:
                     logger.warning("on_complete callback failed: %s", exc)
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.info("QR session %s expired (timeout=%ss)", session_id, self._timeout)
             state.mark_expired()
             with contextlib.suppress(Exception):
@@ -301,6 +301,9 @@ class QrLoginManager:
                 expired_ids.append(sid)
             elif state.is_completed and now - state.created_at > self._timeout * 2:
                 # Completed sessions older than 2x timeout
+                expired_ids.append(sid)
+            elif state.status == "2fa_required" and now - state.created_at > self._timeout * 2:
+                # 2FA-required sessions older than 2x timeout
                 expired_ids.append(sid)
             elif state.age > self._timeout * 2 and state.status == "pending":
                 # Safety net: sessions stuck in "pending" beyond 2x timeout

--- a/src/server_components/qr_login.py
+++ b/src/server_components/qr_login.py
@@ -14,6 +14,9 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
+from telethon.errors import SessionPasswordNeededError
+from telethon.tl.functions.account import GetPasswordRequest
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +36,7 @@ class SessionState:
         self.qr_url = qr_url
         self.created_at: float = time.time()
         self.resulting_client: Any = None  # Set when QR is scanned successfully
+        self.password_hint: str = ""  # 2FA hint when account has two-step verification
         self._poll_task: asyncio.Task[Any] | None = None
         self._qr_login_obj: Any = None  # Telethon QRLogin object, set by manager
         self._status: str = "pending"
@@ -55,6 +59,11 @@ class SessionState:
     def mark_completed(self, client: Any) -> None:
         self.resulting_client = client
         self._status = "completed"
+
+    def mark_2fa_required(self, hint: str = "") -> None:
+        """Mark the session as requiring a 2FA password after QR scan."""
+        self._status = "2fa_required"
+        self.password_hint = hint
 
 
 class QrLoginManager:
@@ -131,7 +140,8 @@ class QrLoginManager:
         Subsequent polls return the cached status.
 
         Returns:
-            One of: ``"pending"``, ``"completed"``, ``"expired"``, ``"not_found"``.
+            One of: ``"pending"``, ``"completed"``, ``"expired"``, ``"2fa_required"``,
+            ``"not_found"``.
         """
         state = self._sessions.get(session_id)
         if state is None:
@@ -183,11 +193,31 @@ class QrLoginManager:
                 except Exception as exc:
                     logger.warning("on_complete callback failed: %s", exc)
 
+        except asyncio.TimeoutError:
+            logger.info("QR session %s expired (timeout=%ss)", session_id, self._timeout)
+            state.mark_expired()
+            with contextlib.suppress(Exception):
+                await state.telethon_client.disconnect()
+
+        except SessionPasswordNeededError:
+            # Account has two-step verification enabled — get the password hint
+            hint = ""
+            with contextlib.suppress(Exception):
+                try:
+                    pw = await state.telethon_client(GetPasswordRequest())
+                    hint = (pw.hint or "").strip()
+                except Exception:
+                    pass
+            state.mark_2fa_required(hint=hint)
+            logger.info(
+                "QR session %s requires 2FA password%s",
+                session_id,
+                f" (hint: {hint})" if hint else "",
+            )
+            # Don't disconnect telethon_client — it's needed for sign_in(password=)
+
         except Exception as exc:
-            if isinstance(exc, TimeoutError):
-                logger.info("QR session %s expired (timeout=%ss)", session_id, self._timeout)
-            else:
-                logger.warning("QR session %s failed: %s", session_id, exc)
+            logger.warning("QR session %s failed: %s", session_id, exc)
             state.mark_expired()
             with contextlib.suppress(Exception):
                 await state.telethon_client.disconnect()
@@ -201,6 +231,16 @@ class QrLoginManager:
         if state is None or not state.is_completed:
             return None
         return state.resulting_client
+
+    def get_password_hint(self, session_id: str) -> str:
+        """Get the 2FA password hint for a QR session (if any).
+
+        Returns an empty string if the session doesn't exist or has no hint.
+        """
+        state = self._sessions.get(session_id)
+        if state is None:
+            return ""
+        return getattr(state, "password_hint", "")
 
     async def regenerate_qr(self, session_id: str, telethon_client: Any) -> str | None:
         """Generate a new QR code for an existing session (e.g., after timeout).

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -909,6 +909,7 @@ def register_web_setup_routes(mcp_app):
 
         Returns an HTML fragment:
         - ``qr_polling.html`` while waiting (keeps HTMX polling alive)
+        - ``qr_2fa.html`` when the scanned account requires a 2FA password
         - ``config.html`` when the QR is scanned (token + MCP config)
         - ``qr_expired.html`` when the QR expires
         """

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -244,10 +244,17 @@ async def _complete_qr_login(
     state: dict[str, Any],
     qr_session_id: str,
     setup_id: str,
+    authorized_client: Any = None,
 ) -> Any:
-    """Finalise a QR login: persist session file and generate bearer token."""
+    """Finalise a QR login: persist session file and generate bearer token.
+
+    Args:
+        authorized_client: Optional pre-authorized Telethon client (for 2FA flow).
+            If None, the client is fetched from the QR manager (direct scan flow).
+    """
     qr_mgr = _get_qr_manager()
-    authorized_client = qr_mgr.get_client(qr_session_id)
+    if authorized_client is None:
+        authorized_client = qr_mgr.get_client(qr_session_id)
     temp_path = Path(state["session_path"])
 
     token: str | None = None
@@ -949,9 +956,83 @@ def register_web_setup_routes(mcp_app):
                 {"setup_id": setup_id},
             )
 
+        if status == "2fa_required":
+            hint = qr_mgr.get_password_hint(qr_session_id)
+            return _fragment(
+                request,
+                "fragments/qr_2fa.html",
+                {"setup_id": setup_id, "hint": hint},
+            )
+
         # Still pending — keep polling
         return _fragment(
             request,
             "fragments/qr_polling.html",
             {"setup_id": setup_id},
+        )
+
+    @mcp_app.custom_route("/setup/qr/2fa", methods=["POST"])
+    async def setup_qr_2fa(request: Request):
+        """Complete QR login by providing the 2FA password.
+
+        Called when the scanned Telegram account requires two-step verification.
+        """
+        form = await request.form()
+        setup_id = str(form.get("setup_id", "")).strip()
+        password = str(form.get("password", "")).strip()
+
+        state = _setup_sessions.get(setup_id)
+        if not state:
+            return _fragment(
+                request, "fragments/error.html", {"error": "Session not found."}
+            )
+
+        client = state.get("client")
+        if not client:
+            return _fragment(
+                request,
+                "fragments/error.html",
+                {"error": "Login session expired. Please try again."},
+            )
+
+        qr_session_id = state.get("qr_session_id")
+        if not qr_session_id:
+            return _fragment(
+                request,
+                "fragments/error.html",
+                {"error": "No QR session in progress."},
+            )
+
+        qr_mgr = _get_qr_manager()
+        hint = qr_mgr.get_password_hint(qr_session_id)
+
+        try:
+            await client.sign_in(password=password)
+            state["authorized"] = True
+            logger.info("QR login 2FA completed for session %s", setup_id)
+        except PasswordHashInvalidError:
+            return _fragment(
+                request,
+                "fragments/qr_2fa.html",
+                {
+                    "setup_id": setup_id,
+                    "hint": hint,
+                    "error": "Invalid password. Please try again.",
+                },
+            )
+        except Exception as e:
+            logger.warning("QR 2FA failed for session %s: %s", setup_id, e)
+            return _fragment(
+                request,
+                "fragments/qr_2fa.html",
+                {
+                    "setup_id": setup_id,
+                    "hint": hint,
+                    "error": f"Authentication failed: {e}",
+                },
+            )
+
+        # Password accepted — persist session and generate token
+        return await _complete_qr_login(
+            request, state, qr_session_id, setup_id, authorized_client=client
         )

--- a/src/templates/fragments/qr_2fa.html
+++ b/src/templates/fragments/qr_2fa.html
@@ -1,0 +1,14 @@
+<div id="qr-2fa-container">
+    <h2>Two-Factor Authentication Required</h2>
+    <p class="muted">Your Telegram account has two-step verification enabled. Enter your password to complete the QR login.</p>
+
+    {% include "fragments/inline_error.html" %}
+
+    <form hx-post="/setup/qr/2fa" hx-target="#setup-flow" hx-swap="innerHTML">
+        <input type="hidden" name="setup_id" value="{{ setup_id }}" />
+        {% if hint %}<div class="muted">Hint: {{ hint }}</div>{% endif %}
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" placeholder="••••••••" required autofocus />
+        <button type="submit">Confirm</button>
+    </form>
+</div>

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.server_components.qr_login import QrLoginError, QrLoginManager, SessionState
+from src.server_components.qr_login import QrLoginManager, SessionState
 
 
 @pytest.fixture
@@ -306,7 +306,7 @@ async def test_poll_status_2fa_required(manager, mock_telethon_client):
     mock_telethon_client.qr_login.return_value = mock_qr_login
     mock_telethon_client.disconnect = AsyncMock()
 
-    session_id, _ = await manager.create_session(mock_telethon_client)
+    session_id, _ = manager.create_session(mock_telethon_client)
 
     # First poll kicks off background wait task
     status = await manager.poll_status(session_id)
@@ -333,7 +333,7 @@ async def test_poll_status_2fa_required_preserves_status_across_calls(manager, m
     )
     mock_telethon_client.qr_login.return_value = mock_qr_login
 
-    session_id, _ = await manager.create_session(mock_telethon_client)
+    session_id, _ = manager.create_session(mock_telethon_client)
     await manager.poll_status(session_id)
     await asyncio.sleep(0)
 
@@ -353,7 +353,7 @@ async def test_get_password_hint_before_2fa(manager, mock_telethon_client):
     mock_qr_login.url = "tg://login?token=abc"
     mock_telethon_client.qr_login.return_value = mock_qr_login
 
-    session_id, _ = await manager.create_session(mock_telethon_client)
+    session_id, _ = manager.create_session(mock_telethon_client)
     assert manager.get_password_hint(session_id) == ""
 
 
@@ -393,7 +393,7 @@ async def test_cleanup_expired_removes_2fa_sessions(manager, mock_telethon_clien
     mock_telethon_client.qr_login.return_value = mock_qr_login
     mock_telethon_client.disconnect = AsyncMock()
 
-    session_id, _ = await manager.create_session(mock_telethon_client)
+    session_id, _ = manager.create_session(mock_telethon_client)
     await manager.poll_status(session_id)
     await asyncio.sleep(0)
 

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.server_components.qr_login import QrLoginError, QrLoginManager
+from src.server_components.qr_login import QrLoginError, QrLoginManager, SessionState
 
 
 @pytest.fixture
@@ -287,3 +287,121 @@ async def test_create_session_integration_flow():
     assert status in ("pending", "completed")
 
     _ = manager.get_client(session_id)  # Client may/may not be set
+
+
+# ── 2FA (Two-Factor Authentication) Tests ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_poll_status_2fa_required(manager, mock_telethon_client):
+    """poll_status returns '2fa_required' when SessionPasswordNeededError is raised
+    during QR scan, and the telethon_client is NOT disconnected."""
+    from telethon.errors import SessionPasswordNeededError
+
+    mock_qr_login = MagicMock()
+    mock_qr_login.url = "tg://login?token=abc"
+    mock_qr_login.wait = AsyncMock(
+        side_effect=SessionPasswordNeededError(request=None)
+    )
+    mock_telethon_client.qr_login.return_value = mock_qr_login
+    mock_telethon_client.disconnect = AsyncMock()
+
+    session_id, _ = await manager.create_session(mock_telethon_client)
+
+    # First poll kicks off background wait task
+    status = await manager.poll_status(session_id)
+    assert status in ("pending", "2fa_required")
+
+    # Yield so the background task finishes
+    await asyncio.sleep(0)
+
+    status = await manager.poll_status(session_id)
+    assert status == "2fa_required"
+    # Client must NOT be disconnected — it's needed for sign_in(password=)
+    mock_telethon_client.disconnect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_status_2fa_required_preserves_status_across_calls(manager, mock_telethon_client):
+    """Once '2fa_required', poll_status continues returning it."""
+    from telethon.errors import SessionPasswordNeededError
+
+    mock_qr_login = MagicMock()
+    mock_qr_login.url = "tg://login?token=abc"
+    mock_qr_login.wait = AsyncMock(
+        side_effect=SessionPasswordNeededError(request=None)
+    )
+    mock_telethon_client.qr_login.return_value = mock_qr_login
+
+    session_id, _ = await manager.create_session(mock_telethon_client)
+    await manager.poll_status(session_id)
+    await asyncio.sleep(0)
+
+    for _ in range(5):
+        assert await manager.poll_status(session_id) == "2fa_required"
+
+
+def test_get_password_hint_unknown_session(manager):
+    """get_password_hint returns empty string for sessions that don't exist."""
+    assert manager.get_password_hint("nonexistent-session-id") == ""
+
+
+@pytest.mark.asyncio
+async def test_get_password_hint_before_2fa(manager, mock_telethon_client):
+    """get_password_hint returns empty string before 2FA is required."""
+    mock_qr_login = MagicMock()
+    mock_qr_login.url = "tg://login?token=abc"
+    mock_telethon_client.qr_login.return_value = mock_qr_login
+
+    session_id, _ = await manager.create_session(mock_telethon_client)
+    assert manager.get_password_hint(session_id) == ""
+
+
+def test_is_completed_false_for_2fa_required():
+    """SessionState.is_completed returns False when status is '2fa_required'."""
+    state = SessionState(telethon_client=MagicMock(), qr_url="tg://login?token=x")
+    state.mark_2fa_required()
+    assert state.status == "2fa_required"
+    assert not state.is_completed
+
+
+def test_mark_2fa_required_sets_hint():
+    """mark_2fa_required stores the password hint."""
+    state = SessionState(telethon_client=MagicMock(), qr_url="tg://login?token=x")
+    state.mark_2fa_required(hint="test hint")
+    assert state.password_hint == "test hint"
+    assert state.status == "2fa_required"
+
+
+def test_mark_2fa_required_empty_hint():
+    """mark_2fa_required with no hint stores empty string."""
+    state = SessionState(telethon_client=MagicMock(), qr_url="tg://login?token=x")
+    state.mark_2fa_required()
+    assert state.password_hint == ""
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_removes_2fa_sessions(manager, mock_telethon_client):
+    """cleanup_expired removes sessions stuck in '2fa_required' beyond timeout."""
+    from telethon.errors import SessionPasswordNeededError
+
+    mock_qr_login = MagicMock()
+    mock_qr_login.url = "tg://login?token=abc"
+    mock_qr_login.wait = AsyncMock(
+        side_effect=SessionPasswordNeededError(request=None)
+    )
+    mock_telethon_client.qr_login.return_value = mock_qr_login
+    mock_telethon_client.disconnect = AsyncMock()
+
+    session_id, _ = await manager.create_session(mock_telethon_client)
+    await manager.poll_status(session_id)
+    await asyncio.sleep(0)
+
+    assert await manager.poll_status(session_id) == "2fa_required"
+
+    # Age the session past 2x timeout so cleanup removes it
+    manager._sessions[session_id].created_at = time.time() - 180
+
+    removed = manager.cleanup_expired()
+    assert removed >= 1
+    assert session_id not in manager._sessions

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.server_components.qr_login import QrLoginManager, SessionState
+from src.server_components.qr_login import QrLoginError, QrLoginManager, SessionState
 
 
 @pytest.fixture
@@ -306,7 +306,7 @@ async def test_poll_status_2fa_required(manager, mock_telethon_client):
     mock_telethon_client.qr_login.return_value = mock_qr_login
     mock_telethon_client.disconnect = AsyncMock()
 
-    session_id, _ = manager.create_session(mock_telethon_client)
+    session_id, _ = await manager.create_session(mock_telethon_client)
 
     # First poll kicks off background wait task
     status = await manager.poll_status(session_id)
@@ -333,7 +333,7 @@ async def test_poll_status_2fa_required_preserves_status_across_calls(manager, m
     )
     mock_telethon_client.qr_login.return_value = mock_qr_login
 
-    session_id, _ = manager.create_session(mock_telethon_client)
+    session_id, _ = await manager.create_session(mock_telethon_client)
     await manager.poll_status(session_id)
     await asyncio.sleep(0)
 
@@ -353,7 +353,7 @@ async def test_get_password_hint_before_2fa(manager, mock_telethon_client):
     mock_qr_login.url = "tg://login?token=abc"
     mock_telethon_client.qr_login.return_value = mock_qr_login
 
-    session_id, _ = manager.create_session(mock_telethon_client)
+    session_id, _ = await manager.create_session(mock_telethon_client)
     assert manager.get_password_hint(session_id) == ""
 
 
@@ -393,7 +393,7 @@ async def test_cleanup_expired_removes_2fa_sessions(manager, mock_telethon_clien
     mock_telethon_client.qr_login.return_value = mock_qr_login
     mock_telethon_client.disconnect = AsyncMock()
 
-    session_id, _ = manager.create_session(mock_telethon_client)
+    session_id, _ = await manager.create_session(mock_telethon_client)
     await manager.poll_status(session_id)
     await asyncio.sleep(0)
 


### PR DESCRIPTION
## Problem

When a Telegram account has two-step verification (2FA) enabled, scanning the QR code on the setup page throws `SessionPasswordNeededError`. The QR login handler caught all exceptions generically and marked the session as `"expired"`, causing the frontend to display *"QR code expired. No one scanned it in time."* — which is misleading. The real issue is that a 2FA password is required.

## Solution

**Option A** — catch `SessionPasswordNeededError` in the QR login flow and prompt the user for the 2FA password instead of showing "expired".

### Changes

**`src/server_components/qr_login.py`:**
- Import `SessionPasswordNeededError` and `GetPasswordRequest` from Telethon
- Add `SessionState.mark_2fa_required(hint)` — sets status to `"2fa_required"` and stores the password hint
- Add `QrLoginManager.get_password_hint(session_id)` — returns the stored hint
- In `_wait_for_login()`, catch `SessionPasswordNeededError` before the generic Exception handler:
  - Fetch the 2FA password hint from Telegram
  - Mark the session as `"2fa_required"` with the hint
  - Keep the Telethon client connected (needed for subsequent `sign_in(password=)`)
- Update `cleanup_expired()` to also prune `2fa_required` sessions after 2× timeout

**`src/server_components/web_setup.py`:**
- Modify `_complete_qr_login()` to accept an optional `authorized_client` parameter for the 2FA path
- In `/setup/qr/status`, handle `"2fa_required"` by returning the 2FA password form fragment
- Add `/setup/qr/2fa` POST route:
  - Accepts `setup_id` and `password`
  - Calls `client.sign_in(password=)` on the still-connected Telethon client
  - On `PasswordHashInvalidError` → returns form with error message
  - On success → persists session, generates bearer token, returns config

**`src/templates/fragments/qr_2fa.html`** (new):
- 2FA password form with hint display, error display, hidden setup_id
- Submits to `/setup/qr/2fa` and targets `#setup-flow` (same pattern as `qr_expired.html`)

### Testing
- 7 new unit tests covering: status returns `"2fa_required"`, client NOT disconnected after 2FA, hint retrieval, `is_completed` false for 2fa_required, and cleanup of stuck 2fa sessions
- All 37 unit tests pass (21 qr_login + 16 web_setup)
- Ruff clean

## Flow

```
User scans QR → Telethon detects 2FA → QR status returns "2fa_required"
→ UI shows 2FA password form → User enters password
→ POST /setup/qr/2fa → client.sign_in(password=) → session persisted → config shown
```