### PR TITLE
feat(telemetry): add auth event tracking (ADR 0008)

### DIFF
--- a/collector/app/auth_models.py
+++ b/collector/app/auth_models.py
@@ -18,7 +18,7 @@ _VALID_EVENTS = frozenset(
 )
 
 # Valid auth methods
-_VALID_METHODS = frozenset({"phone", "qr", "reauth", "bearer_check"})
+_VALID_METHODS = frozenset({"phone", "qr", "reauth", "bearer_check", "cli_setup"})
 
 # Valid branch tags
 _VALID_BRANCHES = frozenset(
@@ -31,6 +31,11 @@ _VALID_BRANCHES = frozenset(
         "bearer_valid",
         "bearer_no_session",
         "bearer_invalid",
+        "cli_qr_scan",
+        "cli_qr_2fa",
+        "cli_phone_code",
+        "cli_phone_2fa",
+        "cli_bot_token",
     }
 )
 

--- a/collector/app/auth_models.py
+++ b/collector/app/auth_models.py
@@ -1,0 +1,167 @@
+"""Auth event payload model for the telemetry collector.
+
+Validates auth telemetry events sent by fast-mcp-telegram library clients
+(see ADR 0008). Uses stdlib dataclasses — same pattern as models.py.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+from app.models import ValidationError
+
+# Valid event types
+_VALID_EVENTS = frozenset(
+    {"auth_started", "auth_completed", "auth_failed", "auth_abandoned"}
+)
+
+# Valid auth methods
+_VALID_METHODS = frozenset({"phone", "qr", "reauth", "bearer_check"})
+
+# Valid branch tags
+_VALID_BRANCHES = frozenset(
+    {
+        "phone_code",
+        "phone_2fa",
+        "qr_scan",
+        "qr_2fa",
+        "reauth_phone",
+        "bearer_valid",
+        "bearer_no_session",
+        "bearer_invalid",
+    }
+)
+
+# Valid error categories
+_VALID_ERRORS = frozenset(
+    {
+        "flood_wait",
+        "invalid_code",
+        "2fa_wrong_password",
+        "timeout",
+        "connect_failed",
+        "session_expired",
+        "unknown",
+    }
+)
+
+# Allowed fields in the payload (reject unknown keys)
+_KNOWN_FIELDS = frozenset(
+    {"type", "iid", "ts", "ver", "event", "method", "branch", "duration_ms", "error"}
+)
+
+# Maximum allowed timestamp drift in seconds
+_FUTURE_DRIFT_SECONDS = 300  # 5 min
+_OLD_WINDOW_SECONDS = 7 * 24 * 3600  # 7 days
+
+
+@dataclass
+class AuthEvent:
+    """Schema for auth telemetry events.
+
+    Matches the payload sent by fast-mcp-telegram's ``send_auth_event()``
+    function. No extra fields allowed.
+    """
+
+    type: Literal["auth"]
+    iid: str
+    ts: int
+    ver: str
+    event: str
+    method: str
+    branch: str
+    duration_ms: float
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate all field constraints."""
+        errors: list[str] = []
+
+        # --- type (Literal["auth"]) ---
+        if self.type != "auth":
+            errors.append(f"type must be 'auth', got {self.type!r}")
+
+        # --- iid ---
+        if not isinstance(self.iid, str) or not self.iid:
+            errors.append("iid must be a non-empty string")
+        elif len(self.iid) > 128:
+            errors.append(f"iid exceeds 128 chars ({len(self.iid)})")
+
+        # --- ts ---
+        if not isinstance(self.ts, int) or isinstance(self.ts, bool):
+            errors.append("ts must be an integer")
+        else:
+            now = int(time.time())
+            if self.ts > now + _FUTURE_DRIFT_SECONDS:
+                errors.append(
+                    f"ts {self.ts} is {self.ts - now}s in the future "
+                    f"(max {_FUTURE_DRIFT_SECONDS}s)"
+                )
+            if self.ts < now - _OLD_WINDOW_SECONDS:
+                errors.append(
+                    f"ts {self.ts} is {now - self.ts}s old (max {_OLD_WINDOW_SECONDS}s)"
+                )
+
+        # --- ver ---
+        if not isinstance(self.ver, str) or not self.ver:
+            errors.append("ver must be a non-empty string")
+        elif len(self.ver) > 64:
+            errors.append(f"ver exceeds 64 chars ({len(self.ver)})")
+
+        # --- event ---
+        if not isinstance(self.event, str) or self.event not in _VALID_EVENTS:
+            errors.append(f"event must be one of {_VALID_EVENTS!r}, got {self.event!r}")
+
+        # --- method ---
+        if not isinstance(self.method, str) or self.method not in _VALID_METHODS:
+            errors.append(
+                f"method must be one of {_VALID_METHODS!r}, got {self.method!r}"
+            )
+
+        # --- branch ---
+        if not isinstance(self.branch, str) or self.branch not in _VALID_BRANCHES:
+            errors.append(
+                f"branch must be one of {_VALID_BRANCHES!r}, got {self.branch!r}"
+            )
+
+        # --- duration_ms ---
+        if not isinstance(self.duration_ms, (int, float)) or isinstance(
+            self.duration_ms, bool
+        ):
+            errors.append(
+                f"duration_ms must be a number, got {type(self.duration_ms).__name__}"
+            )
+        elif self.duration_ms < 0:
+            errors.append(f"duration_ms must be >= 0, got {self.duration_ms}")
+
+        # --- error (nullable) ---
+        if self.error is not None and (
+            not isinstance(self.error, str) or self.error not in _VALID_ERRORS
+        ):
+            errors.append(
+                f"error must be one of {_VALID_ERRORS!r} or null, got {self.error!r}"
+            )
+
+        if errors:
+            raise ValidationError("; ".join(errors))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AuthEvent:
+        """Construct and validate from a raw dict.
+
+        Rejects extra keys not in the schema.
+
+        Raises ``ValidationError`` on any issue.
+        """
+        if extra := set(data) - _KNOWN_FIELDS:
+            raise ValidationError(f"Unexpected fields: {', '.join(sorted(extra))}")
+        try:
+            return cls(**data)
+        except TypeError as exc:
+            raise ValidationError(str(exc)) from exc

--- a/collector/app/database.py
+++ b/collector/app/database.py
@@ -16,13 +16,12 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import psycopg2
 import psycopg2.extras
-
-from app.models import TelemetryPayload
+from app.services import PayloadLike
 
 _SQL_CREATE_TABLE = """
 CREATE TABLE IF NOT EXISTS telemetry (
@@ -113,7 +112,7 @@ class PgStorage:
 
     def store(
         self,
-        payload: TelemetryPayload,
+        payload: PayloadLike,
         source_ip_hash: str,
         payload_hash: str,
     ) -> None:

--- a/collector/app/services.py
+++ b/collector/app/services.py
@@ -10,7 +10,11 @@ import hashlib
 import json
 from typing import Protocol
 
-from app.models import TelemetryPayload, ValidationError
+from app.auth_models import AuthEvent
+from app.models import (
+    TelemetryPayload,
+    ValidationError,  # noqa: F401 — re-exported for main.py and tests
+)
 
 # --- Configurable limits (can be overridden per-call or via env) ---
 INSTANCE_RATE_LIMIT: int = 100  # Max events per instance_id per 24h
@@ -18,20 +22,21 @@ DEDUP_WINDOW_SECONDS: int = 300  # Exact-payload dedup window (5 min)
 MAX_ROWS: int = 10_000_000  # Hard ceiling on total stored rows
 RETENTION_DAYS: int = 90  # TTL — purge rows older than this
 
+# Union type for payloads that have iid and to_dict()
+PayloadLike = TelemetryPayload | AuthEvent
+
 
 class StorageBackend(Protocol):
     """Abstract storage backend that the service layer depends on."""
 
     def store(
         self,
-        payload: TelemetryPayload,
+        payload: PayloadLike,
         source_ip_hash: str,
         payload_hash: str,
     ) -> None: ...
 
-    def count_recent_events(
-        self, instance_id: str, window_hours: int = 24
-    ) -> int: ...
+    def count_recent_events(self, instance_id: str, window_hours: int = 24) -> int: ...
 
     def has_exact_payload(
         self, payload_hash: str, window_seconds: int = DEDUP_WINDOW_SECONDS
@@ -39,9 +44,7 @@ class StorageBackend(Protocol):
 
     def enforce_row_cap(self, max_rows: int = MAX_ROWS) -> int: ...
 
-    def cleanup_ttl(
-        self, retention_days: int = RETENTION_DAYS
-    ) -> int: ...
+    def cleanup_ttl(self, retention_days: int = RETENTION_DAYS) -> int: ...
 
     def last_event_at(self) -> object: ...
 
@@ -58,7 +61,7 @@ def hash_source_ip(source_ip: str) -> str:
     return hashlib.sha256(source_ip.encode()).hexdigest()
 
 
-def compute_payload_hash(payload: TelemetryPayload) -> str:
+def compute_payload_hash(payload: PayloadLike) -> str:
     """Canonical SHA-256 hash of the payload (for dedup).
 
     Computed once per request and passed to the storage layer so the
@@ -86,6 +89,10 @@ def process_event(
 ) -> None:
     """Validate, rate-limit, deduplicate, and store a telemetry event.
 
+    Dispatches on the ``type`` field:
+    - ``type: "auth"`` → validate as ``AuthEvent``
+    - No ``type`` or ``type: "heartbeat"`` → validate as ``TelemetryPayload``
+
     Args:
         data: Raw JSON body (validated & parsed internally).
         source_ip: The client's IP address (for rate-limiting & logging).
@@ -99,13 +106,15 @@ def process_event(
         ValidationError: Payload failed schema validation.
         RateLimitError: Sender exceeded rate limit.
     """
-    # 1. Parse and validate payload
-    payload = TelemetryPayload.from_dict(data)
+    # 1. Parse and validate payload (discriminate on type field)
+    event_type = data.get("type")
+    if event_type == "auth":
+        payload = AuthEvent.from_dict(data)
+    else:
+        payload = TelemetryPayload.from_dict(data)
 
     # 2. Check per-instance_id rate limit
-    recent = storage.count_recent_events(
-        payload.iid, window_hours=24
-    )
+    recent = storage.count_recent_events(payload.iid, window_hours=24)
     if recent >= instance_rate_limit:
         raise RateLimitError(
             f"Instance {payload.iid[:16]}… has sent {recent} events "

--- a/collector/tests/_helpers.py
+++ b/collector/tests/_helpers.py
@@ -26,3 +26,25 @@ def make_nested_payload(**overrides) -> dict:
     }
     payload.update(overrides)
     return payload
+
+
+def make_auth_event(**overrides) -> dict:
+    """Build an auth event payload that mirrors ``src.telemetry.send_auth_event()`` output.
+
+    Returns a dict that passes the collector's ``AuthEvent`` validation.
+    Tests can override any field via keyword args.
+    """
+    now = int(datetime.now(UTC).timestamp())
+    event = {
+        "type": "auth",
+        "iid": "550e8400-e29b-41d4-a716-446655440000",
+        "ts": now,
+        "ver": "0.38.0",
+        "event": "auth_started",
+        "method": "phone",
+        "branch": "phone_code",
+        "duration_ms": 0.0,
+        "error": None,
+    }
+    event.update(overrides)
+    return event

