### PR TITLE
chore: move MCP registry id string to bottom of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-mcp-name: io.github.leshchenko1979/fast-mcp-telegram
-
 <img alt="Hero image" src="https://github.com/user-attachments/assets/635236f6-b776-41c7-b6e5-0dd14638ecc1" />
 
 **Telegram MCP Server** — Model Context Protocol (MCP) gateway for Telegram. 8 context-efficient tools, multi-tenant, MTProto bridge.
@@ -165,5 +163,7 @@ Anonymous tool telemetry since v0.30.1 — heartbeat every 6h, no credentials or
 ## License
 
 MIT License - see [LICENSE](LICENSE)
+
+mcp-name: io.github.leshchenko1979/fast-mcp-telegram
 
 


### PR DESCRIPTION
Moves the `mcp-name: io.github.leshchenko1979/fast-mcp-telegram` line from the top of README.md to the bottom (after License). Cleaner first impression for visitors.

## Summary by Sourcery

Документация:
- Переместить строку с идентификатором реестра MCP из верхней части файла README в самый низ, после раздела с лицензией.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Move the MCP registry ID line from the top of the README to the bottom after the license section.

</details>