### PR TITLE
fix(telemetry): capture ok=false error message in traces

### DIFF
--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -141,7 +141,7 @@ def mcp_tool_with_restrictions(
                     error = traceback.format_exc()
                     raise
                 if isinstance(result, dict) and result.get("ok") is False:
-                    error = result.get("error", "")
+                    error = str(result.get("error", ""))
                 return result
             finally:
                 metrics.record_tool_call(

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -141,7 +141,7 @@ def mcp_tool_with_restrictions(
                     error = traceback.format_exc()
                     raise
                 if isinstance(result, dict) and result.get("ok") is False:
-                    error = ""
+                    error = result.get("error", "")
                 return result
             finally:
                 metrics.record_tool_call(


### PR DESCRIPTION
## Problem

When a tool returns `{'ok': False}`, the telemetry error counter increments correctly but the trace is always empty.

**Root cause:** `error = ""` on `ok=False`. In `record_tool_call`, `if error:` is False for empty strings, so trace is never appended.

## Fix

`error = result.get("error", "")` — captures the actual error message from `build_error_response`.

## Verification
- ✅ ruff clean
- ✅ 695 unit tests pass

## Summary by Sourcery

Исправления ошибок:
- Обеспечить, чтобы трассировки телеметрии записывали сообщения об ошибках из вызовов инструментов, которые возвращают `ok=False`, вместо логирования пустых ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure telemetry traces record error messages from tool calls that return ok=False rather than logging empty errors.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Исправления ошибок:
- Обеспечить, чтобы трассировки телеметрии записывали сообщения об ошибках из вызовов инструментов, которые возвращают `ok=False`, вместо логирования пустых ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure telemetry traces record error messages from tool calls that return ok=False rather than logging empty errors.

</details>

</details>
- Захватывать и передавать сообщение об ошибке из ответов инструментов с `ok=False`, чтобы трассировки больше не были пустыми для неудачных вызовов инструментов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Исправления ошибок:
- Обеспечить, чтобы трассировки телеметрии записывали сообщения об ошибках из вызовов инструментов, которые возвращают `ok=False`, вместо логирования пустых ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure telemetry traces record error messages from tool calls that return ok=False rather than logging empty errors.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Исправления ошибок:
- Обеспечить, чтобы трассировки телеметрии записывали сообщения об ошибках из вызовов инструментов, которые возвращают `ok=False`, вместо логирования пустых ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure telemetry traces record error messages from tool calls that return ok=False rather than logging empty errors.

</details>

</details>

</details>