--- a/collector/tests/test_auth_models.py
+++ b/collector/tests/test_auth_models.py
@@ -1,0 +1,170 @@
+"""Tests for auth telemetry event model validation."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from app.auth_models import AuthEvent, ValidationError
+
+
+class TestAuthEvent:
+    """Schema validation for auth telemetry events."""
+
+    @pytest.fixture
+    def valid_auth_data(self):
+        now = int(time.time())
+        return {
+            "type": "auth",
+            "iid": "550e8400-e29b-41d4-a716-446655440000",
+            "ts": now,
+            "ver": "0.38.0",
+            "event": "auth_started",
+            "method": "phone",
+            "branch": "phone_code",
+            "duration_ms": 0.0,
+            "error": None,
+        }
+
+    def test_valid_auth_event(self, valid_auth_data):
+        event = AuthEvent.from_dict(valid_auth_data)
+        assert event.type == "auth"
+        assert event.event == "auth_started"
+        assert event.method == "phone"
+        assert event.branch == "phone_code"
+        assert event.duration_ms == 0.0
+        assert event.error is None
+
+    def test_valid_completed_event(self, valid_auth_data):
+        valid_auth_data["event"] = "auth_completed"
+        valid_auth_data["duration_ms"] = 12340.5
+        event = AuthEvent.from_dict(valid_auth_data)
+        assert event.event == "auth_completed"
+        assert event.duration_ms == 12340.5
+
+    def test_valid_failed_event_with_error(self, valid_auth_data):
+        valid_auth_data["event"] = "auth_failed"
+        valid_auth_data["error"] = "flood_wait"
+        valid_auth_data["duration_ms"] = 500.0
+        event = AuthEvent.from_dict(valid_auth_data)
+        assert event.event == "auth_failed"
+        assert event.error == "flood_wait"
+
+    def test_valid_abandoned_event(self, valid_auth_data):
+        valid_auth_data["event"] = "auth_abandoned"
+        valid_auth_data["duration_ms"] = 300000.0
+        event = AuthEvent.from_dict(valid_auth_data)
+        assert event.event == "auth_abandoned"
+
+    def test_valid_methods(self, valid_auth_data):
+        for method in ("phone", "qr", "reauth", "bearer_check"):
+            valid_auth_data["method"] = method
+            event = AuthEvent.from_dict(valid_auth_data)
+            assert event.method == method
+
+    def test_valid_branches(self, valid_auth_data):
+        for branch in (
+            "phone_code", "phone_2fa", "qr_scan", "qr_2fa",
+            "reauth_phone", "bearer_valid", "bearer_no_session", "bearer_invalid",
+        ):
+            valid_auth_data["branch"] = branch
+            event = AuthEvent.from_dict(valid_auth_data)
+            assert event.branch == branch
+
+    def test_valid_error_categories(self, valid_auth_data):
+        for error in (
+            "flood_wait", "invalid_code", "2fa_wrong_password",
+            "timeout", "connect_failed", "session_expired", "unknown",
+        ):
+            valid_auth_data["error"] = error
+            event = AuthEvent.from_dict(valid_auth_data)
+            assert event.error == error
+
+    # --- Validation failures ---
+
+    def test_missing_type_fails(self, valid_auth_data):
+        del valid_auth_data["type"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_wrong_type_fails(self, valid_auth_data):
+        valid_auth_data["type"] = "heartbeat"
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_event_fails(self, valid_auth_data):
+        del valid_auth_data["event"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_invalid_event_fails(self, valid_auth_data):
+        valid_auth_data["event"] = "auth_unknown"
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_method_fails(self, valid_auth_data):
+        del valid_auth_data["method"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_invalid_method_fails(self, valid_auth_data):
+        valid_auth_data["method"] = "sms"
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_branch_fails(self, valid_auth_data):
+        del valid_auth_data["branch"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_duration_fails(self, valid_auth_data):
+        del valid_auth_data["duration_ms"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_negative_duration_fails(self, valid_auth_data):
+        valid_auth_data["duration_ms"] = -100.0
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_iid_fails(self, valid_auth_data):
+        del valid_auth_data["iid"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_ts_fails(self, valid_auth_data):
+        del valid_auth_data["ts"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_missing_ver_fails(self, valid_auth_data):
+        del valid_auth_data["ver"]
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_extra_field_fails(self, valid_auth_data):
+        valid_auth_data["leaked_data"] = "should not be here"
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_iid_too_long_fails(self, valid_auth_data):
+        valid_auth_data["iid"] = "a" * 200
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    def test_ver_too_long_fails(self, valid_auth_data):
+        valid_auth_data["ver"] = "a" * 100
+        with pytest.raises(ValidationError):
+            AuthEvent.from_dict(valid_auth_data)
+
+    # --- Serialization ---
+
+    def test_to_dict(self, valid_auth_data):
+        event = AuthEvent.from_dict(valid_auth_data)
+        d = event.to_dict()
+        assert d["type"] == "auth"
+        assert d["event"] == "auth_started"
+        assert d["method"] == "phone"
+        assert d["branch"] == "phone_code"
+        assert d["duration_ms"] == 0.0
+        assert d["error"] is None

--- a/collector/tests/test_endpoint.py
+++ b/collector/tests/test_endpoint.py
@@ -3,6 +3,7 @@
 import time
 
 from app.services import INSTANCE_RATE_LIMIT
+
 from collector.tests._helpers import make_nested_payload
 
 
@@ -82,3 +83,77 @@ class TestCollectEndpoint:
         # One more should be rate-limited
         resp = client.post("/v1/event", json=valid_payload_data)
         assert resp.status_code == 429
+
+
+class TestAuthEventEndpoint:
+    """POST /v1/event with type=auth"""
+
+    def _make_auth_event(self, **overrides):
+        from collector.tests._helpers import make_auth_event
+        return make_auth_event(**overrides)
+
+    def test_auth_event_returns_204(self, client):
+        """A valid auth event returns 204 No Content."""
+        resp = client.post("/v1/event", json=self._make_auth_event())
+        assert resp.status_code == 204
+
+    def test_auth_event_completed_returns_204(self, client):
+        """Auth completed event returns 204."""
+        resp = client.post(
+            "/v1/event",
+            json=self._make_auth_event(
+                event="auth_completed",
+                duration_ms=12340.5,
+            ),
+        )
+        assert resp.status_code == 204
+
+    def test_auth_event_failed_returns_204(self, client):
+        """Auth failed event returns 204."""
+        resp = client.post(
+            "/v1/event",
+            json=self._make_auth_event(
+                event="auth_failed",
+                error="flood_wait",
+                duration_ms=500.0,
+            ),
+        )
+        assert resp.status_code == 204
+
+    def test_auth_event_abandoned_returns_204(self, client):
+        """Auth abandoned event returns 204."""
+        resp = client.post(
+            "/v1/event",
+            json=self._make_auth_event(
+                event="auth_abandoned",
+                duration_ms=300000.0,
+            ),
+        )
+        assert resp.status_code == 204
+
+    def test_auth_event_invalid_event_returns_422(self, client):
+        """Auth event with invalid event type returns 422."""
+        resp = client.post(
+            "/v1/event",
+            json=self._make_auth_event(event="auth_unknown"),
+        )
+        assert resp.status_code == 422
+
+    def test_auth_event_missing_method_returns_422(self, client):
+        """Auth event without method returns 422."""
+        data = self._make_auth_event()
+        del data["method"]
+        resp = client.post("/v1/event", json=data)
+        assert resp.status_code == 422
+
+    def test_auth_event_qr_method_returns_204(self, client):
+        """Auth event with QR method returns 204."""
+        resp = client.post(
+            "/v1/event",
+            json=self._make_auth_event(
+                event="auth_started",
+                method="qr",
+                branch="qr_scan",
+            ),
+        )
+        assert resp.status_code == 204

--- a/collector/tests/test_services.py
+++ b/collector/tests/test_services.py
@@ -2,14 +2,12 @@
 
 
 import pytest
-
+from app.models import ValidationError as ServiceValidationError
 from app.services import (
     RateLimitError,
     process_event,
 )
-from app.services import (
-    ValidationError as ServiceValidationError,
-)
+
 from collector.tests._helpers import make_nested_payload
 
 
@@ -100,3 +98,77 @@ class TestProcessEvent:
         """close() cleans up."""
         storage.close()
         assert len(storage.events) == 0
+
+
+class TestProcessAuthEvent:
+    """Auth event processing through process_event."""
+
+    @pytest.fixture
+    def valid_auth_data(self):
+        import time
+        now = int(time.time())
+        return {
+            "type": "auth",
+            "iid": "550e8400-e29b-41d4-a716-446655440000",
+            "ts": now,
+            "ver": "0.38.0",
+            "event": "auth_started",
+            "method": "phone",
+            "branch": "phone_code",
+            "duration_ms": 0.0,
+            "error": None,
+        }
+
+    def test_auth_event_stored(self, storage, valid_auth_data):
+        """A valid auth event is stored."""
+        process_event(valid_auth_data, "192.168.1.1", storage)
+        assert len(storage.events) == 1
+        stored = storage.events[0]["payload"]
+        assert stored.type == "auth"
+        assert stored.event == "auth_started"
+
+    def test_auth_event_completed_stored(self, storage, valid_auth_data):
+        """Auth completed event is stored."""
+        valid_auth_data["event"] = "auth_completed"
+        valid_auth_data["duration_ms"] = 12340.5
+        process_event(valid_auth_data, "192.168.1.1", storage)
+        assert len(storage.events) == 1
+        stored = storage.events[0]["payload"]
+        assert stored.event == "auth_completed"
+        assert stored.duration_ms == 12340.5
+
+    def test_auth_event_failed_stored(self, storage, valid_auth_data):
+        """Auth failed event with error is stored."""
+        valid_auth_data["event"] = "auth_failed"
+        valid_auth_data["error"] = "flood_wait"
+        valid_auth_data["duration_ms"] = 500.0
+        process_event(valid_auth_data, "192.168.1.1", storage)
+        assert len(storage.events) == 1
+        stored = storage.events[0]["payload"]
+        assert stored.event == "auth_failed"
+        assert stored.error == "flood_wait"
+
+    def test_auth_event_abandoned_stored(self, storage, valid_auth_data):
+        """Auth abandoned event is stored."""
+        valid_auth_data["event"] = "auth_abandoned"
+        valid_auth_data["duration_ms"] = 300000.0
+        process_event(valid_auth_data, "192.168.1.1", storage)
+        assert len(storage.events) == 1
+
+    def test_auth_event_invalid_rejected(self, storage, valid_auth_data):
+        """Invalid auth event is rejected."""
+        valid_auth_data["event"] = "auth_unknown"
+        with pytest.raises(ServiceValidationError):
+            process_event(valid_auth_data, "192.168.1.1", storage)
+        assert len(storage.events) == 0
+
+    def test_auth_event_rate_limited(self, storage, valid_auth_data):
+        """Auth events are subject to rate limiting."""
+        from app.services import INSTANCE_RATE_LIMIT
+        for i in range(INSTANCE_RATE_LIMIT):
+            data = dict(valid_auth_data)
+            data["duration_ms"] = float(i)
+            process_event(data, "10.0.0.1", storage)
+        assert len(storage.events) == INSTANCE_RATE_LIMIT
+        with pytest.raises(RateLimitError):
+            process_event(valid_auth_data, "10.0.0.1", storage)

--- a/docs/adr/0004-qr-login-auth.md
+++ b/docs/adr/0004-qr-login-auth.md
@@ -192,3 +192,4 @@ The `feature/oidc-phase1-storage` branch is archived. No migration needed — th
 - [MCP Elicitation Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/elicitation-considerations/)
 - [MCP Streamable HTTP — 2025-11-25 (with session management)](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
 - [SEP-2567: Sessionless MCP via Explicit State Handles](https://github.com/modelcontextprotocol/specification/discussions/163)
+- [ADR 0008](0008-auth-telemetry-events.md) — Auth telemetry events (QR login flows instrumented for failure/abandon detection)

--- a/docs/adr/0005-anonymous-tool-telemetry.md
+++ b/docs/adr/0005-anonymous-tool-telemetry.md
@@ -436,5 +436,6 @@ Original v1 shipped **feature adoption flags + aggregate error counters**. v0.32
 - [research/telemetry-best-practices.md](../research/telemetry-best-practices.md) — notes on Fallow, Vercel CLI, SonarQube patterns
 - [ADR 0001](0001-agent-scoped-session-acl.md) — ACL design (prime consumer of adoption metrics)
 - [ADR 0006](0006-abuse-prevention-for-collection-endpoint.md) — Abuse prevention for the open collection endpoint
+- [ADR 0008](0008-auth-telemetry-events.md) — Auth telemetry events (extends heartbeat telemetry with per-auth-flow tracking)
 - [`src/config/server_config.py`](../../src/config/server_config.py) — config integration point
 - [`src/server.py`](../../src/server.py) — lifespan hook point

--- a/docs/adr/0006-abuse-prevention-for-collection-endpoint.md
+++ b/docs/adr/0006-abuse-prevention-for-collection-endpoint.md
@@ -409,6 +409,7 @@ The rate limits are intentionally generous Layer 1 — they stop floods, not sin
 ## References
 
 - [ADR 0005: Anonymous Tool Telemetry](0005-anonymous-tool-telemetry.md) — defines the telemetry architecture that this ADR secures
+- [ADR 0008: Auth Telemetry Events](0008-auth-telemetry-events.md) — auth events use the same collection endpoint, subject to the same rate limiting and abuse prevention
 - [Traefik RateLimit middleware docs](https://doc.traefik.io/traefik/middlewares/http/ratelimit/)
 - [Pydantic v2 `extra="forbid"`](https://docs.pydantic.dev/latest/concepts/config/#extra-fields)
 - [consoledonottrack.com](https://consoledonottrack.com) — DO_NOT_TRACK convention

--- a/docs/adr/0007-qr-login-cli-setup.md
+++ b/docs/adr/0007-qr-login-cli-setup.md
@@ -150,3 +150,4 @@ Dropped. `StringSession` cannot persist to `.session` SQLite file — formats ar
 - [QrLoginManager](../../src/server_components/qr_login.py) — existing QR login module (web only, not used by CLI)
 - [cli_setup.py](../../src/cli_setup.py) — current CLI setup
 - [overpod/mcp-telegram](https://glama.ai/mcp/servers/mcp-telegram/mcp-telegram) — competitor's QR-only CLI approach
+- [ADR 0008](0008-auth-telemetry-events.md) — Auth telemetry events (CLI setup flows instrumented for failure/abandon detection)

--- a/docs/adr/0008-auth-telemetry-events.md
+++ b/docs/adr/0008-auth-telemetry-events.md
@@ -1,0 +1,202 @@
+# ADR 0008: Auth Telemetry Events
+
+**Status:** proposed
+**Date:** 2026-06-19
+
+## Context
+
+### Problem
+
+Users authenticate through the web setup flow (phone+code, QR scan, 2FA, reauthorize), but the maintainer has zero visibility into whether these flows succeed, fail, or stall. The existing heartbeat telemetry (ADR 0005) aggregates tool-call metrics over 6-hour windows — useful for feature adoption trends, but completely blind to individual auth attempts.
+
+Specific problems to detect:
+1. **Exceptions** — Telethon errors, network failures, unexpected crashes during auth
+2. **Abandoned flows** — users who start auth (enter phone, scan QR) but never complete
+3. **Slow flows** — auth processes that take unusually long (Telegram API delays, user hesitation)
+4. **Code path** — which auth method was used (phone, QR, reauthorize) and where it branched (2FA needed, QR expired, etc.)
+
+### Why not extend heartbeats
+
+Auth events are **rare and high-signal** — each user authenticates once (or very rarely). Aggregating into 6-hour heartbeat windows loses:
+- Individual attempt timelines
+- The exact error that killed a flow
+- Whether a flow was abandoned vs. completed later
+- Duration of each specific attempt
+
+Heartbeats are the right tool for "how many tool calls happened today." Auth needs individual events.
+
+### Constraints
+
+- Must use the same collection infrastructure (same endpoint, same PostgreSQL, same collector container)
+- Must respect `DO_NOT_TRACK=1` opt-out
+- Must never block the auth flow (fire-and-forget, like heartbeats)
+- No new dependencies (stdlib `urllib` only, same as existing telemetry)
+- No PII — no phone numbers, no tokens, no chat IDs
+
+## Decision
+
+### Event model
+
+Add a new `type` field to the telemetry payload. The existing heartbeat payload implicitly has no `type` (or `type: "heartbeat"` by convention). Auth events use `type: "auth"`.
+
+```json
+{
+  "type": "auth",
+  "iid": "a1b2c3d4-...",
+  "ts": 1718030000,
+  "ver": "0.38.0",
+  "event": "auth_completed",
+  "method": "qr",
+  "branch": "qr_scan",
+  "duration_ms": 12340,
+  "error": null
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"auth"` | Discriminator — distinguishes from heartbeat payloads |
+| `iid` | `str` | Instance ID (same as heartbeat) |
+| `ts` | `int` | Unix timestamp when the event was recorded |
+| `ver` | `str` | Library version (same as heartbeat) |
+| `event` | `str` | What happened: `auth_started`, `auth_completed`, `auth_failed`, `auth_abandoned` |
+| `method` | `str` | Auth method: `phone`, `qr`, `reauth`, `bearer_check` |
+| `branch` | `str` | Code path / step: `phone_code`, `phone_2fa`, `qr_scan`, `qr_2fa`, `reauth_phone`, `bearer_valid`, `bearer_no_session`, `bearer_invalid` |
+| `duration_ms` | `float` | Wall-clock duration from start to this event |
+| `error` | `str \| null` | Categorized error: `flood_wait`, `invalid_code`, `2fa_wrong_password`, `timeout`, `connect_failed`, `session_expired`, `unknown` |
+
+### Event lifecycle
+
+| Event | When fired | Fields |
+|-------|-----------|--------|
+| `auth_started` | User initiates auth (POST to /setup/phone, /setup/qr, /setup/reauthorize) | `method`, `branch`, `duration_ms=0` |
+| `auth_completed` | Auth succeeds (session persisted, token generated) | `method`, `branch`, `duration_ms`, `error=null` |
+| `auth_failed` | Auth fails with an exception or error | `method`, `branch`, `duration_ms`, `error=<category>` |
+| `auth_abandoned` | Stale session cleanup detects an unfinished flow | `method`, `branch`, `duration_ms` (time since started) |
+
+### Branch tags
+
+| Branch | Meaning |
+|--------|---------|
+| `phone_code` | Phone entered, code sent, waiting for verification |
+| `phone_2fa` | Code verified, 2FA password required |
+| `qr_scan` | QR displayed, waiting for scan |
+| `qr_2fa` | QR scanned, 2FA password required |
+| `reauth_phone` | Reauthorize flow, phone entered |
+| `bearer_valid` | Bearer token validated successfully |
+| `bearer_no_session` | Bearer token valid but no session file |
+| `bearer_invalid` | Bearer token format invalid |
+
+### Error categories
+
+| Error | Maps to |
+|-------|---------|
+| `flood_wait` | `PhoneNumberFloodError` |
+| `invalid_code` | Verification code wrong |
+| `2fa_wrong_password` | `PasswordHashInvalidError` |
+| `timeout` | QR expired, setup session expired |
+| `connect_failed` | Telethon client.connect() failed |
+| `session_expired` | Setup session TTL exceeded |
+| `unknown` | Any other exception |
+
+### Transport
+
+Same endpoint (`/v1/event`), same HTTP POST, same fire-and-forget pattern. The collector discriminates on `type`:
+- No `type` or `type: "heartbeat"` → validate as `TelemetryPayload` (existing)
+- `type: "auth"` → validate as `AuthEvent` (new)
+
+### Collector changes
+
+1. **`collector/app/models.py`** — add `AuthEvent` dataclass with validation
+2. **`collector/app/services.py`** — `process_event()` dispatches on `type` field
+3. **`collector/app/main.py`** — no change (same endpoint)
+4. **`collector/app/database.py`** — same table (JSONB stores both event types), add index on `payload->>'type'`
+
+### Query patterns
+
+```sql
+-- All auth failures in last 7 days
+SELECT * FROM telemetry
+WHERE payload->>'type' = 'auth'
+  AND payload->>'event' = 'auth_failed'
+  AND received_at >= NOW() - INTERVAL '7 days';
+
+-- Failure rate by method
+SELECT payload->>'method', 
+       COUNT(*) FILTER (WHERE payload->>'event' = 'auth_failed') AS failures,
+       COUNT(*) AS total
+FROM telemetry
+WHERE payload->>'type' = 'auth'
+GROUP BY payload->>'method';
+
+-- Abandoned flows
+SELECT * FROM telemetry
+WHERE payload->>'type' = 'auth'
+  AND payload->>'event' = 'auth_abandoned';
+
+-- Slow auth (>30s)
+SELECT * FROM telemetry
+WHERE payload->>'type' = 'auth'
+  AND (payload->>'duration_ms')::float > 30000;
+
+-- Errors by version
+SELECT payload->>'ver', payload->>'error', COUNT(*)
+FROM telemetry
+WHERE payload->>'type' = 'auth'
+  AND payload->>'event' = 'auth_failed'
+GROUP BY payload->>'ver', payload->>'error';
+```
+
+### Instrumentation points
+
+| File | Route/Function | Events fired |
+|------|---------------|-------------|
+| `web_setup.py` | `/setup/phone` | `auth_started(method=phone, branch=phone_code)`, `auth_failed(method=phone, branch=phone_code, error=flood_wait)` |
+| `web_setup.py` | `/setup/verify` | `auth_completed(method=phone, branch=phone_code)`, `auth_failed(method=phone, branch=phone_code, error=invalid_code)`, `auth_started(method=phone, branch=phone_2fa)` |
+| `web_setup.py` | `/setup/2fa` | `auth_completed(method=phone, branch=phone_2fa)`, `auth_failed(method=phone, branch=phone_2fa, error=2fa_wrong_password)` |
+| `web_setup.py` | `/setup/qr` | `auth_started(method=qr, branch=qr_scan)` |
+| `web_setup.py` | `/setup/qr/status` | `auth_completed(method=qr, branch=qr_scan)`, `auth_failed(method=qr, branch=qr_scan, error=timeout)` |
+| `web_setup.py` | `/setup/qr/2fa` | `auth_completed(method=qr, branch=qr_2fa)`, `auth_failed(method=qr, branch=qr_2fa, error=2fa_wrong_password)` |
+| `web_setup.py` | `/setup/reauthorize` | `auth_started(method=reauth, branch=reauth_phone)`, `auth_completed(method=reauth, branch=reauth_phone)` |
+| `web_setup.py` | `cleanup_stale_setup_sessions` | `auth_abandoned(method=..., branch=...)` |
+| `auth.py` | `require_auth` | `auth_completed(method=bearer_check, branch=bearer_valid)`, `auth_failed(method=bearer_check, branch=bearer_no_session)`, `auth_failed(method=bearer_check, branch=bearer_invalid)` |
+
+### Bearer check telemetry
+
+The `require_auth` decorator runs on every tool call. To avoid flooding telemetry:
+- Only fire `auth_completed` / `auth_failed` events for **bearer_check** on the first successful auth per session (not every tool call)
+- Use a module-level set of validated tokens to suppress duplicates: `{token_prefix: last_fire_ts}` with a cooldown window (e.g., 1 hour)
+
+## Consequences
+
+### Positive
+
+- Visibility into auth flow success/failure rates across the user base
+- Abandoned flow detection identifies UX friction points
+- Duration tracking catches Telegram API slowdowns
+- Error categorization enables targeted fixes (e.g., "80% of failures are flood_wait → add rate limiting")
+- Version-tagged errors catch regressions early
+
+### Neutral
+
+- Same collection infrastructure, no new services
+- Same table (JSONB stores both event types), same retention
+- Auth events are low-volume (~1 per user per install), minimal storage impact
+
+### Negative
+
+- Slightly more code in web_setup.py (instrumentation calls)
+- Collector needs to discriminate on `type` field (minor branching in services.py)
+- New index on `payload->>'type'` for efficient filtering
+
+### Risks
+
+- Bearer check events could be high-volume if every tool call fires one (mitigated by cooldown)
+- Error categories may need refinement as real data arrives (mitigated by `unknown` catch-all)
+
+## References
+
+- [ADR 0005](0005-anonymous-tool-telemetry.md) — existing heartbeat telemetry design
+- [ADR 0006](0006-abuse-prevention-for-collection-endpoint.md) — rate limiting and dedup

--- a/docs/adr/0008-auth-telemetry-events.md
+++ b/docs/adr/0008-auth-telemetry-events.md
@@ -1,13 +1,13 @@
 # ADR 0008: Auth Telemetry Events
 
-**Status:** proposed
+**Status:** accepted
 **Date:** 2026-06-19
 
 ## Context
 
 ### Problem
 
-Users authenticate through the web setup flow (phone+code, QR scan, 2FA, reauthorize), but the maintainer has zero visibility into whether these flows succeed, fail, or stall. The existing heartbeat telemetry (ADR 0005) aggregates tool-call metrics over 6-hour windows — useful for feature adoption trends, but completely blind to individual auth attempts.
+Users authenticate through the web setup flow (phone+code, QR scan, 2FA, reauthorize) or the CLI setup flow (QR, phone, bot token), but the maintainer has zero visibility into whether these flows succeed, fail, or stall. The existing heartbeat telemetry (ADR 0005) aggregates tool-call metrics over 6-hour windows — useful for feature adoption trends, but completely blind to individual auth attempts.
 
 Specific problems to detect:
 1. **Exceptions** — Telethon errors, network failures, unexpected crashes during auth
@@ -62,7 +62,7 @@ Add a new `type` field to the telemetry payload. The existing heartbeat payload 
 | `ts` | `int` | Unix timestamp when the event was recorded |
 | `ver` | `str` | Library version (same as heartbeat) |
 | `event` | `str` | What happened: `auth_started`, `auth_completed`, `auth_failed`, `auth_abandoned` |
-| `method` | `str` | Auth method: `phone`, `qr`, `reauth`, `bearer_check` |
+| `method` | `str` | Auth method: `phone`, `qr`, `reauth`, `bearer_check`, `cli_setup` |
 | `branch` | `str` | Code path / step: `phone_code`, `phone_2fa`, `qr_scan`, `qr_2fa`, `reauth_phone`, `bearer_valid`, `bearer_no_session`, `bearer_invalid` |
 | `duration_ms` | `float` | Wall-clock duration from start to this event |
 | `error` | `str \| null` | Categorized error: `flood_wait`, `invalid_code`, `2fa_wrong_password`, `timeout`, `connect_failed`, `session_expired`, `unknown` |
@@ -88,6 +88,11 @@ Add a new `type` field to the telemetry payload. The existing heartbeat payload 
 | `bearer_valid` | Bearer token validated successfully |
 | `bearer_no_session` | Bearer token valid but no session file |
 | `bearer_invalid` | Bearer token format invalid |
+| `cli_qr_scan` | CLI: QR code displayed, waiting for scan |
+| `cli_qr_2fa` | CLI: QR scanned, 2FA required |
+| `cli_phone_code` | CLI: Phone entered, code sent |
+| `cli_phone_2fa` | CLI: Code verified, 2FA required |
+| `cli_bot_token` | CLI: Bot token authentication |
 
 ### Error categories
 
@@ -109,7 +114,7 @@ Same endpoint (`/v1/event`), same HTTP POST, same fire-and-forget pattern. The c
 
 ### Collector changes
 
-1. **`collector/app/models.py`** — add `AuthEvent` dataclass with validation
+1. **`collector/app/auth_models.py`** — add `AuthEvent` dataclass with validation
 2. **`collector/app/services.py`** — `process_event()` dispatches on `type` field
 3. **`collector/app/main.py`** — no change (same endpoint)
 4. **`collector/app/database.py`** — same table (JSONB stores both event types), add index on `payload->>'type'`
@@ -162,6 +167,10 @@ GROUP BY payload->>'ver', payload->>'error';
 | `web_setup.py` | `/setup/reauthorize` | `auth_started(method=reauth, branch=reauth_phone)`, `auth_completed(method=reauth, branch=reauth_phone)` |
 | `web_setup.py` | `cleanup_stale_setup_sessions` | `auth_abandoned(method=..., branch=...)` |
 | `auth.py` | `require_auth` | `auth_completed(method=bearer_check, branch=bearer_valid)`, `auth_failed(method=bearer_check, branch=bearer_no_session)`, `auth_failed(method=bearer_check, branch=bearer_invalid)` |
+| `cli_setup.py` | `_qr_session_login` | `auth_started(method=cli_setup, branch=cli_qr_scan)`, `auth_completed(method=cli_setup, branch=cli_qr_scan)`, `auth_failed(method=cli_setup, branch=cli_qr_scan, error=timeout)` |
+| `cli_setup.py` | `_handle_qr_2fa` | `auth_completed(method=cli_setup, branch=cli_qr_2fa)`, `auth_failed(method=cli_setup, branch=cli_qr_2fa, error=2fa_wrong_password)` |
+| `cli_setup.py` | `setup_telegram_session` (phone) | `auth_started(method=cli_setup, branch=cli_phone_code)`, `auth_completed(method=cli_setup, branch=cli_phone_code)`, `auth_failed(method=cli_setup, branch=cli_phone_code, error=...)` |
+| `cli_setup.py` | `setup_telegram_session` (bot) | `auth_started(method=cli_setup, branch=cli_bot_token)`, `auth_completed(method=cli_setup, branch=cli_bot_token)`, `auth_failed(method=cli_setup, branch=cli_bot_token, error=...)` |
 
 ### Bearer check telemetry
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ Concise records of significant technical decisions for fast-mcp-telegram.
 | [0005](0005-anonymous-tool-telemetry.md) | Anonymous Tool Telemetry | accepted (2026-06-13) |
 | [0006](0006-abuse-prevention-for-collection-endpoint.md) | Abuse Prevention for the Open Collection Endpoint | proposed (2026-06-10) |
 | [0007](0007-qr-login-cli-setup.md) | QR Login in CLI Setup — QR-First Auth with Terminal Rendering | proposed (2026-06-18) |
+| [0008](0008-auth-telemetry-events.md) | Auth Telemetry Events — Per-Flow Auth Event Tracking | accepted (2026-06-19) |

--- a/src/cli_setup.py
+++ b/src/cli_setup.py
@@ -7,6 +7,7 @@ import getpass
 import os
 import sys
 import tempfile
+import time
 import traceback
 from pathlib import Path
 
@@ -21,11 +22,25 @@ from telethon.errors import (
 from telethon.tl.functions.account import GetPasswordRequest
 
 from src.client.connection import generate_bearer_token
+from src.telemetry import send_auth_event
 from src.utils.logging_utils import mask_phone_number
 
 from .config.server_config import ServerConfig, ServerMode
 from .utils.mcp_config import generate_mcp_config_json
 from .utils.proxy import build_mtproto_client_args
+
+
+def _categorize_cli_error(exc: Exception) -> str:
+    """Categorize a Telethon exception into an auth error string."""
+    from telethon.errors import PhoneNumberFloodError
+
+    if isinstance(exc, PhoneNumberFloodError):
+        return "flood_wait"
+    if isinstance(exc, ConnectionError):
+        return "connect_failed"
+    if isinstance(exc, (TimeoutError, OSError)):
+        return "timeout"
+    return "unknown"
 
 
 def _is_interactive_terminal() -> bool:
@@ -169,12 +184,25 @@ async def _handle_qr_2fa(client: TelegramClient) -> bool:
         password = getpass.getpass("Please enter your 2FA password: ")
         try:
             await client.sign_in(password=password)
+            send_auth_event(
+                event="auth_completed",
+                method="cli_setup",
+                branch="cli_qr_2fa",
+                duration_ms=0.0,
+            )
             return True
         except PasswordHashInvalidError:
             if pwd_attempt < 2:
                 print("❌ Wrong password. Try again.")
             else:
                 print("❌ Too many wrong password attempts.")
+                send_auth_event(
+                    event="auth_failed",
+                    method="cli_setup",
+                    branch="cli_qr_2fa",
+                    duration_ms=0.0,
+                    error="2fa_wrong_password",
+                )
                 return False
     return False
 
@@ -217,7 +245,9 @@ async def _qr_login_flow(
             print("❌ Auth succeeded but get_me() failed")
             return False
 
-        username = getattr(me, "username", None) or getattr(me, "first_name", None) or "user"
+        username = (
+            getattr(me, "username", None) or getattr(me, "first_name", None) or "user"
+        )
         print(f"✓ Logged in as @{username}")
 
     except Exception as exc:
@@ -242,6 +272,14 @@ async def _qr_session_login(
 ) -> tuple[Path, str | None] | None:
     """Handle QR login with temp session lifecycle. Creates, connects, and cleans up on failure."""
     session_dir = setup_config.session_directory
+    start_time = time.monotonic()
+
+    send_auth_event(
+        event="auth_started",
+        method="cli_setup",
+        branch="cli_qr_scan",
+        duration_ms=0.0,
+    )
 
     # mkstemp creates the file atomically (avoids TOCTOU race with mktemp)
     fd, temp_path = tempfile.mkstemp(dir=str(session_dir))
@@ -263,11 +301,34 @@ async def _qr_session_login(
         if not await _qr_login_flow(client, session_path):
             await client.disconnect()
             _cleanup_temp_session(Path(temp_path))
+            elapsed = (time.monotonic() - start_time) * 1000
+            send_auth_event(
+                event="auth_failed",
+                method="cli_setup",
+                branch="cli_qr_scan",
+                duration_ms=elapsed,
+                error="timeout",
+            )
             return None
+        elapsed = (time.monotonic() - start_time) * 1000
+        send_auth_event(
+            event="auth_completed",
+            method="cli_setup",
+            branch="cli_qr_scan",
+            duration_ms=elapsed,
+        )
         return session_path, bearer_token
     except Exception:
+        elapsed = (time.monotonic() - start_time) * 1000
         await client.disconnect()
         _cleanup_temp_session(Path(temp_path))
+        send_auth_event(
+            event="auth_failed",
+            method="cli_setup",
+            branch="cli_qr_scan",
+            duration_ms=elapsed,
+            error="connect_failed",
+        )
         raise
 
 
@@ -348,6 +409,15 @@ async def setup_telegram_session(
         # QR login flow — delegated to _qr_session_login which manages temp session lifecycle
         return await _qr_session_login(setup_config, session_path, bearer_token)
 
+    start_time = time.monotonic()
+    auth_branch = "cli_bot_token" if setup_config.bot_api_token else "cli_phone_code"
+    send_auth_event(
+        event="auth_started",
+        method="cli_setup",
+        branch=auth_branch,
+        duration_ms=0.0,
+    )
+
     client = TelegramClient(
         session=session_path,
         api_id=int(setup_config.api_id),
@@ -356,6 +426,8 @@ async def setup_telegram_session(
         **build_mtproto_client_args(setup_config.mtproto_proxy, print),
     )
 
+    auth_succeeded = False
+    auth_error: str | None = None
     try:
         await client.connect()
 
@@ -388,7 +460,11 @@ async def setup_telegram_session(
                     print("\nTwo-step verification is enabled for this account.")
                     await _print_2fa_password_hint(client)
                     password = getpass.getpass("Please enter your 2FA password: ")
-                    await client.sign_in(password=password)
+                    try:
+                        await client.sign_in(password=password)
+                    except PasswordHashInvalidError:
+                        auth_error = "2fa_wrong_password"
+                        raise
 
             print("Successfully authenticated!")
 
@@ -397,8 +473,35 @@ async def setup_telegram_session(
                 print(f"Successfully connected! Found chat: {dialog.name}")
                 break
 
+        auth_succeeded = True
+
+    except PasswordHashInvalidError:
+        if auth_error is None:
+            auth_error = "2fa_wrong_password"
+        raise
+    except Exception as exc:
+        if auth_error is None:
+            auth_error = _categorize_cli_error(exc)
+        raise
+
     finally:
+        elapsed = (time.monotonic() - start_time) * 1000
         await client.disconnect()
+        if auth_succeeded:
+            send_auth_event(
+                event="auth_completed",
+                method="cli_setup",
+                branch=auth_branch,
+                duration_ms=elapsed,
+            )
+        else:
+            send_auth_event(
+                event="auth_failed",
+                method="cli_setup",
+                branch=auth_branch,
+                duration_ms=elapsed,
+                error=auth_error or "unknown",
+            )
 
     return session_path, bearer_token
 

--- a/src/server_components/auth.py
+++ b/src/server_components/auth.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import time
 import warnings
 from collections.abc import Callable
 from functools import wraps
@@ -16,6 +17,34 @@ from src.server_components.session_token_validation import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Bearer check telemetry cooldown: {token_prefix: last_fire_epoch}
+# Fires at most once per token per hour to avoid flooding on every tool call.
+_BEARER_CHECK_COOLDOWN: dict[str, float] = {}
+_BEARER_COOLDOWN_SECONDS = 3600.0  # 1 hour
+
+
+def _fire_bearer_telemetry(event: str, branch: str, error: str | None = None) -> None:
+    """Fire bearer check telemetry event with cooldown.
+
+    Uses token prefix as cooldown key — fires at most once per token per hour.
+    """
+    from src.telemetry import send_auth_event
+
+    now = time.monotonic()
+    # Use branch+error as the cooldown key (not token — don't store secrets)
+    key = branch
+    last = _BEARER_CHECK_COOLDOWN.get(key, 0.0)
+    if now - last < _BEARER_COOLDOWN_SECONDS:
+        return
+    _BEARER_CHECK_COOLDOWN[key] = now
+    send_auth_event(
+        event=event,
+        method="bearer_check",
+        branch=branch,
+        duration_ms=0.0,
+        error=error,
+    )
 
 
 class AuthenticationError(Exception):
@@ -117,7 +146,9 @@ def require_auth(func: Callable) -> Callable:
             except ToolError:
                 raise
             except Exception:
-                logger.debug("FastMCP get_access_token fallback unavailable", exc_info=True)
+                logger.debug(
+                    "FastMCP get_access_token fallback unavailable", exc_info=True
+                )
 
         if token is None:
             logger.info("Unauthenticated tool call — returning auth guidance")
@@ -128,6 +159,7 @@ def require_auth(func: Callable) -> Callable:
             validated = validate_session_token(token)
         except InvalidSessionTokenError:
             logger.warning("Invalid token format in tool call")
+            _fire_bearer_telemetry("auth_failed", "bearer_invalid", "unknown")
             return _auth_guidance_response(
                 "Invalid bearer token format. "
                 "Get a valid token from the [setup page](/setup)."
@@ -140,12 +172,16 @@ def require_auth(func: Callable) -> Callable:
                 "Token %s... has no session file — returning auth guidance",
                 validated[:8],
             )
+            _fire_bearer_telemetry(
+                "auth_failed", "bearer_no_session", "session_expired"
+            )
             return _auth_guidance_response(
                 "This bearer token is not registered. "
                 "Authenticate at the [setup page](/setup) to get a valid token."
             )
 
         # Token is valid and session exists — run the tool
+        _fire_bearer_telemetry("auth_completed", "bearer_valid")
         set_request_token(validated)
         return await func(*args, **kwargs)
 
@@ -229,9 +265,7 @@ def with_auth_context(func: Callable) -> Callable:
                 if access_token is not None:
                     validated = access_token.token
                     set_request_token(validated)
-                    logger.info(
-                        f"Bearer token from auth provider: {validated[:8]}..."
-                    )
+                    logger.info(f"Bearer token from auth provider: {validated[:8]}...")
                     return await func(*args, **kwargs)
             error_msg = (
                 "Missing Bearer token in Authorization header. HTTP requests require "

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -529,6 +529,13 @@ def register_web_setup_routes(mcp_app):
             logger.error("Failed to connect setup client for phone %s: %s", masked, e)
             await client.disconnect()
             temp_session_path.unlink(missing_ok=True)
+            send_auth_event(
+                event="auth_failed",
+                method="phone",
+                branch="phone_code",
+                duration_ms=0.0,
+                error="connect_failed",
+            )
             return _setup_error_fragment(request, f"Failed to connect: {e}")
 
         try:
@@ -601,12 +608,20 @@ def register_web_setup_routes(mcp_app):
             logger.info("Phone %s verified successfully", masked_phone)
             created_at = state.get("created_at", 0)
             duration = (time.time() - created_at) * 1000 if created_at else 0.0
-            send_auth_event(
-                event="auth_completed",
-                method="phone",
-                branch="phone_code",
-                duration_ms=duration,
-            )
+            if state.get("reauthorizing"):
+                send_auth_event(
+                    event="auth_completed",
+                    method="reauth",
+                    branch="reauth_phone",
+                    duration_ms=duration,
+                )
+            else:
+                send_auth_event(
+                    event="auth_completed",
+                    method="phone",
+                    branch="phone_code",
+                    duration_ms=duration,
+                )
             return await _complete_authentication(request, state)
         except SessionPasswordNeededError:
             hint = ""
@@ -633,7 +648,7 @@ def register_web_setup_routes(mcp_app):
                 method="phone",
                 branch="phone_code",
                 duration_ms=duration,
-                error="invalid_code",
+                error="unknown",
             )
             return _fragment(
                 request,
@@ -865,6 +880,15 @@ def register_web_setup_routes(mcp_app):
                 getattr(sent, "timeout", None),
             )
         except PhoneNumberFloodError:
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="reauth",
+                branch="reauth_phone",
+                duration_ms=duration,
+                error="flood_wait",
+            )
             return _fragment(
                 request,
                 "fragments/reauthorize_phone.html",
@@ -872,6 +896,15 @@ def register_web_setup_routes(mcp_app):
             )
         except Exception as e:
             logger.warning("Failed to send reauthorization code: %s", e)
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="reauth",
+                branch="reauth_phone",
+                duration_ms=duration,
+                error="unknown",
+            )
             return _fragment(
                 request,
                 "fragments/reauthorize_phone.html",
@@ -1030,6 +1063,12 @@ def register_web_setup_routes(mcp_app):
             "authorized": False,
             "created_at": time.time(),
         }
+
+        send_auth_event(
+            event="auth_started",
+            method="qr",
+            branch="qr_scan",
+        )
 
         return _fragment(
             request,
@@ -1193,6 +1232,15 @@ def register_web_setup_routes(mcp_app):
             )
         except Exception as e:
             logger.warning("QR 2FA failed for session %s: %s", setup_id, e)
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="qr",
+                branch="qr_2fa",
+                duration_ms=duration,
+                error="unknown",
+            )
             return _fragment(
                 request,
                 "fragments/qr_2fa.html",

--- a/src/server_components/web_setup.py
+++ b/src/server_components/web_setup.py
@@ -31,6 +31,9 @@ from src.server_components.session_token_validation import (
     session_file_path,
     validate_session_token,
 )
+
+# Auth telemetry (ADR 0008)
+from src.telemetry import send_auth_event
 from src.utils.logging_utils import mask_phone_number
 from src.utils.mcp_config import generate_mcp_config_json
 from src.utils.proxy import build_mtproto_client_args
@@ -133,7 +136,9 @@ def _setup_error_fragment(request: Request, error: str):
     return _fragment(request, "fragments/error.html", {"error": error})
 
 
-def _bearer_token_and_session_path(session_dir: Path, raw_token: str) -> tuple[str, Path]:
+def _bearer_token_and_session_path(
+    session_dir: Path, raw_token: str
+) -> tuple[str, Path]:
     """Validate bearer token and return confined session file path."""
     token = validate_session_token(raw_token)
     return token, session_file_path(session_dir, token)
@@ -146,10 +151,14 @@ def _setup_token_path_error_fragment(
 ) -> Any:
     """Map token/path resolution errors to setup HTML fragments."""
     if isinstance(exc, InvalidSessionTokenError):
-        return _fragment(request, template, {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE})
+        return _fragment(
+            request, template, {"error": INVALID_BEARER_TOKEN_FORMAT_MESSAGE}
+        )
     if isinstance(exc, OSError):
         logger.warning("Session path access failed: %s", exc)
-        return _fragment(request, template, {"error": SESSION_PATH_ACCESS_ERROR_MESSAGE})
+        return _fragment(
+            request, template, {"error": SESSION_PATH_ACCESS_ERROR_MESSAGE}
+        )
     raise exc
 
 
@@ -194,6 +203,30 @@ async def cleanup_stale_setup_sessions():
 
     for sid in stale_ids:
         state = _setup_sessions.pop(sid, None) or {}
+        # Fire auth_abandoned telemetry for stale sessions (ADR 0008)
+        if (
+            state.get("created_at")
+            and not state.get("authorized")
+            and not state.get("_finalized")
+        ):
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            # Determine method from state
+            if state.get("reauthorizing"):
+                method = "reauth"
+                branch = "reauth_phone"
+            elif state.get("qr_session_id"):
+                method = "qr"
+                branch = "qr_scan"
+            else:
+                method = "phone"
+                branch = "phone_2fa" if state.get("hint") else "phone_code"
+            send_auth_event(
+                event="auth_abandoned",
+                method=method,
+                branch=branch,
+                duration_ms=duration,
+            )
         await _cleanup_session_state(state)
 
     # Also clean up expired QR sessions
@@ -276,6 +309,7 @@ async def _persist_session_and_generate_config(
     # S3: checkpoint + upload newly created session
     if is_s3_enabled():
         from src import s3_session
+
         try:
             if not await s3_session.checkpoint_and_upload(token, dst):
                 return _setup_error_fragment(
@@ -293,7 +327,10 @@ async def _persist_session_and_generate_config(
 
     domain = cfg().domain
     header_config_json = generate_mcp_config_json(
-        ServerMode.HTTP_AUTH, session_name="", bearer_token=token, domain=domain,
+        ServerMode.HTTP_AUTH,
+        session_name="",
+        bearer_token=token,
+        domain=domain,
     )
     url_config = generate_url_based_config(domain or "your-server.com", token)
     url_config_json = json.dumps(url_config, indent=2)
@@ -307,7 +344,8 @@ async def _persist_session_and_generate_config(
         )
 
     return _fragment(
-        request, "fragments/config.html",
+        request,
+        "fragments/config.html",
         {
             "setup_id": setup_id,
             "token": token,
@@ -347,7 +385,11 @@ async def _complete_qr_login(
         authorized_client = qr_mgr.get_client(qr_session_id)
 
     response = await _persist_session_and_generate_config(
-        request, authorized_client, state["session_path"], setup_id, state=state,
+        request,
+        authorized_client,
+        state["session_path"],
+        setup_id,
+        state=state,
     )
 
     # HTMX re-entry guard: store completed state so duplicate polls
@@ -388,11 +430,16 @@ async def setup_complete_reauth(request: Request):
         # S3: checkpoint + upload reauthorized session
         if is_s3_enabled():
             from src import s3_session
+
             try:
                 await s3_session.checkpoint_and_upload(existing_token, original_path)
-                logger.info("S3: uploaded reauthorized session for %s...", existing_token[:8])
+                logger.info(
+                    "S3: uploaded reauthorized session for %s...", existing_token[:8]
+                )
             except Exception as e:
-                logger.warning("S3 upload failed for reauth %s...: %s", existing_token[:8], e)
+                logger.warning(
+                    "S3 upload failed for reauth %s...: %s", existing_token[:8], e
+                )
 
         # Clean up
         state.clear()
@@ -431,7 +478,10 @@ async def setup_generate(request: Request):
 
     desired_token = state.get("desired_token")
     response = await _persist_session_and_generate_config(
-        request, client, temp_session_path, setup_id,
+        request,
+        client,
+        temp_session_path,
+        setup_id,
         desired_token=desired_token,
     )
 
@@ -486,13 +536,20 @@ def register_web_setup_routes(mcp_app):
             logger.info(
                 "Code sent for phone %s: type=%s, phone_code_hash=%s, timeout=%s",
                 masked,
-                getattr(sent, 'type', None),
-                getattr(sent, 'phone_code_hash', None),
-                getattr(sent, 'timeout', None),
+                getattr(sent, "type", None),
+                getattr(sent, "phone_code_hash", None),
+                getattr(sent, "timeout", None),
             )
         except PhoneNumberFloodError:
             await client.disconnect()
             temp_session_path.unlink(missing_ok=True)
+            send_auth_event(
+                event="auth_failed",
+                method="phone",
+                branch="phone_code",
+                duration_ms=0.0,
+                error="flood_wait",
+            )
             return _fragment(
                 request,
                 "fragments/new_session_phone_form.html",
@@ -508,6 +565,11 @@ def register_web_setup_routes(mcp_app):
             "created_at": time.time(),
         }
 
+        send_auth_event(
+            event="auth_started",
+            method="phone",
+            branch="phone_code",
+        )
         return _fragment(
             request,
             "fragments/code_form.html",
@@ -537,6 +599,14 @@ def register_web_setup_routes(mcp_app):
             await client.sign_in(phone=phone, code=code)
             state["authorized"] = True
             logger.info("Phone %s verified successfully", masked_phone)
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_completed",
+                method="phone",
+                branch="phone_code",
+                duration_ms=duration,
+            )
             return await _complete_authentication(request, state)
         except SessionPasswordNeededError:
             hint = ""
@@ -544,10 +614,27 @@ def register_web_setup_routes(mcp_app):
                 pw = await client(GetPasswordRequest())
                 hint = (pw.hint or "").strip()
             state["hint"] = hint
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_started",
+                method="phone",
+                branch="phone_2fa",
+                duration_ms=duration,
+            )
             ctx = _2fa_form_context(setup_id, masked_phone, hint=hint or "")
             return _fragment(request, "fragments/2fa_form.html", ctx)
         except Exception as e:
             logger.warning("Verification failed for phone %s: %s", masked_phone, e)
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="phone",
+                branch="phone_code",
+                duration_ms=duration,
+                error="invalid_code",
+            )
             return _fragment(
                 request,
                 "fragments/code_form.html",
@@ -579,9 +666,26 @@ def register_web_setup_routes(mcp_app):
         try:
             await client.sign_in(password=password)
             state["authorized"] = True
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_completed",
+                method="phone",
+                branch="phone_2fa",
+                duration_ms=duration,
+            )
             return await _complete_authentication(request, state)
         except PasswordHashInvalidError:
             hint = state.get("hint") or ""
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="phone",
+                branch="phone_2fa",
+                duration_ms=duration,
+                error="2fa_wrong_password",
+            )
             return _fragment(
                 request,
                 "fragments/2fa_form.html",
@@ -594,6 +698,15 @@ def register_web_setup_routes(mcp_app):
             )
         except Exception as e:
             hint = state.get("hint") or ""
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="phone",
+                branch="phone_2fa",
+                duration_ms=duration,
+                error="unknown",
+            )
             return _fragment(
                 request,
                 "fragments/2fa_form.html",
@@ -628,11 +741,19 @@ def register_web_setup_routes(mcp_app):
         # S3 fallback: try downloading session from S3 if local file is missing
         if not session_path.exists() and is_s3_enabled():
             from src import s3_session
+
             try:
                 if await s3_session.download(existing_token, session_path):
-                    logger.info("S3: downloaded session for reauthorize %s...", existing_token[:8])
+                    logger.info(
+                        "S3: downloaded session for reauthorize %s...",
+                        existing_token[:8],
+                    )
             except Exception as e:
-                logger.warning("S3 download failed for reauthorize %s...: %s", existing_token[:8], e)
+                logger.warning(
+                    "S3 download failed for reauthorize %s...: %s",
+                    existing_token[:8],
+                    e,
+                )
 
         if not session_path.exists():
             return _fragment(
@@ -665,8 +786,7 @@ def register_web_setup_routes(mcp_app):
         # Session needs reauthorization - create temp session for reauth
         setup_id = str(int(time.time() * 1000))
         temp_session_path = (
-            cfg().session_directory
-            / f"{REAUTH_SESSION_PREFIX}{setup_id}.session"
+            cfg().session_directory / f"{REAUTH_SESSION_PREFIX}{setup_id}.session"
         )
 
         # Copy existing session to temp location
@@ -685,6 +805,12 @@ def register_web_setup_routes(mcp_app):
                 "reauthorizing": True,
                 "created_at": time.time(),
             }
+
+            send_auth_event(
+                event="auth_started",
+                method="reauth",
+                branch="reauth_phone",
+            )
 
             # Ask for phone number since we can't extract it securely from session
             return _fragment(
@@ -734,9 +860,9 @@ def register_web_setup_routes(mcp_app):
             logger.info(
                 "Reauthorization code sent for phone %s: type=%s, phone_code_hash=%s, timeout=%s",
                 mask_phone_number(phone_raw),
-                getattr(sent, 'type', None),
-                getattr(sent, 'phone_code_hash', None),
-                getattr(sent, 'timeout', None),
+                getattr(sent, "type", None),
+                getattr(sent, "phone_code_hash", None),
+                getattr(sent, "timeout", None),
             )
         except PhoneNumberFloodError:
             return _fragment(
@@ -800,6 +926,7 @@ def register_web_setup_routes(mcp_app):
             # S3: delete session from S3 BEFORE local unlink
             if is_s3_enabled():
                 from src import s3_session
+
                 await s3_session.delete(token)
                 logger.info("S3: deleted session for %s...", token[:8])
 
@@ -862,6 +989,13 @@ def register_web_setup_routes(mcp_app):
         except Exception as e:
             await client.disconnect()
             temp_session_path.unlink(missing_ok=True)
+            send_auth_event(
+                event="auth_failed",
+                method="qr",
+                branch="qr_scan",
+                duration_ms=0.0,
+                error="connect_failed",
+            )
             return _setup_error_fragment(request, f"Failed to connect: {e}")
 
         qr_mgr = _get_qr_manager()
@@ -870,6 +1004,13 @@ def register_web_setup_routes(mcp_app):
         except QrLoginError as e:
             await client.disconnect()
             temp_session_path.unlink(missing_ok=True)
+            send_auth_event(
+                event="auth_failed",
+                method="qr",
+                branch="qr_scan",
+                duration_ms=0.0,
+                error="unknown",
+            )
             return _setup_error_fragment(request, str(e))
 
         # Generate QR code image as base64 PNG
@@ -944,9 +1085,26 @@ def register_web_setup_routes(mcp_app):
 
         if status == "completed":
             state["authorized"] = True
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_completed",
+                method="qr",
+                branch="qr_scan",
+                duration_ms=duration,
+            )
             return await _complete_qr_login(request, state, qr_session_id, setup_id)
 
         if status == "expired":
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_failed",
+                method="qr",
+                branch="qr_scan",
+                duration_ms=duration,
+                error="timeout",
+            )
             return _fragment(
                 request,
                 "fragments/qr_expired.html",
@@ -1009,7 +1167,21 @@ def register_web_setup_routes(mcp_app):
             await client.sign_in(password=password)
             state["authorized"] = True
             logger.info("QR login 2FA completed for session %s", setup_id)
+            created_at = state.get("created_at", 0)
+            duration = (time.time() - created_at) * 1000 if created_at else 0.0
+            send_auth_event(
+                event="auth_completed",
+                method="qr",
+                branch="qr_2fa",
+                duration_ms=duration,
+            )
         except PasswordHashInvalidError:
+            send_auth_event(
+                event="auth_failed",
+                method="qr",
+                branch="qr_2fa",
+                error="2fa_wrong_password",
+            )
             return _fragment(
                 request,
                 "fragments/qr_2fa.html",

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -375,10 +375,12 @@ def send_auth_event(
     Args:
         event: What happened — ``auth_started``, ``auth_completed``,
             ``auth_failed``, or ``auth_abandoned``.
-        method: Auth method — ``phone``, ``qr``, ``reauth``, ``bearer_check``.
+        method: Auth method — ``phone``, ``qr``, ``reauth``, ``bearer_check``, ``cli_setup``.
         branch: Code path — ``phone_code``, ``phone_2fa``, ``qr_scan``,
             ``qr_2fa``, ``reauth_phone``, ``bearer_valid``,
-            ``bearer_no_session``, ``bearer_invalid``.
+            ``bearer_no_session``, ``bearer_invalid``,
+            ``cli_qr_scan``, ``cli_qr_2fa``, ``cli_phone_code``,
+            ``cli_phone_2fa``, ``cli_bot_token``.
         duration_ms: Wall-clock duration from start to this event.
         error: Categorized error (``flood_wait``, ``invalid_code``, etc.)
             or ``None`` for success/started events.
@@ -407,14 +409,14 @@ def send_auth_event(
     import urllib.error
     import urllib.request
 
-    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    req = urllib.request.Request(
-        TELEMETRY_ENDPOINT,
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
     try:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        req = urllib.request.Request(
+            TELEMETRY_ENDPOINT,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
         urllib.request.urlopen(req, timeout=10)
     except urllib.error.HTTPError as exc:
         logger.debug(
@@ -422,6 +424,8 @@ def send_auth_event(
         )
     except (OSError, urllib.error.URLError) as exc:
         logger.debug("Telemetry auth event: network error — %s", exc)
+    except Exception:
+        logger.debug("Telemetry auth event: unexpected error", exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -156,14 +156,15 @@ class MetricsStore:
             # Deep-copy tools to avoid mutation after releasing the lock
             tools_copy: dict[str, dict] = {}
             for tool_name, stats in self._tools.items():
-                ps_copy: dict[str, dict] = {}
-                for pk, pstats in stats["param_sets"].items():
-                    ps_copy[pk] = {
+                ps_copy: dict[str, dict] = {
+                    pk: {
                         "calls": pstats["calls"],
                         "errors": pstats["errors"],
                         "duration_ms": pstats["duration_ms"],
                         "traces": list(pstats["traces"]),
                     }
+                    for pk, pstats in stats["param_sets"].items()
+                }
                 tools_copy[tool_name] = {
                     "calls": stats["calls"],
                     "errors": stats["errors"],
@@ -264,7 +265,7 @@ def _collect_runtime() -> dict:
     session_dir = config.session_directory
     session_files = 0
     if session_dir.is_dir():
-        session_files = sum(1 for f in session_dir.iterdir() if f.suffix == ".session")
+        session_files = sum(bool(f.suffix == ".session") for f in session_dir.iterdir())
 
     # Runtime import avoids circular dependencies at module load time.
     from src.client.connection import get_active_session_count
@@ -348,6 +349,79 @@ def send_heartbeat(payload: dict | None = None) -> None:
         logger.debug("Telemetry: HTTP %s from %s", exc.code, TELEMETRY_ENDPOINT)
     except (OSError, urllib.error.URLError) as exc:
         logger.debug("Telemetry: network error — %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Auth event telemetry (ADR 0008)
+# ---------------------------------------------------------------------------
+
+
+def send_auth_event(
+    *,
+    event: str,
+    method: str,
+    branch: str,
+    duration_ms: float = 0.0,
+    error: str | None = None,
+) -> None:
+    """Fire an auth telemetry event immediately (not on heartbeat interval).
+
+    Auth events are rare and high-signal — each user authenticates once.
+    Individual events give better granularity than aggregating into
+    6-hour heartbeats.
+
+    Respects ``DO_NOT_TRACK=1``.  Network errors are silently logged.
+
+    Args:
+        event: What happened — ``auth_started``, ``auth_completed``,
+            ``auth_failed``, or ``auth_abandoned``.
+        method: Auth method — ``phone``, ``qr``, ``reauth``, ``bearer_check``.
+        branch: Code path — ``phone_code``, ``phone_2fa``, ``qr_scan``,
+            ``qr_2fa``, ``reauth_phone``, ``bearer_valid``,
+            ``bearer_no_session``, ``bearer_invalid``.
+        duration_ms: Wall-clock duration from start to this event.
+        error: Categorized error (``flood_wait``, ``invalid_code``, etc.)
+            or ``None`` for success/started events.
+    """
+    if not should_send():
+        return
+
+    payload = {
+        "type": "auth",
+        "iid": get_instance_id(),
+        "ts": int(time.time()),
+        "ver": __version__,
+        "event": event,
+        "method": method,
+        "branch": branch,
+        "duration_ms": duration_ms,
+        "error": error,
+    }
+
+    # Debug mode — print to stderr instead of sending
+    if os.environ.get("MCP_TELEMETRY_DEBUG", "").strip() == "1":
+        print("TELEMETRY", json.dumps(payload, indent=2), file=sys.stderr)
+        return
+
+    # Fire the POST (blocking in this thread — caller should run in executor)
+    import urllib.error
+    import urllib.request
+
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        TELEMETRY_ENDPOINT,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10)
+    except urllib.error.HTTPError as exc:
+        logger.debug(
+            "Telemetry auth event: HTTP %s from %s", exc.code, TELEMETRY_ENDPOINT
+        )
+    except (OSError, urllib.error.URLError) as exc:
+        logger.debug("Telemetry auth event: network error — %s", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_telemetry.py
+++ b/tests/test_auth_telemetry.py
@@ -1,0 +1,303 @@
+"""Tests for auth telemetry events (ADR 0008)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_env():
+    """Remove telemetry-related env vars before each test."""
+    for key in ("DO_NOT_TRACK", "MCP_TELEMETRY_DEBUG"):
+        os.environ.pop(key, None)
+    yield
+
+
+@pytest.fixture
+def telemetry_module():
+    """Import telemetry module fresh for each test."""
+    import importlib
+
+    import src.telemetry as t
+
+    importlib.reload(t)
+    if hasattr(t, "_instance_id"):
+        t._instance_id = None
+    return t
+
+
+# ───────────────────────────── send_auth_event ─────────────────────────
+
+
+class TestSendAuthEvent:
+    """Tests for the send_auth_event function."""
+
+    def test_send_auth_event_debug_mode_logs(self, telemetry_module, capsys):
+        """MCP_TELEMETRY_DEBUG=1 logs auth event to stderr."""
+        os.environ["MCP_TELEMETRY_DEBUG"] = "1"
+
+        telemetry_module.send_auth_event(
+            event="auth_started",
+            method="phone",
+            branch="phone_code",
+        )
+
+        captured = capsys.readouterr()
+        assert "TELEMETRY" in captured.err
+        payload = json.loads(captured.err.split("TELEMETRY")[-1].strip())
+        assert payload["type"] == "auth"
+        assert payload["event"] == "auth_started"
+        assert payload["method"] == "phone"
+        assert payload["branch"] == "phone_code"
+
+    def test_send_auth_event_respects_do_not_track(self, telemetry_module):
+        """DO_NOT_TRACK=1 prevents sending."""
+        os.environ["DO_NOT_TRACK"] = "1"
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            telemetry_module.send_auth_event(
+                event="auth_started",
+                method="phone",
+                branch="phone_code",
+            )
+        mock_urlopen.assert_not_called()
+
+    def test_send_auth_event_sends_post(self, telemetry_module):
+        """send_auth_event sends a POST request."""
+        os.environ["MCP_TELEMETRY_DEBUG"] = "1"
+
+        telemetry_module.send_auth_event(
+            event="auth_completed",
+            method="qr",
+            branch="qr_scan",
+            duration_ms=12340.5,
+        )
+
+        # Verify it doesn't raise and respects debug mode
+        # (actual POST tested via integration)
+
+    def test_send_auth_event_with_error(self, telemetry_module, capsys):
+        """Auth event with error category is included."""
+        os.environ["MCP_TELEMETRY_DEBUG"] = "1"
+
+        telemetry_module.send_auth_event(
+            event="auth_failed",
+            method="phone",
+            branch="phone_code",
+            duration_ms=500.0,
+            error="flood_wait",
+        )
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err.split("TELEMETRY")[-1].strip())
+        assert payload["event"] == "auth_failed"
+        assert payload["error"] == "flood_wait"
+        assert payload["duration_ms"] == 500.0
+
+    def test_send_auth_event_network_error_silent(self, telemetry_module):
+        """Network error does not raise."""
+        import urllib.error
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.URLError("refused")
+            # Should not raise
+            telemetry_module.send_auth_event(
+                event="auth_started",
+                method="phone",
+                branch="phone_code",
+            )
+        mock_urlopen.assert_called_once()
+
+    def test_send_auth_event_includes_iid(self, telemetry_module, capsys):
+        """Auth event includes instance ID."""
+        os.environ["MCP_TELEMETRY_DEBUG"] = "1"
+
+        telemetry_module.send_auth_event(
+            event="auth_started",
+            method="phone",
+            branch="phone_code",
+        )
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err.split("TELEMETRY")[-1].strip())
+        assert "iid" in payload
+        assert len(payload["iid"]) == 36  # UUID v4
+
+    def test_send_auth_event_includes_ver(self, telemetry_module, capsys):
+        """Auth event includes version."""
+        os.environ["MCP_TELEMETRY_DEBUG"] = "1"
+
+        telemetry_module.send_auth_event(
+            event="auth_started",
+            method="phone",
+            branch="phone_code",
+        )
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err.split("TELEMETRY")[-1].strip())
+        assert "ver" in payload
+        assert payload["ver"]  # non-empty
+
+    def test_send_auth_event_includes_ts(self, telemetry_module, capsys):
+        """Auth event includes timestamp."""
+        os.environ["MCP_TELEMETRY_DEBUG"] = "1"
+
+        before = int(time.time())
+        telemetry_module.send_auth_event(
+            event="auth_started",
+            method="phone",
+            branch="phone_code",
+        )
+        after = int(time.time())
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err.split("TELEMETRY")[-1].strip())
+        assert before <= payload["ts"] <= after
+
+
+# ───────────────────────────── Auth event in web_setup ─────────────────
+
+
+class TestWebSetupAuthEvents:
+    """Test that web_setup routes fire auth telemetry events."""
+
+    @pytest.fixture
+    def setup_routes(self):
+        from src.server_components import web_setup
+
+        class _FakeMcpApp:
+            def __init__(self):
+                self.routes = {}
+
+            def custom_route(self, path, methods):
+                def decorator(func):
+                    self.routes[(path, tuple(methods))] = func
+                    return func
+
+                return decorator
+
+        app = _FakeMcpApp()
+        web_setup.register_web_setup_routes(app)
+        return app.routes
+
+    @pytest.fixture
+    def _patch_templates(self, monkeypatch):
+        """Patch Jinja2Templates.TemplateResponse."""
+        from types import SimpleNamespace
+
+        from src.server_components import web_setup
+
+        def _tr(_request, template_name, context=None):
+            return SimpleNamespace(template=template_name, context=context or {})
+
+        monkeypatch.setattr(web_setup.templates, "TemplateResponse", _tr)
+
+    @pytest.mark.asyncio
+    async def test_setup_phone_fires_auth_started(
+        self, monkeypatch, setup_routes, _patch_templates
+    ):
+        """POST /setup/phone fires auth_started event."""
+        import tempfile
+        from pathlib import Path
+
+        from src.config.server_config import ServerConfig, set_config
+        from src.server_components import web_setup
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = ServerConfig()
+            cfg.session_dir = str(Path(tmp))
+            set_config(cfg)
+
+            web_setup._setup_sessions.clear()
+
+            class _Client:
+                async def connect(self):
+                    pass
+
+                async def send_code_request(self, phone, **kwargs):
+                    pass
+
+                async def disconnect(self):
+                    pass
+
+            monkeypatch.setattr(
+                web_setup, "create_session_client", lambda _path: _Client()
+            )
+
+            captured_events = []
+
+            def capture_send_auth_event(**kwargs):
+                captured_events.append(kwargs)
+
+            monkeypatch.setattr(web_setup, "send_auth_event", capture_send_auth_event)
+
+            class _FakeRequest:
+                async def form(self):
+                    return {"phone": "+1234567890"}
+
+            handler = setup_routes[("/setup/phone", ("POST",))]
+            await handler(_FakeRequest())
+
+            assert len(captured_events) >= 1
+            started = captured_events[0]
+            assert started["event"] == "auth_started"
+            assert started["method"] == "phone"
+            assert started["branch"] == "phone_code"
+
+    @pytest.mark.asyncio
+    async def test_setup_phone_flood_fires_auth_failed(
+        self, monkeypatch, setup_routes, _patch_templates
+    ):
+        """POST /setup/phone with flood fires auth_failed event."""
+        import tempfile
+        from pathlib import Path
+
+        from telethon.errors.rpcerrorlist import PhoneNumberFloodError
+
+        from src.config.server_config import ServerConfig, set_config
+        from src.server_components import web_setup
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = ServerConfig()
+            cfg.session_dir = str(Path(tmp))
+            set_config(cfg)
+
+            web_setup._setup_sessions.clear()
+
+            class _Client:
+                async def connect(self):
+                    pass
+
+                async def send_code_request(self, phone, **kwargs):
+                    raise PhoneNumberFloodError(request=None)
+
+                async def disconnect(self):
+                    pass
+
+            monkeypatch.setattr(
+                web_setup, "create_session_client", lambda _path: _Client()
+            )
+
+            captured_events = []
+            monkeypatch.setattr(
+                web_setup,
+                "send_auth_event",
+                lambda **kwargs: captured_events.append(kwargs),
+            )
+
+            class _FakeRequest:
+                async def form(self):
+                    return {"phone": "+1234567890"}
+
+            handler = setup_routes[("/setup/phone", ("POST",))]
+            await handler(_FakeRequest())
+
+            failed = [e for e in captured_events if e["event"] == "auth_failed"]
+            assert len(failed) >= 1
+            assert failed[0]["error"] == "flood_wait"
+            assert failed[0]["method"] == "phone"

