### PR TITLE
refactor: remove unused client param from build_message_result chain

### DIFF
--- a/src/tools/messages/reading.py
+++ b/src/tools/messages/reading.py
@@ -60,7 +60,6 @@ def _find_message_by_id(messages: list, requested_id: int, idx: int):
 
 
 async def _build_message_results(
-    client,
     messages: list,
     message_ids: list[int],
     entity,
@@ -85,7 +84,7 @@ async def _build_message_results(
 
         link = id_to_link.get(getattr(msg, "id", requested_id))
         built = await build_message_result(
-            client, msg, entity, link, include_chat_entity=False
+            msg, entity, link, include_chat_entity=False
         )
         results.append(built)
 
@@ -149,7 +148,7 @@ async def read_messages_by_ids(
         chat_dict = build_entity_dict(entity) or {}
 
         results = await _build_message_results(
-            client, messages, message_ids, entity, id_to_link, chat_dict
+            messages, message_ids, entity, id_to_link, chat_dict
         )
 
         successful_results = [r for r in results if "error" not in r]

--- a/src/tools/search/forum_replies.py
+++ b/src/tools/search/forum_replies.py
@@ -355,7 +355,7 @@ async def _collect_forum_anchor_replies(
     collected: list[dict[str, Any]] = []
     for stub in matched:
         built = await results._build_result_for_message(
-            client, by_id.get(stub.id, stub), entity, include_chat_entity
+            by_id.get(stub.id, stub), entity, include_chat_entity
         )
         if built:
             collected.append(built)

--- a/src/tools/search/replies.py
+++ b/src/tools/search/replies.py
@@ -93,7 +93,6 @@ async def _collect_full_thread_messages(
         remaining = target - len(collected)
         collected.extend(
             await results._build_results_up_to_limit(
-                client,
                 messages,
                 entity,
                 include_chat_entity,
@@ -130,7 +129,7 @@ async def _fetch_direct_replies(
         if min_date and message.date and message.date < min_date:
             continue
         result = await results._build_result_for_message(
-            client, message, entity, include_chat_entity
+            message, entity, include_chat_entity
         )
         if not result:
             continue

--- a/src/tools/search/results.py
+++ b/src/tools/search/results.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 async def _build_results_up_to_limit(
-    client,
     messages,
     chat_entity,
     include_chat_entity: bool,
@@ -25,7 +24,7 @@ async def _build_results_up_to_limit(
     target = limit + 1 if limit is not None else None
     for message in messages:
         built = await _build_result_for_message(
-            client, message, chat_entity, include_chat_entity
+            message, chat_entity, include_chat_entity
         )
         if not built:
             continue
@@ -36,7 +35,6 @@ async def _build_results_up_to_limit(
 
 
 async def _build_result_for_message(
-    client,
     message,
     chat_entity,
     include_chat_entity: bool = False,
@@ -60,7 +58,7 @@ async def _build_result_for_message(
         )
         link = links.get("message_links", [None])[0]
         return await build_message_result(
-            client, message, chat_entity, link, include_chat_entity
+            message, chat_entity, link, include_chat_entity
         )
     except Exception as e:
         logger.warning(f"Error processing message: {e}")

--- a/src/tools/search/search_generators.py
+++ b/src/tools/search/search_generators.py
@@ -54,7 +54,7 @@ async def _search_chat_messages_generator(
                 continue
 
             result = await results._build_result_for_message(
-                client, message, entity, include_chat_entity
+                message, entity, include_chat_entity
             )
             if not result:
                 continue
@@ -118,7 +118,7 @@ async def _search_global_messages_generator(
                     continue
 
                 msg_result = await results._build_result_for_message(
-                    client, message, chat, include_chat_entity
+                    message, chat, include_chat_entity
                 )
                 if not msg_result:
                     continue

--- a/src/tools/search/search_mode.py
+++ b/src/tools/search/search_mode.py
@@ -150,7 +150,7 @@ async def _process_raw_message(
             return None
 
         return await results._build_result_for_message(
-            client, message, chat, include_chat_entity
+            message, chat, include_chat_entity
         )
     except Exception as e:
         logger.warning(f"Error processing message: {e}")

--- a/src/utils/message_format.py
+++ b/src/utils/message_format.py
@@ -524,7 +524,7 @@ def _extract_topic_metadata(message: Any) -> dict[str, Any]:
 
 
 async def build_message_result(
-    client, message, entity_or_chat, link: str | None, include_chat_entity: bool = False
+    message, entity_or_chat, link: str | None, include_chat_entity: bool = False
 ) -> dict[str, Any]:
     sender = await get_sender_info(message)
     chat = build_entity_dict(entity_or_chat)

--- a/tests/test_forum_topics_minimal.py
+++ b/tests/test_forum_topics_minimal.py
@@ -37,7 +37,7 @@ async def test_build_message_result_includes_topic_fields_for_forum_chat():
             new=AsyncMock(return_value=None),
         ),
     ):
-        result = await build_message_result(None, message, entity, None)
+        result = await build_message_result(message, entity, None)
 
     assert result["topic_id"] == 51
 
@@ -63,7 +63,7 @@ async def test_build_message_result_topic_fallback_to_message_reply_to_msg_id():
             new=AsyncMock(return_value=None),
         ),
     ):
-        result = await build_message_result(None, message, entity, None)
+        result = await build_message_result(message, entity, None)
 
     assert result["topic_id"] == 42
 
@@ -90,7 +90,7 @@ async def test_build_message_result_topic_fallback_to_reply_object_reply_to_msg_
             new=AsyncMock(return_value=None),
         ),
     ):
-        result = await build_message_result(None, message, entity, None)
+        result = await build_message_result(message, entity, None)
 
     assert result["topic_id"] == 99
 
@@ -117,7 +117,7 @@ async def test_build_message_result_omits_topic_fields_when_forum_topic_has_no_i
             new=AsyncMock(return_value=None),
         ),
     ):
-        result = await build_message_result(None, message, entity, None)
+        result = await build_message_result(message, entity, None)
 
     assert "topic_id" not in result
 
@@ -143,7 +143,7 @@ async def test_build_message_result_omits_topic_fields_for_non_forum_chat():
             new=AsyncMock(return_value=None),
         ),
     ):
-        result = await build_message_result(None, message, entity, None)
+        result = await build_message_result(message, entity, None)
 
     assert "topic_id" not in result
 

--- a/tests/test_message_formatting.py
+++ b/tests/test_message_formatting.py
@@ -477,7 +477,7 @@ class TestBuildMessageResultExcludeChat:
             new=AsyncMock(return_value={"id": 789, "name": "Sender"}),
         ):
             result = await build_message_result(
-                client, msg, entity, link="https://t.me/testchat/123", include_chat_entity=False
+                msg, entity, link="https://t.me/testchat/123", include_chat_entity=False
             )
 
         assert "chat" not in result, f"Expected no 'chat' field, got {result.keys()}"
@@ -513,7 +513,7 @@ class TestBuildMessageResultExcludeChat:
             new=AsyncMock(return_value={"id": 789, "name": "Sender"}),
         ):
             result = await build_message_result(
-                client, msg, entity, link="https://t.me/testchat/123", include_chat_entity=True
+                msg, entity, link="https://t.me/testchat/123", include_chat_entity=True
             )
 
         assert "chat" in result, f"Expected 'chat' field, got {result.keys()}"
@@ -548,7 +548,7 @@ class TestBuildMessageResultExcludeChat:
             new=AsyncMock(return_value={"id": 789, "name": "Sender"}),
         ):
             result = await build_message_result(
-                client, msg, entity, link="https://t.me/testchat/123"
+                msg, entity, link="https://t.me/testchat/123"
             )
 
         assert "chat" not in result, f"Expected no 'chat' field by default, got {result.keys()}"
@@ -581,14 +581,12 @@ class TestBuildMessageResultServicePlaceholder:
         entity.username = "testchat"
         entity.type = "chat"
 
-        client = AsyncMock()
-
         with patch(
             "src.utils.message_format.get_sender_info",
             new=AsyncMock(return_value={"id": 789, "name": "Sender"}),
         ):
             result = await build_message_result(
-                client, msg, entity, link=None, include_chat_entity=False
+                msg, entity, link=None, include_chat_entity=False
             )
 
         assert result["text"] == "[Service: PinMessage]"

--- a/tests/test_thread_scope_replies_fetch.py
+++ b/tests/test_thread_scope_replies_fetch.py
@@ -369,7 +369,7 @@ async def test_forum_in_topic_replies_hydrate_search_stubs():
         )
 
     assert len(collected) == 1
-    hydrated_call = build_mock.call_args_list[0][0][1]
+    hydrated_call = build_mock.call_args_list[0][0][0]
     assert hydrated_call.text == "hydrated reply"
 
 

--- a/tests/test_thread_scope_replies_fetch.py
+++ b/tests/test_thread_scope_replies_fetch.py
@@ -369,7 +369,8 @@ async def test_forum_in_topic_replies_hydrate_search_stubs():
         )
 
     assert len(collected) == 1
