### PR TITLE
fix(telemetry): only track explicitly-set params in param set key

### DIFF
--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -112,6 +112,11 @@ _DESC_INVOKE_MTPROTO = _tool_description(
 )
 
 
+# Types whose equality is well-defined for default-value comparison.
+# Defined at module level to avoid recomputation in a hot helper.
+_SCALAR_TYPES = (type(None), bool, int, float, str, bytes)
+
+
 def _matches_default(value: Any, default: Any) -> bool:
     """Check if value matches its signature default, safely handling complex types.
 
@@ -120,16 +125,14 @@ def _matches_default(value: Any, default: Any) -> bool:
     More complex defaults (lists, dicts, custom objects) skip comparison and
     are treated as explicitly provided, which is conservative but safe.
     """
-    scalar_types = (type(None), bool, int, float, str, bytes)
-
-    if isinstance(default, scalar_types):
+    if isinstance(default, _SCALAR_TYPES):
         return value == default
 
     if isinstance(default, (tuple, frozenset)):
         # Only compare if default is a flat collection of scalars.
         # Collections with complex elements are treated as explicit
         # to avoid expensive or side-effectful __eq__ calls.
-        if not all(isinstance(el, scalar_types) for el in default):
+        if not all(isinstance(el, _SCALAR_TYPES) for el in default):
             return False
         return isinstance(value, type(default)) and value == default
 