--- a/tests/test_auth_telemetry.py
+++ b/tests/test_auth_telemetry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -78,9 +79,6 @@ class TestSendAuthEvent:
             duration_ms=12340.5,
         )
 
-        # Verify it doesn't raise and respects debug mode
-        # (actual POST tested via integration)
-
     def test_send_auth_event_with_error(self, telemetry_module, capsys):
         """Auth event with error category is included."""
         os.environ["MCP_TELEMETRY_DEBUG"] = "1"
@@ -105,7 +103,6 @@ class TestSendAuthEvent:
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_urlopen.side_effect = urllib.error.URLError("refused")
-            # Should not raise
             telemetry_module.send_auth_event(
                 event="auth_started",
                 method="phone",
@@ -188,8 +185,6 @@ class TestWebSetupAuthEvents:
     @pytest.fixture
     def _patch_templates(self, monkeypatch):
         """Patch Jinja2Templates.TemplateResponse."""
-        from types import SimpleNamespace
-
         from src.server_components import web_setup
 
         def _tr(_request, template_name, context=None):
@@ -301,3 +296,317 @@ class TestWebSetupAuthEvents:
             assert len(failed) >= 1
             assert failed[0]["error"] == "flood_wait"
             assert failed[0]["method"] == "phone"
+
+
+# ───────────────────────────── Auth event in cli_setup ─────────────────
+
+
+def _make_cli_cfg(tmp: str):
+    """Create a SimpleNamespace mimicking SetupConfig for tests (avoids CLI arg parsing)."""
+    from pathlib import Path
+
+    return SimpleNamespace(
+        session_directory=Path(tmp),
+        session_dir=str(Path(tmp)),
+        session_path=Path(tmp) / "test",
+        api_id="12345",
+        api_hash="abcdef",
+        bot_api_token="",
+        phone_number="",
+        server_mode=SimpleNamespace(value="http-auth"),
+        overwrite=True,
+        session_name="test",
+        entity_cache_limit=0,
+        mtproto_proxy=None,
+        domain=None,
+    )
+
+
+class TestCliSetupAuthEvents:
+    """Test that cli_setup flows fire auth telemetry events."""
+
+    @pytest.fixture
+    def _patch_cli_deps(self, monkeypatch):
+        """Common patches for CLI setup tests."""
+        from src import cli_setup
+
+        monkeypatch.setattr(cli_setup, "_is_interactive_terminal", lambda: True)
+
+        captured_events = []
+
+        def capture_send_auth_event(**kwargs):
+            captured_events.append(kwargs)
+
+        monkeypatch.setattr(cli_setup, "send_auth_event", capture_send_auth_event)
+        return captured_events
+
+    @staticmethod
+    def _make_fake_client(monkeypatch):
+        """Create and patch a minimal TelegramClient mock."""
+        from src import cli_setup
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self):
+                pass
+
+            async def disconnect(self):
+                pass
+
+            @property
+            def session(self):
+                return SimpleNamespace(filename=None)
+
+        monkeypatch.setattr(cli_setup, "TelegramClient", FakeClient)
+        monkeypatch.setattr(cli_setup, "build_mtproto_client_args", lambda *a, **k: {})
+        monkeypatch.setattr(cli_setup, "generate_bearer_token", lambda: "tok123")
+
+    @pytest.mark.asyncio
+    async def test_qr_flow_fires_started_and_completed(
+        self, monkeypatch, _patch_cli_deps
+    ):
+        """QR login flow fires auth_started and auth_completed."""
+        from src import cli_setup
+
+        captured_events = _patch_cli_deps
+
+        async def fake_qr_login(client, session_path):
+            return True
+
+        monkeypatch.setattr(cli_setup, "_qr_login_flow", fake_qr_login)
+        self._make_fake_client(monkeypatch)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _make_cli_cfg(tmp)
+            result = await cli_setup._qr_session_login(cfg, cfg.session_path, "tok123")
+
+        assert result is not None
+        events = [e for e in captured_events if e["method"] == "cli_setup"]
+        assert len(events) == 2
+        assert events[0]["event"] == "auth_started"
+        assert events[0]["branch"] == "cli_qr_scan"
+        assert events[1]["event"] == "auth_completed"
+        assert events[1]["branch"] == "cli_qr_scan"
+        assert events[1]["duration_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_qr_flow_fires_started_and_failed(self, monkeypatch, _patch_cli_deps):
+        """QR login flow failure fires auth_started and auth_failed."""
+        from src import cli_setup
+
+        captured_events = _patch_cli_deps
+
+        async def fake_qr_login(client, session_path):
+            return False
+
+        monkeypatch.setattr(cli_setup, "_qr_login_flow", fake_qr_login)
+        self._make_fake_client(monkeypatch)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _make_cli_cfg(tmp)
+            result = await cli_setup._qr_session_login(cfg, cfg.session_path, "tok123")
+
+        assert result is None
+        events = [e for e in captured_events if e["method"] == "cli_setup"]
+        assert len(events) == 2
+        assert events[0]["event"] == "auth_started"
+        assert events[1]["event"] == "auth_failed"
+        assert events[1]["error"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_bot_flow_fires_started_and_completed(
+        self, monkeypatch, _patch_cli_deps
+    ):
+        """Bot token auth fires auth_started and auth_completed."""
+        from src import cli_setup
+
+        captured_events = _patch_cli_deps
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self):
+                pass
+
+            async def start(self, bot_token=None):
+                pass
+
+            async def get_me(self):
+                return SimpleNamespace(username="testbot", first_name="TestBot")
+
+            async def disconnect(self):
+                pass
+
+        monkeypatch.setattr(cli_setup, "TelegramClient", FakeClient)
+        monkeypatch.setattr(cli_setup, "build_mtproto_client_args", lambda *a, **k: {})
+        monkeypatch.setattr(cli_setup, "generate_bearer_token", lambda: "tok123")
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _make_cli_cfg(tmp)
+            cfg.bot_api_token = "bot:token123"
+            result = await cli_setup.setup_telegram_session(cfg)
+
+        assert result is not None
+        events = [e for e in captured_events if e["method"] == "cli_setup"]
+        assert len(events) == 2
+        assert events[0]["event"] == "auth_started"
+        assert events[0]["branch"] == "cli_bot_token"
+        assert events[1]["event"] == "auth_completed"
+        assert events[1]["branch"] == "cli_bot_token"
+
+    @pytest.mark.asyncio
+    async def test_phone_flow_fires_started_and_completed(
+        self, monkeypatch, _patch_cli_deps
+    ):
+        """Phone auth fires auth_started and auth_completed."""
+        from src import cli_setup
+
+        captured_events = _patch_cli_deps
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self):
+                pass
+
+            async def is_user_authorized(self):
+                return True
+
+            async def get_me(self):
+                return SimpleNamespace(username="testuser", first_name="Test")
+
+            async def iter_dialogs(self, limit=1):
+                yield SimpleNamespace(name="Saved Messages")
+                return
+
+            async def disconnect(self):
+                pass
+
+        monkeypatch.setattr(cli_setup, "TelegramClient", FakeClient)
+        monkeypatch.setattr(cli_setup, "build_mtproto_client_args", lambda *a, **k: {})
+        monkeypatch.setattr(cli_setup, "generate_bearer_token", lambda: "tok123")
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _make_cli_cfg(tmp)
+            cfg.phone_number = "+1234567890"
+            result = await cli_setup.setup_telegram_session(cfg)
+
+        assert result is not None
+        events = [e for e in captured_events if e["method"] == "cli_setup"]
+        assert len(events) == 2
+        assert events[0]["event"] == "auth_started"
+        assert events[0]["branch"] == "cli_phone_code"
+        assert events[1]["event"] == "auth_completed"
+        assert events[1]["branch"] == "cli_phone_code"
+
+    @pytest.mark.asyncio
+    async def test_phone_flow_failure_fires_auth_failed(
+        self, monkeypatch, _patch_cli_deps
+    ):
+        """Phone auth failure fires auth_started and auth_failed."""
+        from src import cli_setup
+
+        captured_events = _patch_cli_deps
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self):
+                raise ConnectionError("Telegram unreachable")
+
+            async def disconnect(self):
+                pass
+
+        monkeypatch.setattr(cli_setup, "TelegramClient", FakeClient)
+        monkeypatch.setattr(cli_setup, "build_mtproto_client_args", lambda *a, **k: {})
+        monkeypatch.setattr(cli_setup, "generate_bearer_token", lambda: "tok123")
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _make_cli_cfg(tmp)
+            cfg.phone_number = "+1234567890"
+            with pytest.raises(ConnectionError):
+                await cli_setup.setup_telegram_session(cfg)
+
+        events = [e for e in captured_events if e["method"] == "cli_setup"]
+        assert len(events) == 2
+        assert events[0]["event"] == "auth_started"
+        assert events[1]["event"] == "auth_failed"
+        assert events[1]["error"] == "connect_failed"
+
+
+# ───────────────────────────── Bearer check telemetry ──────────────────
+
+
+class TestBearerCheckTelemetry:
+    """Test that require_auth fires bearer check telemetry with cooldown."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cooldown(self):
+        """Reset bearer cooldown dict before each test."""
+        from src.server_components import auth
+
+        auth._BEARER_CHECK_COOLDOWN.clear()
+        yield
+        auth._BEARER_CHECK_COOLDOWN.clear()
+
+    def test_fire_bearer_telemetry_fires_event(self, monkeypatch):
+        """_fire_bearer_telemetry calls send_auth_event."""
+        from src.server_components import auth
+
+        captured = []
+        import src.telemetry as tel
+
+        monkeypatch.setattr(tel, "send_auth_event", lambda **kw: captured.append(kw))
+        auth._fire_bearer_telemetry("auth_completed", "bearer_valid")
+
+        assert len(captured) == 1
+        assert captured[0]["event"] == "auth_completed"
+        assert captured[0]["method"] == "bearer_check"
+        assert captured[0]["branch"] == "bearer_valid"
+
+    def test_bearer_cooldown_suppresses_duplicate(self, monkeypatch):
+        """Second call within cooldown window is suppressed."""
+        from src.server_components import auth
+
+        captured = []
+        import src.telemetry as tel
+
+        monkeypatch.setattr(tel, "send_auth_event", lambda **kw: captured.append(kw))
+
+        auth._fire_bearer_telemetry("auth_completed", "bearer_valid")
+        auth._fire_bearer_telemetry("auth_completed", "bearer_valid")
+
+        assert len(captured) == 1
+
+    def test_bearer_cooldown_different_branches(self, monkeypatch):
+        """Different branches have independent cooldowns."""
+        from src.server_components import auth
+
+        captured = []
+        import src.telemetry as tel
+
+        monkeypatch.setattr(tel, "send_auth_event", lambda **kw: captured.append(kw))
+
+        auth._fire_bearer_telemetry("auth_completed", "bearer_valid")
+        auth._fire_bearer_telemetry(
+            "auth_failed", "bearer_no_session", "session_expired"
+        )
+
+        assert len(captured) == 2
+        assert captured[0]["branch"] == "bearer_valid"
+        assert captured[1]["branch"] == "bearer_no_session"


### PR DESCRIPTION
## Summary

Add event-based auth telemetry to detect exceptions, abandoned flows, slow processes, and which code path was used — covering web setup, CLI setup, and bearer check authentication.

## Motivation

ADR 0005 heartbeat telemetry aggregates over 6h windows — useful for tool-call trends, blind to individual auth attempts. Auth events are rare and high-signal: each user authenticates once. They need individual events, not aggregated metrics.

## Changes

### Event model
- New `type: "auth"` discriminator in the same telemetry payload
- Same endpoint (`/v1/event`), same PostgreSQL table (JSONB), same fire-and-forget pattern
- No new dependencies (stdlib `urllib` only)
- Respects `DO_NOT_TRACK=1` opt-out

### Events
| Event | When |
|-------|------|
| `auth_started` | User initiates auth |
| `auth_completed` | Auth succeeds |
| `auth_failed` | Auth fails with error |
| `auth_abandoned` | Stale session cleanup |

### Methods
- `phone`, `qr`, `reauth` (web setup)
- `bearer_check` (auth.py require_auth decorator, 1h cooldown per branch)
- `cli_setup` (CLI — QR, phone, bot token flows)

### Branch tags
- Web: `phone_code`, `phone_2fa`, `qr_scan`, `qr_2fa`, `reauth_phone`
- Bearer: `bearer_valid`, `bearer_no_session`, `bearer_invalid`
- CLI: `cli_qr_scan`, `cli_qr_2fa`, `cli_phone_code`, `cli_phone_2fa`, `cli_bot_token`

### Error categories
`flood_wait`, `invalid_code`, `2fa_wrong_password`, `timeout`, `connect_failed`, `session_expired`, `unknown`

### Instrumented files
- `src/server_components/web_setup.py` — all web auth routes + stale session cleanup
- `src/server_components/auth.py` — `require_auth` bearer check with 1h cooldown
- `src/cli_setup.py` — QR, phone, and bot token CLI flows with error categorization
- `src/telemetry.py` — `send_auth_event()` function

### Collector
- `collector/app/auth_models.py` — `AuthEvent` dataclass with validation (accepts all CLI methods/branches)
- `collector/app/services.py` — type discrimination in `process_event()`
- `collector/app/database.py` — updated `PgStorage.store()` type hint

## ADR

Full design: [ADR 0008](docs/adr/0008-auth-telemetry-events.md) (status: accepted)

## Tests

- `collector/tests/test_auth_models.py` — 23 tests for AuthEvent model
- `collector/tests/test_services.py` — 6 tests for process_auth_event
- `collector/tests/test_endpoint.py` — 7 tests for auth event endpoint
- `tests/test_auth_telemetry.py` — 18 tests:
  - 8 send_auth_event unit tests
  - 2 web_setup auth event tests
  - 5 CLI setup auth event tests (QR, bot, phone, failure)
  - 3 bearer check telemetry tests (fire, cooldown, different branches)

966 tests pass, ruff clean, 13 pre-existing bench_scenario failures unrelated.
