### PR TITLE
fix: address remaining Sourcery review comments from #136

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -134,7 +134,7 @@ Counts are fetched via Telethon full-info requests and reflect current values.
 > exceeds 2⁵³ and must round-trip verbatim to rebuild `InputPeer`), and any
 > out-of-range integer in `invoke_mtproto` results (including `document_id`) — small
 > values like offsets, flags and lengths stay numeric. All other id fields (`id`,
-> `message_id`, `reply_to_msg_id`, `topic_id`) remain numbers. Ids are accepted as
+> `message_id`, `reply_to_msg_id`, `topic_id`) remain numbers. ids are accepted as
 > either strings or numbers on input.
 
 **Examples:**

--- a/tests/test_json_ids.py
+++ b/tests/test_json_ids.py
@@ -155,3 +155,17 @@ class TestBuildEntityDict:
         assert isinstance(result["id"], int)
         assert result["access_hash"] == "9007199254740993"
         assert isinstance(result["access_hash"], str)
+
+    def test_no_access_hash_attribute(self):
+        """Entity without access_hash attribute → field omitted from dict."""
+        entity = SimpleNamespace(id=12345, title="NoHash")
+        result = build_entity_dict(entity)
+        assert "access_hash" not in result
+        assert result["id"] == 12345
+
+    def test_access_hash_is_none(self):
+        """Entity with access_hash=None → field omitted (not string 'None')."""
+        entity = SimpleNamespace(id=12345, access_hash=None, title="NullHash")
+        result = build_entity_dict(entity)
+        assert "access_hash" not in result
+        assert result["id"] == 12345


### PR DESCRIPTION
## Summary

Addresses remaining Sourcery review comments on PR #136:

- **Tests for `None`/missing `access_hash`**: Added `test_no_access_hash_attribute` and `test_access_hash_is_none` to verify `build_entity_dict` prunes the field cleanly instead of emitting `"None"`.
- **Typo fix**: Lowercased "Ids" → "ids" in `docs/Tools-Reference.md` for consistency.

Closes #133.

Co-authored-by: Sourcery AI <ai@sourcery.ai>

## Summary by Sourcery

Добавлены регрессионные тесты для обработки `access_hash` у сущностей и скорректированы формулировки в документации для значений `id`.

Документация:
- Уточнить документацию, чтобы последовательно использовать написание полей `id` со строчной буквы.

Тесты:
- Добавить тесты, проверяющие, что у сущностей с отсутствующим или равным `None` `access_hash` это поле опускается в сериализованном словаре, а не записывается как строковое представление `None`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add regression tests for entity access_hash handling and adjust documentation wording for id values.

Documentation:
- Clarify documentation to consistently refer to id fields with lowercase wording.

Tests:
- Add tests ensuring entities with missing or None access_hash omit the field from the serialized dict rather than emitting a stringified None.

</details>

Документация:
- Уточнена формулировка в разделе инструментов: слово «Ids» приведено к нижнему регистру («ids») для консистентности в документации по полям `id`.

Тесты:
- Добавлены тесты, проверяющие, что `build_entity_dict` опускает поле `access_hash`, когда оно отсутствует или установлено в `None`, вместо сериализации его в строку.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавлены регрессионные тесты для обработки `access_hash` у сущностей и скорректированы формулировки в документации для значений `id`.

Документация:
- Уточнить документацию, чтобы последовательно использовать написание полей `id` со строчной буквы.

Тесты:
- Добавить тесты, проверяющие, что у сущностей с отсутствующим или равным `None` `access_hash` это поле опускается в сериализованном словаре, а не записывается как строковое представление `None`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add regression tests for entity access_hash handling and adjust documentation wording for id values.

Documentation:
- Clarify documentation to consistently refer to id fields with lowercase wording.

Tests:
- Add tests ensuring entities with missing or None access_hash omit the field from the serialized dict rather than emitting a stringified None.

</details>

</details>