@@ -165,27 +168,36 @@ def mcp_tool_with_restrictions(
         # as likely framework-filled and excluded from the param set key.
         # If the argument-passing mechanism changes (e.g. to positional-only
         # or partial kwargs), this logic must be revisited.
-        _sig_params = frozenset(inspect.signature(func).parameters.keys())
+        _sig = inspect.signature(func)
+        _sig_params = frozenset(_sig.parameters.keys())
         _param_defaults = {
             name: param.default
-            for name, param in inspect.signature(func).parameters.items()
+            for name, param in _sig.parameters.items()
             if param.default is not param.empty
         }
 
         @functools.wraps(func)
         async def _telemetry_wrapper(*args, **kwargs):
-            # Only count params explicitly provided (not framework-filled defaults).
-            # Restrict to signature-only params to exclude any framework-injected
-            # or auxiliary kwargs that are not part of the tool declaration.
-            param_keys = frozenset(
-                name
+            # Restrict to declared signature params, excluding any
+            # framework-injected or auxiliary kwargs.
+            sig_kwargs = {
+                name: value
                 for name, value in kwargs.items()
                 if name in _sig_params
-                and (
+            }
+
+            # Exclude params whose value matches their signature default
+            # (likely framework-filled, not explicitly provided by the caller).
+            explicit_kwargs = {
+                name: value
+                for name, value in sig_kwargs.items()
+                if (
                     name not in _param_defaults
                     or not _matches_default(value, _param_defaults[name])
                 )
-            )
+            }
+
+            param_keys = frozenset(explicit_kwargs.keys())
             t0 = time.perf_counter()
             error: str | None = None
             try:

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -126,7 +126,10 @@ def _matches_default(value: Any, default: Any) -> bool:
     are treated as explicitly provided, which is conservative but safe.
     """
     if isinstance(default, _SCALAR_TYPES):
-        return value == default
+        # bool is a subclass of int, so value == default would match
+        # cross-type values (e.g. True == 1). Require exact type match
+        # to prevent misclassifying explicit values as defaults.
+        return type(value) is type(default) and value == default
 
     if isinstance(default, (tuple, frozenset)):
         # Only compare if default is a flat collection of scalars.
@@ -181,35 +184,25 @@ def mcp_tool_with_restrictions(
             and name in _sig_params  # skip catch-all params (no sensible default)
         }
 
-        def _ensure_kwargs_only(func_name: str, args: tuple[Any, ...]) -> None:
-            """Guard against positional args; telemetry assumes kwargs-only calls."""
+        @functools.wraps(func)
+        async def _telemetry_wrapper(*args, **kwargs):
+            # Guard against positional args; telemetry assumes kwargs-only calls.
             if args:
                 raise TypeError(
-                    f"Telemetry assumes kwargs-only calls for {func_name}, "
+                    f"Telemetry assumes kwargs-only calls for {func.__name__}, "
                     f"but got {len(args)} positional arg(s)"
                 )
 
-        def _filter_explicit_kwargs(all_kwargs: dict[str, Any]) -> dict[str, Any]:
-            """Restrict to declared params and drop values matching signature defaults."""
-            sig_kwargs = {
-                name: value
-                for name, value in all_kwargs.items()
-                if name in _sig_params
-            }
-            return {
-                name: value
-                for name, value in sig_kwargs.items()
-                if (
-                    name not in _param_defaults
-                    or not _matches_default(value, _param_defaults[name])
-                )
-            }
+            # Single pass: collect explicitly-provided kwargs, skipping
+            # unknown/catch-all params and values matching signature defaults.
+            explicit_kwargs: dict[str, Any] = {}
+            for name, value in kwargs.items():
+                if name not in _sig_params:
+                    continue  # unknown or catch-all param
+                if name in _param_defaults and _matches_default(value, _param_defaults[name]):
+                    continue  # likely framework-filled default
+                explicit_kwargs[name] = value
 
-        @functools.wraps(func)
-        async def _telemetry_wrapper(*args, **kwargs):
-            _ensure_kwargs_only(func.__name__, args)
-
-            explicit_kwargs = _filter_explicit_kwargs(kwargs)
             param_keys = frozenset(explicit_kwargs.keys())
             t0 = time.perf_counter()
             error: str | None = None

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -169,38 +169,34 @@ def mcp_tool_with_restrictions(
         # If the argument-passing mechanism changes (e.g. to positional-only
         # or partial kwargs), this logic must be revisited.
         _sig = inspect.signature(func)
-        _sig_params = frozenset(_sig.parameters.keys())
+        _sig_params = frozenset(
+            name
+            for name, p in _sig.parameters.items()
+            if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        )
         _param_defaults = {
             name: param.default
             for name, param in _sig.parameters.items()
             if param.default is not param.empty
+            and name in _sig_params  # skip catch-all params (no sensible default)
         }
 
-        @functools.wraps(func)
-        async def _telemetry_wrapper(*args, **kwargs):
-            # Encode the assumption that the framework always calls tools
-            # with fully-populated keyword arguments only. Positional-only
-            # arguments would silently fall out of param tracking, skewing
-            # telemetry. This guard serves as a canary if the call pattern
-            # ever changes. Using an explicit TypeError rather than assert
-            # ensures the check survives python -O optimization.
+        def _ensure_kwargs_only(func_name: str, args: tuple[Any, ...]) -> None:
+            """Guard against positional args; telemetry assumes kwargs-only calls."""
             if args:
                 raise TypeError(
-                    f"Telemetry assumes kwargs-only calls for {func.__name__}, "
+                    f"Telemetry assumes kwargs-only calls for {func_name}, "
                     f"but got {len(args)} positional arg(s)"
                 )
 
-            # Restrict to declared signature params, excluding any
-            # framework-injected or auxiliary kwargs.
+        def _filter_explicit_kwargs(all_kwargs: dict[str, Any]) -> dict[str, Any]:
+            """Restrict to declared params and drop values matching signature defaults."""
             sig_kwargs = {
                 name: value
-                for name, value in kwargs.items()
+                for name, value in all_kwargs.items()
                 if name in _sig_params
             }
-
-            # Exclude params whose value matches their signature default
-            # (likely framework-filled, not explicitly provided by the caller).
-            explicit_kwargs = {
+            return {
                 name: value
                 for name, value in sig_kwargs.items()
                 if (
@@ -209,6 +205,11 @@ def mcp_tool_with_restrictions(
                 )
             }
 
+        @functools.wraps(func)
+        async def _telemetry_wrapper(*args, **kwargs):
+            _ensure_kwargs_only(func.__name__, args)
+
+            explicit_kwargs = _filter_explicit_kwargs(kwargs)
             param_keys = frozenset(explicit_kwargs.keys())
             t0 = time.perf_counter()
             error: str | None = None

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -181,13 +181,14 @@ def mcp_tool_with_restrictions(
             # Encode the assumption that the framework always calls tools
             # with fully-populated keyword arguments only. Positional-only
             # arguments would silently fall out of param tracking, skewing
-            # telemetry. This assert serves as a canary if the call pattern
-            # ever changes. See the docstring comment above for the full
-            # rationale.
-            assert not args, (
-                f"Telemetry assumed kwargs-only calls for {func.__name__}, "
-                f"but got {len(args)} positional arg(s)"
-            )
+            # telemetry. This guard serves as a canary if the call pattern
+            # ever changes. Using an explicit TypeError rather than assert
+            # ensures the check survives python -O optimization.
+            if args:
+                raise TypeError(
+                    f"Telemetry assumes kwargs-only calls for {func.__name__}, "
+                    f"but got {len(args)} positional arg(s)"
+                )
 
             # Restrict to declared signature params, excluding any
             # framework-injected or auxiliary kwargs.

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -112,6 +112,22 @@ _DESC_INVOKE_MTPROTO = _tool_description(
 )
 
 
+def _matches_default(value: Any, default: Any) -> bool:
+    """Check if value matches its signature default, safely handling complex types.
+
+    Only scalar types (None, bool, int, float, str, bytes) and immutable
+    collections of those (tuple, frozenset) have well-defined scalar equality.
+    More complex defaults (lists, dicts, custom objects) skip comparison and
+    are treated as explicitly provided, which is conservative but safe.
+    """
+    if isinstance(default, (type(None), bool, int, float, str, bytes)):
+        return value == default
+    if isinstance(default, (tuple, frozenset)):
+        return isinstance(value, type(default)) and value == default
+    # Complex type — can't safely compare, treat as explicitly provided
+    return False
+
+
 def mcp_tool_with_restrictions(
     operation_name: str, *, allow_bot_sessions: bool = False
 ):
@@ -152,7 +168,8 @@ def mcp_tool_with_restrictions(
             param_keys = frozenset(
                 name
                 for name, value in kwargs.items()
-                if name not in _param_defaults or value != _param_defaults[name]
+                if name not in _param_defaults
+                or not _matches_default(value, _param_defaults[name])
             )
             t0 = time.perf_counter()
             error: str | None = None

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -120,10 +120,19 @@ def _matches_default(value: Any, default: Any) -> bool:
     More complex defaults (lists, dicts, custom objects) skip comparison and
     are treated as explicitly provided, which is conservative but safe.
     """
-    if isinstance(default, (type(None), bool, int, float, str, bytes)):
+    scalar_types = (type(None), bool, int, float, str, bytes)
+
+    if isinstance(default, scalar_types):
         return value == default
+
     if isinstance(default, (tuple, frozenset)):
+        # Only compare if default is a flat collection of scalars.
+        # Collections with complex elements are treated as explicit
+        # to avoid expensive or side-effectful __eq__ calls.
+        if not all(isinstance(el, scalar_types) for el in default):
+            return False
         return isinstance(value, type(default)) and value == default
+
     # Complex type — can't safely compare, treat as explicitly provided
     return False
 

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -178,6 +178,17 @@ def mcp_tool_with_restrictions(
 
         @functools.wraps(func)
         async def _telemetry_wrapper(*args, **kwargs):
+            # Encode the assumption that the framework always calls tools
+            # with fully-populated keyword arguments only. Positional-only
+            # arguments would silently fall out of param tracking, skewing
+            # telemetry. This assert serves as a canary if the call pattern
+            # ever changes. See the docstring comment above for the full
+            # rationale.
+            assert not args, (
+                f"Telemetry assumed kwargs-only calls for {func.__name__}, "
+                f"but got {len(args)} positional arg(s)"
+            )
+
             # Restrict to declared signature params, excluding any
             # framework-injected or auxiliary kwargs.
             sig_kwargs = {

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import time
 import traceback
 from typing import Any
@@ -129,9 +130,23 @@ def mcp_tool_with_restrictions(
     def decorator(func):
         """Wrap tool call with per-tool timing, parameter-set breakdown, and error traces."""
 
+        # Pre-compute parameter defaults from function signature
+        # so _telemetry_wrapper can skip framework-filled defaults
+        # and only track params the caller explicitly provided.
+        _param_defaults = {
+            name: param.default
+            for name, param in inspect.signature(func).parameters.items()
+            if param.default is not param.empty
+        }
+
         @functools.wraps(func)
         async def _telemetry_wrapper(*args, **kwargs):
-            param_keys = frozenset(kwargs.keys())
+            # Only count params explicitly provided (not framework-filled defaults)
+            param_keys = frozenset(
+                name
+                for name, value in kwargs.items()
+                if name not in _param_defaults or value != _param_defaults[name]
+            )
             t0 = time.perf_counter()
             error: str | None = None
             try:

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -133,6 +133,13 @@ def mcp_tool_with_restrictions(
         # Pre-compute parameter defaults from function signature
         # so _telemetry_wrapper can skip framework-filled defaults
         # and only track params the caller explicitly provided.
+        #
+        # This relies on Pydantic/MCP always calling tools with fully-populated
+        # keyword arguments (all declared params, defaults filled in for missing
+        # ones). Params whose values match their signature defaults are treated
+        # as likely framework-filled and excluded from the param set key.
+        # If the argument-passing mechanism changes (e.g. to positional-only
+        # or partial kwargs), this logic must be revisited.
         _param_defaults = {
             name: param.default
             for name, param in inspect.signature(func).parameters.items()

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import logging
 import time
 import traceback
 from typing import Any
@@ -116,6 +117,8 @@ _DESC_INVOKE_MTPROTO = _tool_description(
 # Defined at module level to avoid recomputation in a hot helper.
 _SCALAR_TYPES = (type(None), bool, int, float, str, bytes)
 
+logger = logging.getLogger(__name__)
+
 
 def _matches_default(value: Any, default: Any) -> bool:
     """Check if value matches its signature default for simple scalar types.
@@ -169,26 +172,38 @@ def mcp_tool_with_restrictions(
 
         @functools.wraps(func)
         async def _telemetry_wrapper(*args, **kwargs):
-            # Guard against positional args; telemetry assumes kwargs-only calls.
+            # Telemetry layer must never break tool execution. If param-key
+            # detection encounters unexpected call patterns (positional args,
+            # unknown kwargs), we log the anomaly and fall back to the full
+            # kwargs set rather than crashing the tool call.
+
             if args:
-                raise TypeError(
-                    f"Telemetry assumes kwargs-only calls for {func.__name__}, "
-                    f"but got {len(args)} positional arg(s)"
+                logger.warning(
+                    "Telemetry assumes kwargs-only for %s; got %d positional arg(s)",
+                    func.__name__,
+                    len(args),
                 )
-
-            # Use bind_partial to filter kwargs to declared params only
-            # (handles catch-all params like **kwargs transparently).
-            bound = _sig.bind_partial(**kwargs)
-
-            # Single pass: collect explicitly-provided kwargs, skipping
-            # values that match their signature defaults (likely framework-filled).
-            explicit_kwargs: dict[str, Any] = {}
-            for name, value in bound.arguments.items():
-                if name in _param_defaults and _matches_default(value, _param_defaults[name]):
-                    continue  # likely framework-filled default
-                explicit_kwargs[name] = value
-
-            param_keys = frozenset(explicit_kwargs.keys())
+                param_keys = frozenset(kwargs.keys())
+            else:
+                try:
+                    bound = _sig.bind_partial(**kwargs)
+                except TypeError:
+                    logger.warning(
+                        "Telemetry bind_partial failed for %s (unexpected kwargs); "
+                        "falling back to full kwargs set",
+                        func.__name__,
+                        exc_info=True,
+                    )
+                    param_keys = frozenset(kwargs.keys())
+                else:
+                    # Single pass: collect explicitly-provided kwargs, skipping
+                    # values that match their signature defaults (likely framework-filled).
+                    explicit_kwargs: dict[str, Any] = {}
+                    for name, value in bound.arguments.items():
+                        if name in _param_defaults and _matches_default(value, _param_defaults[name]):
+                            continue  # likely framework-filled default
+                        explicit_kwargs[name] = value
+                    param_keys = frozenset(explicit_kwargs.keys())
             t0 = time.perf_counter()
             error: str | None = None
             try:

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -156,6 +156,7 @@ def mcp_tool_with_restrictions(
         # as likely framework-filled and excluded from the param set key.
         # If the argument-passing mechanism changes (e.g. to positional-only
         # or partial kwargs), this logic must be revisited.
+        _sig_params = frozenset(inspect.signature(func).parameters.keys())
         _param_defaults = {
             name: param.default
             for name, param in inspect.signature(func).parameters.items()
@@ -164,12 +165,17 @@ def mcp_tool_with_restrictions(
 
         @functools.wraps(func)
         async def _telemetry_wrapper(*args, **kwargs):
-            # Only count params explicitly provided (not framework-filled defaults)
+            # Only count params explicitly provided (not framework-filled defaults).
+            # Restrict to signature-only params to exclude any framework-injected
+            # or auxiliary kwargs that are not part of the tool declaration.
             param_keys = frozenset(
                 name
                 for name, value in kwargs.items()
-                if name not in _param_defaults
-                or not _matches_default(value, _param_defaults[name])
+                if name in _sig_params
+                and (
+                    name not in _param_defaults
+                    or not _matches_default(value, _param_defaults[name])
+                )
             )
             t0 = time.perf_counter()
             error: str | None = None

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -174,36 +174,27 @@ def mcp_tool_with_restrictions(
         async def _telemetry_wrapper(*args, **kwargs):
             # Telemetry layer must never break tool execution. If param-key
             # detection encounters unexpected call patterns (positional args,
-            # unknown kwargs), we log the anomaly and fall back to the full
+            # unexpected kwargs), we log the anomaly and fall back to the full
             # kwargs set rather than crashing the tool call.
-
-            if args:
+            try:
+                bound = _sig.bind(*args, **kwargs)
+            except TypeError:
                 logger.warning(
-                    "Telemetry assumes kwargs-only for %s; got %d positional arg(s)",
+                    "Telemetry param binding failed for %s; "
+                    "falling back to full kwargs set",
                     func.__name__,
-                    len(args),
+                    exc_info=True,
                 )
                 param_keys = frozenset(kwargs.keys())
             else:
-                try:
-                    bound = _sig.bind_partial(**kwargs)
-                except TypeError:
-                    logger.warning(
-                        "Telemetry bind_partial failed for %s (unexpected kwargs); "
-                        "falling back to full kwargs set",
-                        func.__name__,
-                        exc_info=True,
-                    )
-                    param_keys = frozenset(kwargs.keys())
-                else:
-                    # Single pass: collect explicitly-provided kwargs, skipping
-                    # values that match their signature defaults (likely framework-filled).
-                    explicit_kwargs: dict[str, Any] = {}
-                    for name, value in bound.arguments.items():
-                        if name in _param_defaults and _matches_default(value, _param_defaults[name]):
-                            continue  # likely framework-filled default
-                        explicit_kwargs[name] = value
-                    param_keys = frozenset(explicit_kwargs.keys())
+                # Single pass: collect explicitly-provided kwargs, skipping
+                # values that match their signature defaults (likely framework-filled).
+                explicit_kwargs: dict[str, Any] = {}
+                for name, value in bound.arguments.items():
+                    if name in _param_defaults and _matches_default(value, _param_defaults[name]):
+                        continue  # likely framework-filled default
+                    explicit_kwargs[name] = value
+                param_keys = frozenset(explicit_kwargs.keys())
             t0 = time.perf_counter()
             error: str | None = None
             try:

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -1,6 +1,5 @@
 import functools
 import inspect
-import logging
 import time
 import traceback
 from typing import Any
@@ -113,25 +112,15 @@ _DESC_INVOKE_MTPROTO = _tool_description(
 )
 
 
-# Types whose equality is well-defined for default-value comparison.
-# Defined at module level to avoid recomputation in a hot helper.
-_SCALAR_TYPES = (type(None), bool, int, float, str, bytes)
-
-logger = logging.getLogger(__name__)
-
-
 def _matches_default(value: Any, default: Any) -> bool:
-    """Check if value matches its signature default for simple scalar types.
+    """Best-effort: is *value* the simple scalar default?
 
-    Only scalar types (None, bool, int, float, str, bytes) have well-defined
-    scalar equality. Complex defaults (lists, dicts, custom objects) skip
-    comparison and are treated as explicitly provided, which is conservative
-    but safe.
+    Only compares well-defined immutable types (None, bool, int, float, str,
+    bytes).  Anything else (lists, dicts, objects) is treated as explicitly
+    provided — conservative but safe.
     """
-    if isinstance(default, _SCALAR_TYPES) and isinstance(value, type(default)):
-        # bool is a subclass of int; exact type check prevents True == 1 etc.
+    if isinstance(default, (type(None), bool, int, float, str, bytes)):
         return value == default
-    # Complex / non-scalar defaults treated as explicitly provided
     return False
 
 
@@ -172,29 +161,15 @@ def mcp_tool_with_restrictions(
 
         @functools.wraps(func)
         async def _telemetry_wrapper(*args, **kwargs):
-            # Telemetry layer must never break tool execution. If param-key
-            # detection encounters unexpected call patterns (positional args,
-            # unexpected kwargs), we log the anomaly and fall back to the full
-            # kwargs set rather than crashing the tool call.
-            try:
-                bound = _sig.bind(*args, **kwargs)
-            except TypeError:
-                logger.warning(
-                    "Telemetry param binding failed for %s; "
-                    "falling back to full kwargs set",
-                    func.__name__,
-                    exc_info=True,
-                )
-                param_keys = frozenset(kwargs.keys())
-            else:
-                # Single pass: collect explicitly-provided kwargs, skipping
-                # values that match their signature defaults (likely framework-filled).
-                explicit_kwargs: dict[str, Any] = {}
-                for name, value in bound.arguments.items():
-                    if name in _param_defaults and _matches_default(value, _param_defaults[name]):
-                        continue  # likely framework-filled default
-                    explicit_kwargs[name] = value
-                param_keys = frozenset(explicit_kwargs.keys())
+            # Telemetry layer must never break tool execution.
+            # Assume MCP/Pydantic always calls tools with fully-populated keyword args.
+            # Only track params that differ from their signature defaults.
+            param_keys = frozenset(
+                name
+                for name, value in kwargs.items()
+                if name not in _param_defaults
+                or not _matches_default(value, _param_defaults[name])
+            )
             t0 = time.perf_counter()
             error: str | None = None
             try:

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -118,28 +118,17 @@ _SCALAR_TYPES = (type(None), bool, int, float, str, bytes)
 
 
 def _matches_default(value: Any, default: Any) -> bool:
-    """Check if value matches its signature default, safely handling complex types.
+    """Check if value matches its signature default for simple scalar types.
 
-    Only scalar types (None, bool, int, float, str, bytes) and immutable
-    collections of those (tuple, frozenset) have well-defined scalar equality.
-    More complex defaults (lists, dicts, custom objects) skip comparison and
-    are treated as explicitly provided, which is conservative but safe.
+    Only scalar types (None, bool, int, float, str, bytes) have well-defined
+    scalar equality. Complex defaults (lists, dicts, custom objects) skip
+    comparison and are treated as explicitly provided, which is conservative
+    but safe.
     """
-    if isinstance(default, _SCALAR_TYPES):
-        # bool is a subclass of int, so value == default would match
-        # cross-type values (e.g. True == 1). Require exact type match
-        # to prevent misclassifying explicit values as defaults.
-        return type(value) is type(default) and value == default
-
-    if isinstance(default, (tuple, frozenset)):
-        # Only compare if default is a flat collection of scalars.
-        # Collections with complex elements are treated as explicit
-        # to avoid expensive or side-effectful __eq__ calls.
-        if not all(isinstance(el, _SCALAR_TYPES) for el in default):
-            return False
-        return isinstance(value, type(default)) and value == default
-
-    # Complex type — can't safely compare, treat as explicitly provided
+    if isinstance(default, _SCALAR_TYPES) and isinstance(value, type(default)):
+        # bool is a subclass of int; exact type check prevents True == 1 etc.
+        return value == default
+    # Complex / non-scalar defaults treated as explicitly provided
     return False
 
 
@@ -172,16 +161,10 @@ def mcp_tool_with_restrictions(
         # If the argument-passing mechanism changes (e.g. to positional-only
         # or partial kwargs), this logic must be revisited.
         _sig = inspect.signature(func)
-        _sig_params = frozenset(
-            name
-            for name, p in _sig.parameters.items()
-            if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
-        )
         _param_defaults = {
             name: param.default
             for name, param in _sig.parameters.items()
             if param.default is not param.empty
-            and name in _sig_params  # skip catch-all params (no sensible default)
         }
 
         @functools.wraps(func)
@@ -193,13 +176,16 @@ def mcp_tool_with_restrictions(
                     f"but got {len(args)} positional arg(s)"
                 )
 
+            # Use bind_partial to filter kwargs to declared params only
+            # (handles catch-all params like **kwargs transparently).
+            bound = _sig.bind_partial(**kwargs)
+
             # Single pass: collect explicitly-provided kwargs, skipping
-            # unknown/catch-all params and values matching signature defaults.
+            # values that match their signature defaults (likely framework-filled).
             explicit_kwargs: dict[str, Any] = {}
-            for name, value in kwargs.items():
-                if name not in _sig_params:
-                    continue  # unknown or catch-all param
-                if name in _param_defaults and _matches_default(value, _param_defaults[name]):
+            for name, value in bound.arguments.items():
+                default = _param_defaults.get(name)
+                if default is not None and _matches_default(value, default):
                     continue  # likely framework-filled default
                 explicit_kwargs[name] = value
 

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -184,8 +184,7 @@ def mcp_tool_with_restrictions(
             # values that match their signature defaults (likely framework-filled).
             explicit_kwargs: dict[str, Any] = {}
             for name, value in bound.arguments.items():
-                default = _param_defaults.get(name)
-                if default is not None and _matches_default(value, default):
+                if name in _param_defaults and _matches_default(value, _param_defaults[name]):
                     continue  # likely framework-filled default
                 explicit_kwargs[name] = value
 


### PR DESCRIPTION
MCP/FastMCP fills in defaults for all declared params via Pydantic model_validate before calling the tool function, so frozenset(kwargs.keys()) always contained every param regardless of what the client sent.

This made the param set breakdown meaningless — every call to the same tool shared a single param set key with all declared params, creating phantom combinations like get_messages with query, message_ids, AND reply_to_id simultaneously.

Fix: pre-compute each tool's param defaults from its function signature, then filter kwargs to only include params whose values differ from their defaults. Now each distinct call pattern gets its own param set.

763 unit tests pass, ruff clean.

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>
- Исправлена телеметрия наборов параметров, чтобы вызовы инструмента больше не группировались под одним ключом, включающим все объявленные параметры и значения, заполненные по умолчанию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>

</details>
- Исправлена телеметрия наборов параметров так, чтобы вызовы больше не группировались под одним ключом, включающим все объявленные параметры, что предотвращает появление фиктивных комбинаций параметров в метриках.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>
- Исправлена телеметрия наборов параметров, чтобы вызовы инструмента больше не группировались под одним ключом, включающим все объявленные параметры и значения, заполненные по умолчанию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>

</details>

</details>
- Обеспечить, чтобы телеметрия группировала вызовы инструмента по набору параметров, явно переданных вызывающей стороной, избегая фиктивных комбинаций, возникающих из-за автоматически подставляемых значений по умолчанию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>
- Исправлена телеметрия наборов параметров, чтобы вызовы инструмента больше не группировались под одним ключом, включающим все объявленные параметры и значения, заполненные по умолчанию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>

</details>
- Исправлена телеметрия наборов параметров так, чтобы вызовы больше не группировались под одним ключом, включающим все объявленные параметры, что предотвращает появление фиктивных комбинаций параметров в метриках.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>
- Исправлена телеметрия наборов параметров, чтобы вызовы инструмента больше не группировались под одним ключом, включающим все объявленные параметры и значения, заполненные по умолчанию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда телеметрия сворачивает все вызовы инструмента в один ключ набора параметров, включающий значения по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

Исправления ошибок:
- Предотвратить ситуацию, когда все вызовы инструментов схлопываются в один ключ набора параметров телеметрии, включающий значения параметров по умолчанию, подставленные фреймворком.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

Исправления ошибок:
- Исправить телеметрию наборов параметров, чтобы вызовы инструментов больше не сводились к одному ключу, включающему все объявленные параметры со значениями по умолчанию.

Улучшения:
- Определять значения параметров по умолчанию для каждого инструмента из сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, из ключей наборов параметров в телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Настроить телеметрию инструментов так, чтобы ключи наборов параметров формировались на основе явно переданных аргументов, а не значений по умолчанию, заполняемых фреймворком.

Исправления ошибок:
- Предотвратить сворачивание всех вызовов инструментов в один и тот же ключ набора параметров телеметрии, включающий параметры, заполненные значениями по умолчанию.

Улучшения:
- Предварительно вычислять значения параметров по умолчанию для каждого инструмента на основе сигнатур функций и исключать аргументы, совпадающие с этими значениями по умолчанию, при формировании ключей наборов параметров телеметрии.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool telemetry to derive parameter-set keys from explicitly provided arguments rather than framework-filled defaults.

Bug Fixes:
- Prevent all tool calls from collapsing into a single telemetry parameter-set key that included default-filled parameters.

Enhancements:
- Precompute per-tool parameter defaults from function signatures and exclude arguments matching those defaults when constructing telemetry parameter-set keys.

</details>

</details>

</details>

</details>

</details>

</details>

</details>