-    hydrated_call = build_mock.call_args_list[0][0][0]
+    args, _ = build_mock.call_args_list[0]
+    hydrated_call = args[0]
     assert hydrated_call.text == "hydrated reply"
 
 


### PR DESCRIPTION
## What

Remove the unused `client` parameter from `build_message_result` and its entire call chain, following up on PR #134 which made it unused by switching `get_sender_info` from `get_entity_by_id(client, sender_id)` to `message.get_sender()`.

## Why

After PR #134, `build_message_result` accepted `client` but never used it — the parameter was dead code propagating through 6 layers of callers.

## Changes

- `src/utils/message_format.py` — remove `client` from `build_message_result` signature
- `src/tools/search/results.py` — remove `client` from `_build_result_for_message` and `_build_results_up_to_limit`
- `src/tools/search/search_generators.py` — update 2 callers
- `src/tools/search/search_mode.py` — update 1 caller
- `src/tools/search/forum_replies.py` — update 1 caller
- `src/tools/search/replies.py` — update 2 callers
- `src/tools/messages/reading.py` — remove `client` from `_build_message_results` and update caller
- Tests updated to match new signatures

## Summary by Sourcery

Удалить неиспользуемый параметр `client` из утилит построения результата сообщения и их вызовов в коде поиска и чтения сообщений.

