### PR TITLE
feat(telemetry): store exception traces alongside error counters

### DIFF
--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -1,4 +1,5 @@
 import functools
+import traceback
 from typing import Any
 
 from fastmcp import FastMCP
@@ -109,7 +110,9 @@ _DESC_INVOKE_MTPROTO = _tool_description(
 )
 
 
-def mcp_tool_with_restrictions(operation_name: str, *, allow_bot_sessions: bool = False):
+def mcp_tool_with_restrictions(
+    operation_name: str, *, allow_bot_sessions: bool = False
+):
     """
     Combined decorator for MCP tools: error handling, ACL, auth context, bot restrictions.
 
@@ -131,7 +134,7 @@ def mcp_tool_with_restrictions(operation_name: str, *, allow_bot_sessions: bool 
             try:
                 result = await func(*args, **kwargs)
             except Exception:
-                metrics.record_error()
+                metrics.record_error(traceback.format_exc())
                 raise
             if isinstance(result, dict) and result.get("ok") is False:
                 metrics.record_error()
@@ -139,7 +142,9 @@ def mcp_tool_with_restrictions(operation_name: str, *, allow_bot_sessions: bool 
 
         decorated_func = _telemetry_wrapper
         decorated_func = enforce_session_acl(operation_name)(decorated_func)
-        decorated_func = server_errors.with_error_handling(operation_name)(decorated_func)
+        decorated_func = server_errors.with_error_handling(operation_name)(
+            decorated_func
+        )
         decorated_func = server_auth.require_auth(decorated_func)
         if allow_bot_sessions:
             return decorated_func

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -66,10 +66,14 @@ class MetricsStore:
     while the event-loop wields ``record_call()`` / ``record_error()``.
     """
 
+    # Keep last N error traces in memory for inclusion in heartbeats.
+    MAX_TRACES: int = 10
+
     def __init__(self) -> None:
         self.total_calls: int = 0
         self.errors: int = 0
         self.flood_waits: int = 0
+        self.error_traces: list[str] = []
         self._lock = threading.Lock()
 
     def record_call(self) -> None:
@@ -77,10 +81,19 @@ class MetricsStore:
         with self._lock:
             self.total_calls += 1
 
-    def record_error(self) -> None:
-        """Increment errors by 1 (atomic w.r.t. snapshot)."""
+    def record_error(self, trace: str | None = None) -> None:
+        """Increment errors by 1 (atomic w.r.t. snapshot).
+
+        If ``trace`` is provided, it is stored in the in-memory ring buffer
+        (last ``MAX_TRACES`` entries).  Subsequent heartbeats will include
+        these traces in the ``features.error_traces`` field.
+        """
         with self._lock:
             self.errors += 1
+            if trace:
+                self.error_traces.append(trace)
+                if len(self.error_traces) > self.MAX_TRACES:
+                    self.error_traces.pop(0)
 
     def record_flood_wait(self) -> None:
         """Increment flood_waits by 1 (atomic w.r.t. snapshot)."""
@@ -88,12 +101,13 @@ class MetricsStore:
             self.flood_waits += 1
 
     def snapshot(self) -> dict:
-        """Return a frozen copy of the current counters as a plain dict."""
+        """Return a frozen copy of the current counters + error traces."""
         with self._lock:
             return {
                 "total_calls": self.total_calls,
                 "errors": self.errors,
                 "flood_waits": self.flood_waits,
+                "error_traces": list(self.error_traces),
             }
 
 
@@ -164,9 +178,7 @@ def _collect_runtime() -> dict:
     session_dir = config.session_directory
     session_files = 0
     if session_dir.is_dir():
-        session_files = sum(
-            1 for f in session_dir.iterdir() if f.suffix == ".session"
-        )
+        session_files = sum(1 for f in session_dir.iterdir() if f.suffix == ".session")
 
     # Runtime import avoids circular dependencies at module load time.
     from src.client.connection import get_active_session_count
@@ -182,6 +194,8 @@ def gather_payload() -> dict:
     """Return a self-contained dictionary that can be sent as a heartbeat."""
     from src.server_components.session_acl import principal_count, read_only_count
 
+    counters = metrics.snapshot()
+
     payload = {
         "v": 1,
         "iid": get_instance_id(),
@@ -192,13 +206,14 @@ def gather_payload() -> dict:
         "py": f"{sys.version_info.major}.{sys.version_info.minor}",
         "features": _collect_features(),
         "runtime": _collect_runtime(),
-        "counters": metrics.snapshot(),
+        "counters": counters,
     }
 
     # ACL depth is added to the features block, not sourced from config so we
     # call the new methods on SessionACL.
     payload["features"]["acl_principals"] = principal_count()
     payload["features"]["acl_read_only"] = read_only_count()
+    payload["features"]["error_traces"] = counters["error_traces"]
 
     return payload
 

--- a/tests/unit/test_parse_telegram_url.py
+++ b/tests/unit/test_parse_telegram_url.py
@@ -165,8 +165,7 @@ def test_tg_user_id() -> None:
 def test_tg_join_invite() -> None:
     """tg://join?invite=abc123 → https://t.me/+abc123 for Telethon."""
     assert (
-        _parse_telegram_url("tg://join?invite=abc123DEF")
-        == "https://t.me/+abc123DEF"
+        _parse_telegram_url("tg://join?invite=abc123DEF") == "https://t.me/+abc123DEF"
     )
 
 


### PR DESCRIPTION
## Summary

When tools register catches an exception, it now passes `traceback.format_exc()` to `MetricsStore.record_error()`. The last 10 traces are kept in a ring buffer and shipped as `features.error_traces` in every heartbeat.

## Changes

- **src/telemetry.py**: Added `MAX_TRACES = 10`, `self.error_traces` list, `record_error(trace)` stores trace in ring buffer, `snapshot()` returns error traces alongside counters, `gather_payload()` includes them in heartbeat features
- **src/server_components/tools_register.py**: `_telemetry_wrapper` passes `traceback.format_exc()` to `metrics.record_error()` in the except block

## Testing

- 81/81 unit tests pass
- ruff check + ruff format clean

## Summary by Sourcery

Фиксация недавних трассировок исключений в телеметрических heartbeats для инструментов MCP.

Новые возможности:
- Хранить ограниченный буфер недавних стек-трейсов ошибок в `MetricsStore` и предоставлять их через телеметрические heartbeats как `features.error_traces`.

Улучшения:
- Включать детали трассировок ошибок, когда выполнение инструментов MCP приводит к исключениям, чтобы телеметрические счётчики сопровождались диагностическим контекстом.
- Применить небольшие форматирующие правки в телеметрии, `tools_register` и тесте разбора URL для повышения единообразия.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Capture recent exception traces in telemetry heartbeats for MCP tools.

New Features:
- Store a bounded buffer of recent error stack traces in MetricsStore and expose them via telemetry heartbeats as features.error_traces.

Enhancements:
- Include error trace details when MCP tool executions raise exceptions so telemetry counters are accompanied by diagnostic context.
- Apply minor formatting cleanups in telemetry, tools_register, and a URL parsing test for consistency.

</details>