Улучшения:
- Упростить `build_message_result` и цепочку его вызовов, убрав неиспользуемый аргумент `client` во всех вспомогательных функциях поиска и чтения сообщений.

Тесты:
- Обновить тесты форматирования сообщений, тем форумов и ответов в тредах для использования новой сигнатуры `build_message_result` и соответственно скорректировать моки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the unused client parameter from message result building utilities and their callers across search and message reading code.

Enhancements:
- Simplify build_message_result and its call chain by dropping the unused client argument throughout search and message reading helpers.

Tests:
- Update message formatting, forum topics, and thread replies tests to use the new build_message_result signature and adjust mocks accordingly.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Удалить неиспользуемый параметр `client` из утилит построения результата сообщения и их вызовов в коде поиска и чтения сообщений.

Улучшения:
- Упростить `build_message_result` и цепочку его вызовов, убрав неиспользуемый аргумент `client` во всех вспомогательных функциях поиска и чтения сообщений.

Тесты:
- Обновить тесты форматирования сообщений, тем форумов и ответов в тредах для использования новой сигнатуры `build_message_result` и соответственно скорректировать моки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the unused client parameter from message result building utilities and their callers across search and message reading code.

Enhancements:
- Simplify build_message_result and its call chain by dropping the unused client argument throughout search and message reading helpers.

Tests:
- Update message formatting, forum topics, and thread replies tests to use the new build_message_result signature and adjust mocks accordingly.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Удалить неиспользуемый параметр `client` из утилит построения результата сообщения и их вызовов в коде поиска и чтения сообщений.

Улучшения:
- Упростить `build_message_result` и цепочку его вызовов, убрав неиспользуемый аргумент `client` во всех вспомогательных функциях поиска и чтения сообщений.

Тесты:
- Обновить тесты форматирования сообщений, тем форумов и ответов в тредах для использования новой сигнатуры `build_message_result` и соответственно скорректировать моки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the unused client parameter from message result building utilities and their callers across search and message reading code.

Enhancements:
- Simplify build_message_result and its call chain by dropping the unused client argument throughout search and message reading helpers.

Tests:
- Update message formatting, forum topics, and thread replies tests to use the new build_message_result signature and adjust mocks accordingly.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Удалить неиспользуемый параметр `client` из утилит построения результата сообщения и их вызовов в коде поиска и чтения сообщений.

Улучшения:
- Упростить `build_message_result` и цепочку его вызовов, убрав неиспользуемый аргумент `client` во всех вспомогательных функциях поиска и чтения сообщений.

Тесты:
- Обновить тесты форматирования сообщений, тем форумов и ответов в тредах для использования новой сигнатуры `build_message_result` и соответственно скорректировать моки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the unused client parameter from message result building utilities and their callers across search and message reading code.

Enhancements:
- Simplify build_message_result and its call chain by dropping the unused client argument throughout search and message reading helpers.

Tests:
- Update message formatting, forum topics, and thread replies tests to use the new build_message_result signature and adjust mocks accordingly.

</details>

</details>

</details>