### PR TITLE
feat: context enrichment for search results

### DIFF
--- a/docs/Search-Guidelines.md
+++ b/docs/Search-Guidelines.md
@@ -193,6 +193,61 @@ Telegram search has specific limitations that AI models should understand to pro
 }}
 ```
 
+### Context Enrichment
+
+When you need surrounding conversation context for search results, use `context` and `include_reply_threads`:
+
+```json
+// Search with 3 messages before/after each result
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "deadline",
+  "context": 3,
+  "limit": 10
+}}
+
+// Search with context + reply threads (up to 5 replies per result)
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "announcement",
+  "context": 2,
+  "include_reply_threads": true,
+  "limit": 10
+}}
+
+// Reply threads only (no neighbor context)
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "question",
+  "context": 0,
+  "include_reply_threads": true,
+  "limit": 5
+}}
+```
+
+**Context envelope format** (added to each result when `context > 0`):
+```json
+{
+  "id": 500,
+  "text": "the matched message",
+  "context": {
+    "before": [{"id": 498, "text": "...", "sender_id": 42, "date": "..."}],
+    "after": [{"id": 502, "text": "...", "sender_id": 43, "date": "..."}],
+    "reply_to": {"id": 400, "text": "...", "sender_id": 44, "date": "..."},
+    "replies": [{"id": 501, "text": "...", "sender_id": 45, "date": "..."}]
+  }
+}
+```
+
+**Notes:**
+- `context` is clamped to 1–10. Default 0 = disabled.
+- `include_reply_threads` is opt-in (default false) — each result with replies costs one extra API call.
+- Context uses a lightweight format (id, date, text, sender_id) to save tokens.
+- Enrichment is disabled when result count exceeds cost caps (500 IDs, 20 reply fetches).
+- Requires `chat_id` — not available for global search.
+- Forum topics: neighbors are filtered to the same topic.
+- On enrichment failure, results are returned without context (never loses search results).
+
 ## Performance Tips
 
 ### Limit Management

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -224,6 +224,8 @@ get_messages(
   min_date?: string,             // ISO date filter (search, browse, and reply/forum-topic modes)
   max_date?: string,             // ISO date filter (search, browse, and reply/forum-topic modes)
   from_user?: string,            // Sender filter: @username, phone, user id, t.me URL, 'me' (per-chat only)
+  context?: number = 0,          // Neighbor messages per side (1–10); 0=disabled. Requires chat_id.
+  include_reply_threads?: boolean = false,  // Fetch up to 5 direct replies per result (opt-in)
   auto_expand_batches?: number = 2,  // Extra batches for filtered searches
   include_total_count?: boolean = false  // Include total count (chat search only)
 )
@@ -271,6 +273,22 @@ get_messages(
 }
 ```
 
+When `context > 0` or `include_reply_threads=true`, each message gains a `context` envelope:
+```json
+{
+  "id": 500,
+  "text": "the matched message",
+  "context": {
+    "before": [{"id": 498, "date": "...", "text": "...", "sender_id": 42}],
+    "after": [{"id": 502, "date": "...", "text": "...", "sender_id": 43}],
+    "reply_to": {"id": 400, "date": "...", "text": "...", "sender_id": 44},
+    "replies": [{"id": 501, "date": "...", "text": "...", "sender_id": 45}]
+  }
+}
+```
+
+Context messages use a lightweight format (id, date, text, sender_id) to save tokens. `replies` is only populated when `include_reply_threads=true`. `reply_to` is `null` when the message has no reply target. The `context` key is absent entirely when no enrichment is requested.
+
 **Features:**
 - **Rich Media Parsing**: Automatically parses Todo lists, polls, photos, documents
 - **Voice Transcription**: Automatic for Premium accounts with parallel processing
@@ -278,6 +296,7 @@ get_messages(
 - **Auto-Detection**: Automatically detects channel posts and uses discussion group
 - **Structured Data**: LLM-friendly JSON structures
 - **Context Optimization**: When `chat_id` is provided (per-chat modes), the `chat` field is omitted from each message to save context. Global search includes `chat` since messages span different chats.
+- **Context Enrichment**: `context` parameter adds surrounding messages (before/after) and reply chains. `include_reply_threads` fetches direct replies. Lightweight format saves tokens. Forum topic-aware.
 
 **💡 Tips:**
 - **No query**: Returns latest messages from chat
@@ -353,6 +372,31 @@ get_messages(
 {"tool": "get_messages", "params": {
   "chat_id": "telegram",
   "query": "update, news"
+}}
+
+// 8. Search with context (3 messages before/after each result)
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "deadline",
+  "context": 3,
+  "limit": 10
+}}
+
+// 9. Search with context + reply threads
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "announcement",
+  "context": 2,
+  "include_reply_threads": true,
+  "limit": 10
+}}
+
+// 10. Reply threads only (no neighbor context)
+{"tool": "get_messages", "params": {
+  "chat_id": "-1001234567890",
+  "query": "question",
+  "include_reply_threads": true,
+  "limit": 5
 }}
 ```
 

--- a/docs/adr/0011-context-enrichment-for-search.md
+++ b/docs/adr/0011-context-enrichment-for-search.md
@@ -1,0 +1,177 @@
+# ADR 0011: Context Enrichment for Message Search Results
+
+**Status:** proposed
+**Date:** 2026-06-26
+
+## Context
+
+When LLM agents search messages via `get_messages`, results are flat — each message is an isolated object with no surrounding conversation context. This makes search results less useful for understanding conversation flow, reply chains, and what was said around a match.
+
+Industry precedent:
+- **Slack** `assistant.search.context` returns `context_messages` with `before[]` and `after[]` lists per result
+- **RAG best practices** (Anthropic, PIXION) recommend sentence-window retrieval — find small chunks, expand to neighbors on retrieval
+
+Telegram API capabilities already partially used by fast-mcp-telegram:
+- `client.iter_messages(entity, offset_id=N)` — fetch messages by position (neighbors)
+- `MessageReplyHeader.reply_to_msg_id` — identify what a message replies to
+- `reply_to.forum_topic` + `_extract_topic_metadata` — forum topic handling
+- `_fetch_direct_replies(client, entity, msg_id)` in `replies.py` — fetch reply threads
+
+## Decision
+
+Add a `context` parameter to `get_messages` (int, default 0 = disabled) that enriches search results with surrounding conversation context, and an `include_reply_threads` flag for reply thread fetching.
+
+### Cost analysis
+
+| Enrichment | Extra API calls | Notes |
+|-----------|----------------|-------|
+| Neighbors (±N) | 1 batched `getMessages` per result set | Cheap — one call for all IDs |
+| Reply chain | 1 batched `getMessages` per result set | Cheap — batched with neighbors |
+| Reply threads | `_fetch_direct_replies` per result (max 5 replies each) | Expensive — per-result calls |
+
+### Cost cap
+
+Hard cap on total extra API calls per enrichment:
+- **Neighbor + reply chain IDs**: max 500 per batch (50 results × 10 window)
+- **Reply thread fetches**: max 20 per call (beyond that, reply threads skipped with warning)
+- **Reply thread replies**: capped at 5 per result via `_fetch_direct_replies(limit=5)`
+
+When caps are hit, the response includes a note: `"Context enrichment partially applied (hit cap). Narrow your query for full context."`
+
+### Design choices
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Window size | Configurable (int param, 1–10) | User's requirement; clamped at param boundary to prevent abuse |
+| Reply chain depth | One level only | Recursive is expensive and rarely needed |
+| Forum topic scoping | Filter neighbors by `top_msg_id` | Prevents cross-topic context bleed in forum supergroups |
+| Service message filter | Skip `reply_to.forum_topic=True` + no displayable text | Uses existing `message_has_displayable_content()` |
+| Reply threads | Separate `include_reply_threads` flag (default: False) | Decouples expensive per-result fetches; opt-in to avoid surprising latency |
+| Reply thread cap | 5 replies per result | Prevents unbounded response growth |
+| Token budget | No limit | User's requirement |
+| Failure handling | Partial — return results-without-context on error | Enrichment failure must not lose search results |
+| `chat_id` requirement | Required when `context > 0` | Context enrichment needs a specific chat to fetch neighbors from |
+
+### Implementation
+
+Post-processing step after search results are collected:
+
+1. Run search as normal → N results
+2. If `context > 0`:
+   a. Collect neighbor IDs: for each result, compute `result.id ± context` window
+   b. Collect `reply_to_msg_id` values from results
+   c. Batch-fetch all needed messages via `_get_messages_by_ids_batched(client, entity, all_ids, CHUNK=100)`
+   d. For forum supergroups: filter neighbors by matching `top_msg_id` to result's topic
+   e. Build context envelope per result (see below)
+3. If `include_reply_threads=True`:
+   a. For results with `replies.replies > 0`, call `_fetch_direct_replies(limit=5)` from `replies.py`
+   b. Attach to result's context envelope
+4. Filter out forum topic service messages using `message_has_displayable_content()`
+5. Attach `context` envelope to each result (absent when context=0)
+
+**Failure handling:** wrap steps 2-4 in try/catch. On `FloodWaitError`, include wait duration in warning. Return results without context enrichment on error.
+
+**Timeout budget:** 30s total for enrichment phase. If exceeded, return partial results with warning.
+
+### Result format
+
+When `context=0` (default): no change to existing result format.
+
+When `context > 0`, each result gains a `context` envelope:
+
+```json
+{
+  "id": 123,
+  "text": "the matched message",
+  "sender": {...},
+  ...existing fields...,
+  "context": {
+    "before": [{"id": 120, "text": "...", "sender": "..."}, ...],
+    "after": [{"id": 124, "text": "...", "sender": "..."}, ...],
+    "reply_to": {"id": 100, "text": "...", "sender": "..."} | null,
+    "replies": [{"id": 125, "text": "...", "sender": "..."}, ...]
+  }
+}
+```
+
+Context messages use a **lightweight format** (id, date, text, sender_id) to save tokens — not the full message result format.
+
+When `context=0`, the `"context"` key is absent entirely. This groups all enrichment into one namespace, makes it obvious which fields are enrichment vs native, and reduces top-level field count.
+
+### Reply-to field relationship
+
+When context is enabled and `reply_to_message` is resolved:
+- `reply_to_msg_id` (existing int field) remains — it's the raw ID for downstream use
+- `context.reply_to` (new dict) is the resolved message — lightweight format, populated only when context > 0
+
+## Consequences
+
+### New parameters
+
+- `context: int = 0` on `get_messages` — window size for before/after context (clamped 1–10)
+- `include_reply_threads: bool = False` — whether to fetch reply threads (opt-in to avoid surprising latency)
+- Only applies to search/browse mode (query + chat_id); ignored for `message_ids` and `reply_to_id` modes
+- Enrichment wrapper in `_dispatch_search_mode` — no threading through `_handle_query_mode` or `_collect_messages_in_chat`
+
+### Code changes
+
+- `mcp_tool_types.py` — import existing `ContextWindow` type (already at line 218); add `IncludeReplyThreads` type
+- `tools_register.py` — add `context` and `include_reply_threads` params to `get_messages`
+- `core.py` — thread both params through `search_messages_impl` and `_build_search_params`
+- `search_mode.py` — add enrichment wrapper in `_dispatch_search_mode` after result collection
+- `search_generators.py` — no changes (enrichment is post-processing)
+- `results.py` — no changes (enrichment builds on existing result format)
+
+### Backward compatibility
+
+- `context=0` (default) = current behavior, no context fields added
+- `include_reply_threads=False` (default) = reply threads not fetched unless explicitly requested
+- No changes to existing result schema when context is disabled
+
+### Deferred
+
+- Global search context enrichment (requires cross-chat neighbor fetching)
+- Recursive reply chain depth
+- Parallel reply thread fetches (asyncio.gather for _fetch_direct_replies)
+
+## Resolved findings
+
+### Round 1
+
+| Reviewer | Finding | Resolution |
+|----------|---------|------------|
+| Simplification | Reply threads should be separate flag | Adopted: `include_reply_threads` flag |
+| Simplification | Replace count-based threshold with cost-based cap | Adopted: hard cap on IDs and reply thread fetches |
+| Simplification | Merge context_before/after into single list | Adopted: single `context` envelope with `before`/`after` |
+| Simplification | Use lightweight context format | Adopted: id, date, text, sender_id only |
+| Simplification | Reuse `_fetch_direct_replies` from replies.py | Adopted |
+| Simplification | Nest enrichment under `context` envelope | Adopted |
+| Edge cases | Reply threads unbounded | Adopted: cap at 5 replies per result |
+| Edge cases | No partial-failure resilience | Adopted: try/catch, return results-without-context |
+| Edge cases | Context spans unrelated forum topics | Adopted: filter by `top_msg_id` |
+| Edge cases | Deleted neighbor message None handling | Adopted: skip None results |
+| Edge cases | FloodWaitError from sequential getReplies | Mitigated: sequential but with cap; deferred parallelism |
+| Edge cases | No bounds on context parameter | Adopted: cost caps in implementation |
+
+### Round 2
+
+| Reviewer | Finding | Resolution |
+|----------|---------|------------|
+| Simplification | Thread through 4 files → wrapper in `_dispatch_search_mode` | Adopted: enrichment wrapper, not threaded through query handler |
+| Simplification | `ContextWindow` type already exists at mcp_tool_types.py:218 | Adopted: import, don't redefine |
+| Edge cases | Clamp `context` at parameter boundary (1–10) | Adopted: clamped in param definition |
+| Edge cases | Use batched fetching (CHUNK=100) | Adopted: reuse `_get_messages_by_ids_batched` |
+| Edge cases | Propagate `FloodWaitError` with wait duration | Adopted: include in warning message |
+| Edge cases | Validate `chat_id` required when `context > 0` | Adopted: validation in `_build_search_params` |
+| Edge cases | Default `include_reply_threads` to `False` | Adopted: opt-in to avoid surprising latency |
+| Edge cases | Add timeout budget (30s) | Adopted: enrichment phase timeout |
+
+## References
+
+- Slack `assistant.search.context` API
+- Anthropic contextual retrieval research
+- PIXION sentence-window retrieval
+- `src/tools/search/search_generators.py` — search implementation
+- `src/tools/search/search_mode.py` — search orchestration
+- `src/tools/search/replies.py` — `_fetch_direct_replies` for reply thread enrichment
+- `src/tools/search/forum_replies.py` — forum-specific reply handling

--- a/docs/adr/0011-context-enrichment-review.md
+++ b/docs/adr/0011-context-enrichment-review.md
@@ -1,0 +1,162 @@
+# ADR 0011 — Context Enrichment: Edge Cases & Failure Mode Review
+
+**Reviewer:** MiMo sub-agent  
+**Date:** 2026-06-26  
+**Status:** Thorough review of `docs/adr/0011-context-enrichment-for-search.md` against implementation in `src/tools/search/` and `src/server_components/`.
+
+---
+
+## Summary
+
+The ADR proposes a sound high-level design but has **3 critical gaps**, **5 warnings**, and **3 nitpicks** that would cause production failures or degraded behavior. The most severe issues are: (1) forum topic context windows spanning unrelated topics, (2) unbounded reply thread fetches, and (3) no partial-failure resilience in the enrichment pipeline.
+
+---
+
+## Findings
+
+### 1. Deleted / missing neighbor messages
+
+**[EDGE CASE]** When the batch-fetch in step 4 (`client.get_messages(entity, ids=all_ids)`) includes IDs for deleted or inaccessible messages, Telethon returns `None` in that slot of the result list. The ADR says "build `context_before[context]` and `context_after[context]` from fetched neighbors" but does not mention filtering `None` values from the batch response or building a lookup dict keyed only on valid messages. — **severity: warning** — **Suggested mitigation:** Build a `dict[int, Message]` from the batch result, skipping `None` entries. When assembling context_before/after, skip IDs not in the lookup dict. This pattern already exists in `forum_replies.py::_get_messages_by_ids_batched` (`messages.extend(message for message in loaded if message)`) and `reading.py::_find_message_by_id`, so reuse or mirror it.
+
+---
+
+### 2. reply_to_msg_id pointing to a different chat
+
+**[COVERED]** In Telegram's MTProto protocol, `reply_to_msg_id` always references a message within the same `InputPeer` (entity). Cross-chat replies do not exist — the discussion-group pattern uses a separate `GetDiscussionMessageRequest` to map channel-post IDs to discussion-group IDs, which is unrelated to `reply_to_msg_id` in search results. The batch-fetch scoped to a single `entity` is correct by design.
+
+---
+
+### 3. Context window extending beyond chat history
+
+**[EDGE CASE]** For the first or last messages in a chat, the ±N window produces IDs ≤ 0 or IDs beyond the chat's highest message. Telethon returns `None` for these. The ADR does not document this expected behavior or specify that `context_before`/`context_after` may contain fewer than `context` entries. — **severity: warning** — **Suggested mitigation:** Document in the ADR that context lists may be shorter than `context` at conversation boundaries. In the implementation, the `None`-filtering from finding #1 handles this automatically; no special logic needed beyond that.
+
+---
+
+### 4. Very long reply threads (100+ replies)
+
+**[EDGE_CASE]** The ADR specifies "Fetch reply threads: for results with `replies.replies > 0`, call `messages.getReplies`" with no per-thread cap. In Telegram, channel comment sections commonly have hundreds or thousands of replies. With 10 results (the context threshold), each having 500 replies, the response would contain ~5,000 extra message dicts — likely 2–5 MB of JSON. The "Token budget: No limit" design stance does not protect against this specific unbounded source. — **severity: critical** — **Suggested mitigation:** Add a configurable `reply_thread_limit` parameter (default e.g. 10–20). The ADR already acknowledges "Configurable reply thread limit" as deferred; it should be promoted to the initial implementation. At minimum, add a hardcoded safety cap (e.g. 50) even if not user-configurable.
+
+---
+
+### 5. Forum topic service messages as only available context
+
+**[EDGE_CASE]** The ADR's filter rule is: "reply_to.forum_topic=True + no displayable text = skip." However, `message_has_displayable_content()` in `message_format.py` returns `True` for any message with a service action (via `_service_action_placeholder_text` which generates `[Service: ChatTitleChanged]` etc.). So service messages **do** pass the "has displayable content" check and would **not** be filtered by the ADR's rule as written.
+
+Concretely: a user in a forum topic might get `context_before` filled with `[Service: TopicCreated]`, `[Service: ChatTitleChanged]`, `[Service: PinMessage]` — technically displayable but not useful conversation context. — **severity: warning** — **Suggested mitigation:** Refine the filter to: skip messages where `message.action is not None` AND the message has no user-authored text (`not message.text and not message.message and not message.caption`). Alternatively, filter messages whose only "text" is a `[Service: ...]` placeholder.
+
+---
+
+### 6. Messages with no sender (anonymous, deleted user)
+
+**[COVERED]** The existing `get_sender_info()` in `message_format.py` returns `None` when `message.sender_id` is absent, and `build_message_result()` includes `"sender": null`. Context messages built through the same function inherit this behavior. Anonymous admins in groups and messages from deleted accounts will produce `sender: null` in context dicts — correct and consistent.
+
+---
+
+### 7. Context enrichment partial failures
+
+**[EDGE_CASE]** The ADR describes enrichment as a linear pipeline (steps 2→9). If any step throws, the exception propagates through `_handle_query_mode` and the **entire search result is lost** — the user gets an error instead of results-without-context. Specific failure scenarios:
+
+- **Batch fetch fails** (network error, entity inaccessible): All context lost, but search results are already collected.
+- **`getReplies` fails for one result** (e.g., message was a channel post with discussion disabled, or a FloodWaitError): All reply threads lost for remaining results too if unhandled.
+- **`getReplies` returns an RPCError** for one message (e.g., `MSG_ID_INVALID` for a just-deleted message): One failure kills all enrichment.
+
+— **severity: critical** — **Suggested mitigation:** Wrap each enrichment step in try/except. For the batch-fetch, catch the exception and return results with empty context + a `_warning` field. For individual `getReplies` calls, catch per-result and set `reply_thread: null` with an error note. This mirrors the existing pattern in `search_generators.py` (`except Exception as e: logger.warning(...); continue`).
+
+---
+
+### 8. Context window spanning forum topics
+
+**[EDGE_CASE]** In forum-enabled supergroups, all topics share a single sequential message ID space. Messages from different topics are interleaved in the ID sequence. Computing `result.id ± N` produces neighbor IDs that may belong to **entirely different topics** with unrelated conversations.
+
+Example: Message 500 is in "General" topic. Message 499 is in "Off-Topic" topic. Message 501 is in "General". With `context=2`, the context_before for message 501 includes message 499 from "Off-Topic" — a completely unrelated conversation.
+
+This is a **fundamental design issue** for forum groups. The ADR does not mention topic-aware context filtering. — **severity: critical** — **Suggested mitigation:** After fetching neighbors, filter context_before/after to only include messages that share the same `reply_to.reply_to_top_id` (topic root) as the result message. For non-forum chats, no filtering is needed. The existing `_extract_topic_metadata()` function provides the `topic_id` for this check. Messages without topic metadata (i.e., in the main chat timeline, not a topic) should be included when the result itself is also topic-less.
+
+---
+
+### 9. Race conditions — messages deleted between search and enrichment
+
+**[EDGE_CASE]** TOCTOU window between step 1 (search returns result IDs) and step 4 (batch-fetch those IDs + neighbors). If a message is deleted in that window:
+
+- **Result message deleted:** Already in the collected list; the batch-fetch returns `None` for it. Neighbor context still works (the result's ID is still valid for computing neighbor ranges). But `getReplies` for the deleted message would return empty or error.
+- **Neighbor message deleted:** Returns `None` in batch; handled by #1.
+- **Reply target deleted:** Returns `None` in batch; `reply_to_message` would be `None`. The ADR says `reply_to_message: dict | None`, so this is fine structurally.
+
+— **severity: warning** — **Suggested mitigation:** Same as #7 — per-step try/except with graceful degradation. Additionally, after building the batch-fetch lookup dict, check that each result's `reply_to_msg_id` is present; if not, set `reply_to_message: null` instead of crashing.
+
+---
+
+### 10. Rate limiting — FloodWaitError from enrichment API calls
+
+**[EDGE_CASE]** The ADR's cost analysis counts API calls but does not address Telegram rate limits. The enrichment pipeline makes:
+
+| Call | Count | Rate-limit risk |
+|------|-------|-----------------|
+| `getMessages(ids=...)` | 1 | Low (single batched call) |
+| `getReplies` per result | Up to 10 | **High** — each is a separate RPC call |
+
+For 10 results in an active group, 10 sequential `getReplies` calls can easily trigger a `FloodWaitError`. The existing codebase handles `FloodWaitError` in `message_format.py` (voice transcription) and `contact_search.py`, but the enrichment path (which doesn't exist yet) has no such handling.
+
+— **severity: warning** — **Suggested mitigation:** (1) Wrap `getReplies` calls in try/except for `FloodWaitError`; on catch, skip the reply thread for that result and log a warning. (2) Consider parallelizing `getReplies` with `asyncio.gather(return_exceptions=True)` to reduce wall-clock time. (3) Add an exponential backoff or at minimum respect the `FloodWaitError.seconds` value before retrying (or not retrying at all for enrichment — just skip).
+
+---
+
+### 11. No deduplication of neighbor IDs before batch fetch
+
+**[EDGE_CASE]** When search results are close together (e.g., messages 100 and 102 with `context=3`), their ±N windows overlap: 97–103 and 99–105. The combined `all_ids` list contains duplicates (99, 100, 101, 102, 103 appear twice). While Telethon's `get_messages(ids=...)` handles duplicates without error, it wastes API bandwidth and processing. — **severity: nitpick** — **Suggested mitigation:** Deduplicate `all_ids` using a `set()` before the batch fetch. The response may still contain duplicates at the Telethon level (it returns one result per requested ID), so build the lookup dict as `{msg.id: msg for msg in fetched if msg}`.
+
+---
+
+### 12. No validation on `context` parameter value
+
+**[EDGE_CASE]** The ADR specifies `context: int` with no stated bounds. Potential values:
+- `context < 0`: Should be an error or treated as 0.
+- `context = 0`: Disabled (correct).
+- `context = 1000`: Extreme window — 10 results × 2001 IDs = 20,010 messages to fetch, plus 10 `getReplies` calls. Would almost certainly hit API limits and produce an unusably large response.
+
+— **severity: warning** — **Suggested mitigation:** Validate `context` in the range `[0, max_context]` where `max_context` is a reasonable constant (e.g., 10 or 20). Return an error for out-of-range values. The existing `ContextWindow` Annotated type in `mcp_tool_types.py` should add `ge=0, le=20` constraints.
+
+---
+
+### 13. Reply thread fetches are sequential, not parallelized
+
+**[EDGE_CASE]** The ADR says "1 getReplies per result" but does not specify whether these run sequentially or in parallel. For 10 results, sequential execution means O(10 × latency) for the reply-thread step alone. With typical Telegram API latency of 200–500ms, that's 2–5 seconds of additional wait. — **severity: nitpick** — **Suggested mitigation:** Use `asyncio.gather(*[getReplies(r) for r in results_with_replies], return_exceptions=True)` to parallelize reply-thread fetches. This matches the existing pattern in `_collect_messages_global` which parallelizes `SearchGlobalRequest` calls.
+
+---
+
+### 14. Context messages' output format not specified
+
+**[EDGE_CASE]** The ADR says context messages are attached as `context_before: list[dict]` and `context_after: list[dict]` but does not specify which fields each dict contains. If built through `build_message_result()`, each context message includes links, media placeholders, forward info, reply markup — expensive to compute (link generation requires `generate_telegram_links`) and expensive to serialize.
+
+For 10 results × 7 context messages (context=3) = 70 extra fully-enriched message dicts. — **severity: warning** — **Suggested mitigation:** Define a lightweight context message format: `{id, date, text, sender}` only. Skip link generation, media placeholders, and forward info for context messages. This dramatically reduces token count while preserving conversational understanding. Include a `_context_summary` field noting the lightweight format. Alternatively, make full vs. light context configurable.
+
+---
+
+## Summary Table
+
+| # | Finding | Type | Severity |
+|---|---------|------|----------|
+| 1 | Deleted/missing neighbor messages need `None` filtering | EDGE CASE | warning |
+| 2 | Cross-chat reply_to_msg_id | COVERED | — |
+| 3 | Window beyond history bounds → short context lists | EDGE CASE | warning |
+| 4 | Unbounded reply thread size | EDGE CASE | **critical** |
+| 5 | Service message filter logic mismatch with `message_has_displayable_content` | EDGE CASE | warning |
+| 6 | Sender-less messages | COVERED | — |
+| 7 | No partial-failure resilience in enrichment pipeline | EDGE CASE | **critical** |
+| 8 | Context window spans unrelated forum topics | EDGE CASE | **critical** |
+| 9 | TOCTOU race between search and enrichment | EDGE CASE | warning |
+| 10 | FloodWaitError from sequential getReplies calls | EDGE CASE | warning |
+| 11 | Duplicate neighbor IDs in batch fetch | EDGE CASE | nitpick |
+| 12 | No bounds validation on `context` parameter | EDGE CASE | warning |
+| 13 | Reply thread fetches not parallelized | EDGE CASE | nitpick |
+| 14 | Context message format unspecified (token-heavy vs. lightweight) | EDGE CASE | warning |
+
+---
+
+## Recommendations for ADR revision
+
+1. **Promote reply thread limit from deferred to initial** — even a hardcoded cap of 20 replies per thread prevents catastrophic token explosion.
+2. **Add forum-topic-aware neighbor filtering** — the most architecturally significant gap. Without this, context enrichment in forum groups actively harms signal-to-noise ratio.
+3. **Add a partial-failure design section** — enrichment must be fire-and-forget: search results are the primary deliverable; context is best-effort.
+4. **Specify the context message format** — decide between full and lightweight dicts; document the choice.
+5. **Add `FloodWaitError` handling** to the implementation plan, not just as an afterthought.

--- a/docs/adr/0011-review-findings.md
+++ b/docs/adr/0011-review-findings.md
@@ -1,0 +1,247 @@
+# Design Review: ADR 0011 — Context Enrichment for Message Search Results
+
+**Reviewer:** MiMo (automated review)
+**Date:** 2026-06-26
+**ADR:** `docs/adr/0011-context-enrichment-for-search.md`
+**Source reviewed:**
+- `src/tools/search/search_mode.py` — search orchestration
+- `src/tools/search/results.py` — result building
+- `src/tools/search/replies.py` — reply handling
+- `src/tools/search/forum_replies.py` — forum reply logic
+- `src/tools/search/core.py` — mode dispatch
+- `src/server_components/tools_register.py` — MCP tool surface
+- `src/utils/message_format.py` — message formatting & displayability checks
+- `src/tools/search/types.py` — constants and types
+
+---
+
+## Finding 1 — Chat boundary: no before/after messages
+
+**Question:** What happens when a search result is at the beginning/end of a chat?
+
+**Severity:** ⚠️ nitpick — likely handled, but ADR should state it explicitly
+
+**Analysis:** The ADR says to compute `result.id ± context` window and batch-fetch all IDs. When a message is at a chat boundary (e.g., ID=5 with context=3 → requesting IDs 2,3,4,6,7,8 where only 5-8 exist), `client.get_messages(entity, ids=[...])` returns `None` for non-existent IDs. The existing `_build_result_for_message` in `results.py` (line 13-14: `if not message: return None`) already filters these out. The `context_before`/`context_after` lists will simply be shorter than the requested window size.
+
+**Recommendation:** Add a sentence to the Implementation section: *"Non-existent neighbor IDs (at chat boundaries) are naturally excluded — `client.get_messages` returns None for missing IDs, and the result builder filters them. `context_before`/`context_after` may be shorter than the requested window."*
+
+---
+
+## Finding 2 — `reply_to_msg_id` points to a deleted message
+
+**Question:** What happens when the message being replied to has been deleted?
+
+**Severity:** 🔴 critical — missing from ADR
+
+**Analysis:** The ADR says (step 6): *"For each result with `reply_to_msg_id`, attach `reply_to_message` from fetched messages."* But if the replied-to message is deleted, `client.get_messages(entity, ids=[deleted_id])` returns `None`. The ADR does not specify what `reply_to_message` should be in this case.
+
+Two sub-concerns:
+1. **Null handling:** The ADR's schema says `reply_to_message: dict | None`. This is correct — it should be `None` when the original message is deleted. But the implementation plan should explicitly say: *"If the batch fetch returns None for a `reply_to_msg_id`, set `reply_to_message = None` (message deleted or inaccessible)."*
+2. **Distinguishing deleted vs. not-yet-fetched:** There's a subtle risk that a caller conflates "context enrichment was disabled" (`reply_to_message` field absent from the response entirely) with "the replied-to message was deleted" (`reply_to_message: null` present). The ADR should mandate: when `context > 0`, the field `reply_to_message` is **always present** (as `null` or a dict), so its presence signals enrichment was attempted.
+
+**Recommendation:** Add explicit handling note and mandate that `reply_to_message` presence/absence distinguishes "enrichment off" from "deleted message."
+
+---
+
+## Finding 3 — Reply thread with hundreds of replies
+
+**Question:** What happens when `replies.replies` is 500?
+
+**Severity:** 🔴 critical — unbounded data growth
+
+**Analysis:** The ADR says (step 7): *"For each result with `replies.replies > 0`, call `messages.getReplies`."* The ADR's Design Choices table says *"Reply threads: Always included (no opt-in flag)"* and *"Token budget: No limit."*
+
+`messages.getReplies` is a per-result Telegram API call that can return hundreds of messages. Consider:
+- 10 search results at the context threshold (max), each with 200 replies → 10 × 200 = **2,000 extra messages** in the response, plus neighbor context.
+- `client.iter_messages(entity, reply_to=msg_id)` (used by `_fetch_direct_replies` in `replies.py` line 109-138) has a `limit` parameter. But the ADR does not specify a limit for `reply_thread`.
+
+Additionally, `messages.getReplies` (the raw Telethon method) is **per-result**, not batched. The ADR's cost table acknowledges this: "1 `getReplies` per result — Expensive — per-result calls." But it doesn't propose a mitigation.
+
+**Recommendation:**
+1. Add a configurable `reply_thread_limit` (default e.g., 10-20) to cap reply thread size per message. This is critical to prevent token explosion.
+2. Consider making reply threads opt-in (a boolean `include_reply_threads: bool = False`) rather than always-on, or at minimum make the limit explicit in the schema.
+3. The "Token budget: No limit" decision is risky. Even without a hard token cap, a soft cap on `reply_thread` count is necessary for API-call and response-size sanity.
+
+---
+
+## Finding 4 — Partial failure during context enrichment
+
+**Question:** What happens when some messages fetch successfully and some don't?
+
+**Severity:** 🟡 warning — not addressed in ADR
+
+**Analysis:** The ADR describes a clean happy path but doesn't address failure modes for context enrichment:
+
+1. **Batch fetch of neighbors/reply_to messages (step 4):** If `client.get_messages(entity, ids=all_ids)` throws a `FloodWaitError` or network error, the entire enrichment fails. The ADR should mandate **graceful degradation**: if the batch fetch fails, return the original results without context fields, with a warning.
+
+2. **Reply thread fetch (step 7):** `messages.getReplies` is a per-result call. If it fails for message #3 out of 10, should we:
+   - Skip reply_thread for just that message (partial success)?
+   - Abort all reply threads?
+   - Abort all enrichment?
+
+   The ADR should specify: individual `getReplies` failures produce `reply_thread: []` (empty) for that message with a logged warning, while other messages proceed normally.
+
+3. **Rate limiting:** Multiple `getReplies` calls in sequence risk Telegram's `FloodWaitError`. The existing codebase already handles this (e.g., the transcription cache in `message_format.py`). The ADR should mention that reply thread fetching should respect rate limits and possibly serialize with backoff.
+
+**Recommendation:** Add a "Failure handling" section: neighbor/reply_to batch failures → graceful degradation (return results without context); individual `getReplies` failures → empty `reply_thread` for that message + warning; rate limiting → respect FloodWaitError with backoff.
+
+---
+
+## Finding 5 — Is post-processing in `_handle_query_mode` the right place?
+
+**Question:** Should enrichment live in `_handle_query_mode` or elsewhere?
+
+**Severity:** ⚠️ nitpick — correct placement, but could be cleaner as a separate function
+
+**Analysis:** `_handle_query_mode` in `search_mode.py` is the correct location because:
+- It handles both query search and browse mode (no query + chat_id) — both should get context enrichment.
+- It has access to the `client`, `entity` (via chat_id), and the collected result window.
+- It runs after results are collected but before the response is returned (line 210+ in search_mode.py).
+
+However, `_handle_query_mode` is already ~150 lines with complex control flow (global vs. chat search, error handling, date validation, etc.). Adding 60-100 lines of enrichment logic directly would make it harder to maintain.
+
+**Recommendation:** Extract context enrichment into a separate `async def _enrich_with_context(window, client, entity, context_size)` function called from `_handle_query_mode`. This keeps the function focused and testable. The ADR's code changes section already lists `search_mode.py` as the target, but should specify the extraction pattern.
+
+---
+
+## Finding 6 — Should context enrichment work for browse mode (no query)?
+
+**Question:** Browse mode = `chat_id` without `query` (fetch latest messages). Should it get context?
+
+**Severity:** 🟢 info — ADR correctly includes it, but could be more explicit
+
+**Analysis:** Looking at `_handle_query_mode` (search_mode.py), when `chat_id` is set and `query` is empty/None, the code falls through to `_collect_messages_in_chat` with `queries = [""]`, which effectively does a browse (latest messages). The ADR says context *"applies to search/browse mode (query + chat_id)"* — but the parenthetical "(query + chat_id)" is misleading because browse mode has **no query**. The actual intent (context works for any `_handle_query_mode` call) is correct.
+
+Browse mode would benefit from context because the user might be viewing recent messages and want to understand conversation flow.
+
+**Recommendation:** Clarify the ADR language to: *"Only applies to SEARCH mode (chat_id with or without query); ignored for MESSAGE_IDS and REPLIES modes."* The existing code path handles this correctly — no functional change needed.
+
+---
+
+## Finding 7 — Context threshold of 10: too aggressive or too lenient?
+
+**Question:** Is automatically disabling context when results > 10 the right trade-off?
+
+**Severity:** 🟡 warning — reasonable default but should be overridable
+
+**Analysis:** Let's do the math:
+
+| Results | Context | Neighbors fetched | Reply_to fetched | Reply threads | Total extra API calls |
+|---------|---------|-------------------|------------------|---------------|-----------------------|
+| 5       | 3       | 1 batched         | 1 batched        | ≤5 getReplies | ≤7                   |
+| 10      | 3       | 1 batched         | 1 batched        | ≤10 getReplies| ≤12                  |
+| 10      | 5       | 1 batched         | 1 batched        | ≤10 getReplies| ≤12                  |
+| 20      | 3       | 1 batched         | 1 batched        | ≤20 getReplies| ≤22                  |
+| 50      | 3       | 1 batched         | 1 batched        | ≤50 getReplies| ≤52                  |
+
+The neighbor and reply_to fetches are batched (cheap), so the real cost driver is per-result `getReplies` calls. At 10 results, that's up to 10 extra API calls — significant but manageable. At 20, it's 20 — still within reason for a thorough search.
+
+However:
+- The threshold is **hardcoded and non-overridable**. A user who explicitly wants context on 15 results gets nothing.
+- The "N results > 10" message suggests narrowing the query, which is a UX workaround, not a fix.
+- With `limit=50` (the default in `tools_register.py`), most non-trivial searches will exceed 10 results, making context enrichment almost never activate for the default case.
+
+**Recommendation:**
+1. Make the threshold configurable with a sensible default (e.g., `context_max_results: int = 15`), or
+2. Keep the hard threshold but allow the user to override it via an explicit `force_context: bool = False` parameter, or
+3. Only disable reply thread fetching above the threshold (neighbors and reply_to are cheap and should always work).
+4. Consider: at minimum, the response should still include `reply_to_message` even when the threshold kicks in, since that's a single batched call regardless of result count.
+
+---
+
+## Finding 8 — Global search context enrichment (no chat_id)
+
+**Question:** Should context enrichment work for global search?
+
+**Severity:** 🟢 info — correctly deferred
+
+**Analysis:** Global search returns results from multiple chats. Context enrichment would require:
+1. Grouping results by `chat_id`.
+2. Running per-chat batch fetches for neighbors (can't batch across chats).
+3. Potentially resolving chat entities for each result (already done in `_process_raw_message`).
+
+This is a non-trivial architectural extension. The ADR correctly defers it.
+
+One concern: the ADR's `_handle_query_mode` handles both per-chat and global search. If context enrichment is added as post-processing in `_handle_query_mode`, it needs to detect whether this is a global search and skip enrichment. The ADR should mention this guard: *"Context enrichment is skipped when `chat_id is None` (global search)."*
+
+**Recommendation:** Add a guard clause note in the Implementation section. No functional change needed for the current proposal.
+
+---
+
+## Finding 9 — Forum topic filtering: "service message with no displayable text"
+
+**Question:** What exactly gets filtered? Is the condition correct?
+
+**Severity:** 🟡 warning — condition may be too broad or self-contradictory
+
+**Analysis:** The ADR says: *"Filter service messages: `reply_to.forum_topic=True` + no displayable text = skip."*
+
+Looking at `message_has_displayable_content` in `message_format.py` (line 79-87):
+```python
+def message_has_displayable_content(message):
+    if (getattr(message, "text", None) or getattr(message, "message", None) 
+            or getattr(message, "caption", None)):
+        return True
+    if _has_any_media(message):
+        return True
+    return _service_action_placeholder_text(message) is not None
+```
+
+And `_service_action_placeholder_text` (line 11-20) returns a placeholder like `"[Service: ChatTitle]"` for **any** message with an `action` field.
+
+So a service message **always** has "displayable content" (the placeholder text). The condition "forum_topic=True + no displayable text" would **never** be true for service messages, because the service placeholder always counts as displayable.
+
+The intent is likely to filter **forum topic creation stubs** or other structural messages that are technically messages but not useful context. Two interpretations:
+1. Filter messages where `reply_to.forum_topic=True` and the message is a "structural" topic marker (e.g., the topic creation message with only a service action and no real conversation content).
+2. Filter messages that are empty (no text/media/service) in forum contexts — but these don't exist in Telegram's data model.
+
+The actual risk: **the filter never fires**, so forum topic service messages appear as context neighbors and add noise. This is a minor UX issue (a `[Service: TopicCreated]` message in context_before isn't harmful, just unhelpful).
+
+**Recommendation:** Clarify the filtering intent:
+- If the goal is to exclude **service actions** (title changes, pins, etc.) from context, the condition should be: `reply_to.forum_topic=True` and `_service_action_placeholder_text(message) is not None` (i.e., it IS a service message).
+- If the goal is to exclude **empty/structural** messages, the condition should be: `not message.text and not message.message and not message.caption and not _has_any_media(message)` — i.e., messages with only a service placeholder.
+- Either way, the ADR should use the existing `message_has_displayable_content` and/or `_service_action_placeholder_text` functions explicitly rather than describing a condition that doesn't match the implementation.
+
+---
+
+## Finding 10 — Circular reply chains (A→B→A)
+
+**Question:** Can we get infinite loops when following reply chains?
+
+**Severity:** 🟢 info — correctly mitigated by "one level only"
+
+**Analysis:** The ADR states: *"Reply chain depth: One level only."* This means for each search result, we only follow `reply_to_msg_id` once. If message A replies to B, and B replies to A, we:
+1. Start at A, see `reply_to_msg_id = B`.
+2. Fetch B (one level).
+3. **Stop** — we don't follow B's `reply_to_msg_id` back to A.
+
+This is correct. No circular dependency risk.
+
+However, the ADR says step 6 is: *"For each result with `reply_to_msg_id`, attach `reply_to_message` from fetched messages."* It's unclear whether the **fetched reply_to_message itself** should also get its own `reply_to_message` nested inside. If the schema is flat (each result has `reply_to_message: dict` but that dict doesn't itself have a `reply_to_message` sub-field), then there's no recursion risk. If the schema allows nesting, we need a depth marker.
+
+Looking at the proposed schema: `reply_to_message: dict | None | "The message this one replies to (one level)"`. The dict would be built using `build_message_result`, which does include `reply_to_msg_id` as a field. But the context enrichment step wouldn't recursively enrich the nested dict — it would just build it from the raw Telethon message. So the nested `reply_to_message` would just be a plain message dict, not further enriched. This is safe.
+
+**Recommendation:** No change needed. Just confirm in the ADR that `reply_to_message` is built using the existing `build_message_result` (which includes `reply_to_msg_id` but not a nested `reply_to_message` field).
+
+---
+
+## Summary
+
+| # | Issue | Severity | Action |
+|---|-------|----------|--------|
+| 1 | Chat boundary handling | nitpick | Document explicitly |
+| 2 | Deleted reply_to message | **critical** | Add null-handling note + presence/absence semantics |
+| 3 | Unbounded reply threads | **critical** | Add `reply_thread_limit` or make reply threads opt-in |
+| 4 | Partial enrichment failure | **warning** | Add graceful degradation section |
+| 5 | Placement in `_handle_query_mode` | nitpick | Extract to helper function |
+| 6 | Browse mode context | info | Clarify language (already works correctly) |
+| 7 | Threshold of 10 is non-overridable | **warning** | Make configurable or partially override for cheap operations |
+| 8 | Global search guard | info | Add guard clause note |
+| 9 | Forum topic filter condition is self-contradictory | **warning** | Fix the condition to match intent |
+| 10 | Circular reply chains | info | Correctly mitigated, no action needed |
+
+### Blocking issues before approval
+
+1. **Finding 3** (reply thread size) must be addressed — add a limit.
+2. **Finding 2** (deleted reply_to) must be specified explicitly.
+3. **Finding 9** (forum filter) should be corrected to match the implementation reality.

--- a/docs/adr/0011-review.md
+++ b/docs/adr/0011-review.md
@@ -1,0 +1,179 @@
+# ADR-0011 Design Review: Context Enrichment for Search Results
+
+**Reviewer:** MiMo (ADR review sub-agent)
+**Date:** 2026-06-26
+**Status:** Found issues requiring revision before implementation
+
+---
+
+## Finding 1 — Neighbor fetching strategy is fundamentally broken for non-contiguous IDs
+
+**Severity:** ⚠️ **Warning**
+
+The ADR's implementation step 2 says:
+
+> Collect all neighbor IDs: for each result, compute `result.id ± context` window
+
+This assumes Telegram message IDs are contiguous within a chat. They are not. Deleted messages, service messages, and Telegram-internal allocations create gaps. If message ID 100 exists and IDs 97–99 were deleted, computing `100 - 3` and fetching IDs {97, 98, 99} will return 0 useful neighbors — not 3 preceding messages.
+
+The codebase already uses the correct pattern everywhere: `client.iter_messages(entity, offset_id=N, limit=K)` which returns the K most recent messages *positionally* before offset_id, respecting actual message order. See `search_generators.py:50–54`, `replies.py:120–122`, and `forum_replies.py:114–117`.
+
+**Recommendation:** Replace `id ± context` arithmetic with:
+```python
+# "Before" context:
+before = await client.get_messages(entity, offset_id=result.id, limit=context)
+# "After" context (reverse=False from oldest to newest):
+after = await client.get_messages(entity, offset_id=result.id + 1, limit=context, reverse=True)
+```
+The batch-optimization in step 4 ("one batched `getMessages` call") then becomes per-entity `iter_messages` calls — still batchable across results in the same chat, but not a single `get_messages(ids=...)` call.
+
+---
+
+## Finding 2 — No reply thread size cap; "always include" is unbounded
+
+**Severity:** 🔴 **Critical**
+
+ADR design choice:
+
+> Reply threads: Always included (no opt-in flag)
+
+Combined with:
+
+> Token budget: No limit
+
+This means a search result from a viral announcement channel could have 500+ replies. If 5 of 50 results are popular posts, the response would balloon to thousands of context messages, crushing both the Telegram API latency and the LLM's token window.
+
+The cost analysis table notes "1 `getReplies` per result — Expensive" but doesn't quantify the data volume risk. A single `messages.getReplies` call can return up to ~100 messages per page, and threads with thousands of replies require pagination.
+
+**Recommendation:** Add a `reply_limit` parameter (int, default ~10) to cap how many reply thread messages are returned per result. Document that this is per-result, not total. This is a minimal change that prevents catastrophic responses without losing the "always include" intent.
+
+---
+
+## Finding 3 — Reply thread fetching is N serial API calls (performance cliff)
+
+**Severity:** 🔴 **Critical**
+
+Step 7 says:
+
+> Fetch reply threads: for results with `replies.replies > 0`, call `messages.getReplies`
+
+For a result set of 50 messages, if 30 have replies, this is 30 sequential `getReplies` calls. At ~200ms each (optimistic), that's ~6 seconds of added latency — before accounting for rate limits or Telegram server slowness.
+
+The codebase handles analogous patterns by parallelizing: `_collect_messages_global` uses `asyncio.gather` with semaphore-bounded concurrency (`search_mode.py:263–266`). The ADR doesn't mention parallelization at all.
+
+**Recommendation:** Parallelize reply thread fetches using `asyncio.gather` (or `asyncio.TaskGroup` for Python 3.11+), bounded by a semaphore. The existing `_DEFAULT_MAX_CONCURRENT = 2` pattern is a good model. With parallelism and a `reply_limit`, 30 threads could complete in ~1–2s instead of ~6s.
+
+---
+
+## Finding 4 — Global search cross-chat enrichment is silently broken
+
+**Severity:** 🔴 **Critical**
+
+The implementation steps describe a single batched `client.get_messages(entity, ids=all_ids)` call (step 4). But global search (`chat_id=None`) returns results from multiple chats. `get_messages` requires a single entity — you cannot batch IDs from different chats into one call.
+
+The ADR defers "Global search context enrichment (requires cross-chat neighbor fetching)" in the Consequences section, but the implementation steps (1–9) don't mention this restriction. An implementer reading steps 1–9 would attempt to batch-fetch neighbors across chats and hit runtime errors.
+
+**Recommendation:** Either:
+- (a) Add an explicit guard: "When `chat_id is None`, context enrichment is skipped. Document this in the parameter description."
+- (b) Add a grouping step: group results by `chat_id`, then batch-fetch per group. This is more work but makes global search enrichment functional.
+
+Option (a) is simpler and matches the "deferred" note. Either way, the implementation steps must mention the constraint.
+
+---
+
+## Finding 5 — Deleted reply target silently produces `None`
+
+**Severity:** ⚠️ **Warning**
+
+Step 6 says:
+
+> For each result with `reply_to_msg_id`, attach `reply_to_message` from fetched messages
+
+But if the replied-to message was deleted, the batch fetch returns `None` for that ID. The ADR doesn't specify:
+- Whether `reply_to_message` should be `None` (intuitive) or omitted entirely
+- Whether to include `reply_to_msg_id: <id>` alongside `reply_to_message: null` so the consumer knows *which* message was deleted
+
+The existing code in `build_message_result` (`message_format.py:557–561`) includes `reply_to_msg_id` as an int field unconditionally when present. The enrichment should follow the same pattern: always include `reply_to_msg_id` in the result, set `reply_to_message` to `None` when the target is missing/deleted.
+
+**Recommendation:** Add explicit handling: `reply_to_message = fetched.get(reply_to_msg_id)` where `fetched` is a dict built from the batch. Missing keys produce `None` naturally.
+
+---
+
+## Finding 6 — `context=0` must truly omit enrichment keys from response
+
+**Severity:** ⚠️ **Warning**
+
+The ADR says:
+
+> `context=0` (default) = current behavior, no context fields added
+> No changes to existing result schema when context is disabled
+
+This is correct in intent, but the implementation must be careful. If the enrichment code adds `context_before`, `context_after`, `reply_to_message`, and `reply_thread` keys to every result dict *regardless* of context value, consumers will see new keys they didn't ask for.
+
+The existing codebase follows a "conditional key presence" pattern: `reply_to_msg_id` only appears when the message is a reply (`message_format.py:560–561`), `topic_id` only when applicable. The enrichment should follow the same pattern: skip the entire enrichment post-processing when `context=0`, not just set fields to empty lists.
+
+**Recommendation:** Gate the enrichment with `if context > 0:` at the call site in `_handle_query_mode`. When disabled, no enrichment code runs and no new keys appear in results.
+
+---
+
+## Finding 7 — Placing enrichment in `_handle_query_mode` is correct but needs extraction
+
+**Severity:** 💬 **Nitpick**
+
+The ADR correctly places enrichment as post-processing in `_handle_query_mode` rather than in `search_generators.py`. Rationale:
+- Generators yield individual results; enrichment needs the full result set (for batch-optimizing neighbor fetches)
+- Generators deal with raw Telethon objects; enrichment operates on result dicts
+- The function already has post-processing patterns (voice transcription at line ~190, response_attachment_warning at ~220)
+
+However, `_handle_query_mode` is already 130+ lines. Adding 60–80 lines of enrichment logic would make it unwieldy.
+
+**Recommendation:** Extract enrichment into a standalone `async def _enrich_with_context(results, client, entity, context_size)` function. Call it from `_handle_query_mode` between the result collection and response assembly.
+
+---
+
+## Finding 8 — Deduplication of neighbor IDs across overlapping windows
+
+**Severity:** 💬 **Nitpick**
+
+If search returns results at IDs 100, 102, and 105 with context=3, the neighbor sets overlap heavily (e.g., IDs 99, 101, 103 appear in multiple windows). The ADR step 2 says "collect all neighbor IDs" and step 4 says "one batched call," implying deduplication — but this is never explicitly stated.
+
+With `iter_messages`-based fetching (see Finding 1), deduplication is per-entity: you only need one `iter_messages` call per unique `(entity, offset_id)` pair. Since results in the same chat share the entity, a smart implementation would sort results by ID and compute a union of non-overlapping windows.
+
+**Recommendation:** Add a note: "Deduplicate neighbor IDs before fetching. For results in the same chat, sort by ID and merge overlapping windows."
+
+---
+
+## Finding 9 — Forum service message filter needs more specificity
+
+**Severity:** 💬 **Nitpick**
+
+ADR step 8:
+
+> Filter out forum topic service messages (`reply_to.forum_topic=True` + no displayable text)
+
+This is vague. The codebase has `message_has_displayable_content()` in `message_format.py` which already handles this filtering. The ADR should reference this existing function rather than inventing a new filter criterion.
+
+Also, this filter applies to which messages?
+- Neighbor context messages? (Probably yes — service messages in context are noise)
+- Reply thread messages? (Possibly — depends on use case)
+- Reply-to message? (No — the message you're replying to should always be shown)
+
+**Recommendation:** Specify that the filter applies to context_before/context_after and reply_thread messages, using the existing `message_has_displayable_content()` function. The reply_to_message should be exempt (show it even if it's a service message, so the consumer knows the reply target exists).
+
+---
+
+## Summary
+
+| # | Finding | Severity | Action |
+|---|---------|----------|--------|
+| 1 | ID ± context is wrong; use iter_messages | ⚠️ Warning | Fix before implementation |
+| 2 | No reply thread size cap | 🔴 Critical | Add `reply_limit` param |
+| 3 | N serial getReplies calls | 🔴 Critical | Parallelize with semaphore |
+| 4 | Global search cross-chat batching | 🔴 Critical | Add explicit guard or grouping |
+| 5 | Deleted reply target → None handling | ⚠️ Warning | Document None semantics |
+| 6 | context=0 must omit enrichment keys | ⚠️ Warning | Gate with `if context > 0` |
+| 7 | Extract enrichment from _handle_query_mode | 💬 Nitpick | Separate function |
+| 8 | Dedup neighbor IDs across windows | 💬 Nitpick | Add dedup note |
+| 9 | Forum filter scope and function reference | 💬 Nitpick | Reference existing helper |
+
+**Verdict:** The ADR's high-level design (post-processing enrichment, new fields, backward compat) is sound. The implementation steps need revision: findings 1–4 are blocking issues that would cause incorrect behavior or production failures if implemented as written. The fix for each is straightforward; the overall architecture doesn't need to change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ Concise records of significant technical decisions for fast-mcp-telegram.
 | [0008](0008-auth-telemetry-events.md) | Auth Telemetry Events — Buffered flow-level auth instrumentation | accepted (2026-06-19) |
 | [0009](0009-s3-session-storage.md) | S3 Session Storage for Ephemeral Deployments | proposed (2026-06-17) |
 | [0010](0010-north-star-pivot.md) | North Star Pivot — Best Telegram Bridge for AI Agents | accepted (2026-06-15) |
+| [0011](0011-context-enrichment-for-search.md) | Context Enrichment for Message Search Results | proposed (2026-06-26) |

--- a/src/server_components/mcp_tool_types.py
+++ b/src/server_components/mcp_tool_types.py
@@ -218,12 +218,14 @@ FromUser = Annotated[
 ContextWindow = Annotated[
     int,
     Field(
+        ge=0,
+        le=10,
         description=(
             "Number of surrounding messages to include as context for each search result. "
             "0 = disabled (default). 1–10 = include N messages before and N after each result. "
             "Also fetches the message being replied to and top replies (if include_reply_threads=true). "
             "Requires chat_id. Disabled when result count exceeds cost-based caps."
-        )
+        ),
     ),
 ]
 

--- a/src/server_components/mcp_tool_types.py
+++ b/src/server_components/mcp_tool_types.py
@@ -215,6 +215,28 @@ FromUser = Annotated[
     ),
 ]
 
+ContextWindow = Annotated[
+    int,
+    Field(
+        description=(
+            "Number of surrounding messages to include as context for each search result. "
+            "0 = disabled (default). 1–10 = include N messages before and N after each result. "
+            "Also fetches the message being replied to and top replies (if include_reply_threads=true). "
+            "Requires chat_id. Disabled when result count exceeds cost-based caps."
+        )
+    ),
+]
+
+IncludeReplyThreads = Annotated[
+    bool,
+    Field(
+        description=(
+            "If true, fetch up to 5 direct replies per search result and attach as reply_thread. "
+            "Each result costs one API call (not batchable). Default: false."
+        )
+    ),
+]
+
 FilterParam = Annotated[
     str,
     Field(

--- a/src/server_components/tools_register.py
+++ b/src/server_components/tools_register.py
@@ -19,9 +19,11 @@ from src.server_components.mcp_tool_types import (
     ChatTypeComma,
     ContactFirstName,
     ContactLastName,
+    ContextWindow,
     FilesListParam,
     FilterParam,
     FromUser,
+    IncludeReplyThreads,
     IncludeTotalCount,
     LimitChats,
     LimitMessages,
@@ -87,6 +89,8 @@ _DESC_GET_MESSAGES = _tool_description(
     "Read or search messages in one chat: browse latest, search text, fetch by ids, "
     "or load replies to a message (comments, forum topics, threads). "
     "Use from_user to filter by sender (server-side, per-chat only). "
+    "Use context to include neighboring messages and reply chains around each result. "
+    "Use include_reply_threads to fetch up to 5 direct replies per result. "
     "Do not combine message_ids with query or reply_to_id. "
     "Success: messages, has_more, optional total_count and discussion fields. "
 )
@@ -285,6 +289,8 @@ def register_tools(mcp: FastMCP) -> None:
         min_date: MinDate = None,
         max_date: MaxDate = None,
         from_user: FromUser = None,
+        context: ContextWindow = 0,
+        include_reply_threads: IncludeReplyThreads = False,
         auto_expand_batches: AutoExpandBatches = 2,
         include_total_count: IncludeTotalCount = False,
     ) -> SearchResult:
@@ -302,6 +308,8 @@ def register_tools(mcp: FastMCP) -> None:
             include_total_count=include_total_count,
             thread_scope=thread_scope,
             from_user=from_user,
+            context=context,
+            include_reply_threads=include_reply_threads,
         )
 
     @mcp.tool(

--- a/src/tools/search/core.py
+++ b/src/tools/search/core.py
@@ -1,6 +1,9 @@
 """get_messages entry point and mode dispatch."""
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from src.client.connection import get_connected_client
 from src.tools.messages import read_messages_by_ids
@@ -8,7 +11,7 @@ from src.utils.entity import get_entity_by_id
 from src.utils.error_handling import log_and_build_error
 from src.utils.message_format import response_attachment_warning
 
-from .replies import _fetch_direct_replies, _handle_reply_mode
+from .replies import _handle_reply_mode
 from .search_mode import _DEFAULT_MAX_CONCURRENT, _enrich_with_context, _handle_query_mode
 from .types import MessageRetrievalMode, ThreadScope, resolve_mode
 
@@ -136,16 +139,23 @@ async def _dispatch_search_mode(
 
     # Apply context enrichment if requested and results available
     if (context > 0 or include_reply_threads) and chat_id and "messages" in result:
-        client = await get_connected_client()
-        entity = await get_entity_by_id(chat_id)
-        if entity:
-            result["messages"] = await _enrich_with_context(
-                client=client,
-                entity=entity,
-                messages=result["messages"],
-                context=context,
-                include_reply_threads=include_reply_threads,
-            )
+        try:
+            client = await get_connected_client()
+            entity = await get_entity_by_id(chat_id)
+            if entity:
+                messages, ctx_warning = await _enrich_with_context(
+                    client=client,
+                    entity=entity,
+                    messages=result["messages"],
+                    context=context,
+                    include_reply_threads=include_reply_threads,
+                )
+                result["messages"] = messages
+                if ctx_warning:
+                    existing = result.get("_warning", "")
+                    result["_warning"] = f"{existing}\n{ctx_warning}".strip()
+        except Exception as e:
+            logger.warning("Context enrichment failed, returning results without context: %s", e)
 
     return result
 

--- a/src/tools/search/core.py
+++ b/src/tools/search/core.py
@@ -2,12 +2,14 @@
 
 from typing import Any
 
+from src.client.connection import get_connected_client
 from src.tools.messages import read_messages_by_ids
+from src.utils.entity import get_entity_by_id
 from src.utils.error_handling import log_and_build_error
 from src.utils.message_format import response_attachment_warning
 
-from .replies import _handle_reply_mode
-from .search_mode import _DEFAULT_MAX_CONCURRENT, _handle_query_mode
+from .replies import _fetch_direct_replies, _handle_reply_mode
+from .search_mode import _DEFAULT_MAX_CONCURRENT, _enrich_with_context, _handle_query_mode
 from .types import MessageRetrievalMode, ThreadScope, resolve_mode
 
 
@@ -27,6 +29,8 @@ def _build_search_params(
     include_total_count: bool,
     max_concurrent: int | None = None,
     from_user: str | None = None,
+    context: int = 0,
+    include_reply_threads: bool = False,
 ) -> dict[str, Any]:
     return {
         "query": query,
@@ -43,6 +47,8 @@ def _build_search_params(
         "include_total_count": include_total_count,
         "max_concurrent": max_concurrent,
         "from_user": from_user,
+        "context": context,
+        "include_reply_threads": include_reply_threads,
         "is_global_search": chat_id is None,
         "has_query": bool(query and query.strip()),
         "has_date_filter": bool(min_date or max_date),
@@ -80,6 +86,8 @@ async def _dispatch_search_mode(
     include_total_count: bool,
     thread_scope: ThreadScope,
     from_user: str | None = None,
+    context: int = 0,
+    include_reply_threads: bool = False,
 ) -> dict[str, Any]:
     if mode is MessageRetrievalMode.MESSAGE_IDS:
         if chat_id is None or message_ids is None:
@@ -112,7 +120,7 @@ async def _dispatch_search_mode(
             max_date=max_date,
         )
 
-    return await _handle_query_mode(
+    result = await _handle_query_mode(
         query=query,
         chat_id=chat_id,
         limit=limit,
@@ -125,6 +133,21 @@ async def _dispatch_search_mode(
         params=params,
         from_user=from_user,
     )
+
+    # Apply context enrichment if requested and results available
+    if (context > 0 or include_reply_threads) and chat_id and "messages" in result:
+        client = await get_connected_client()
+        entity = await get_entity_by_id(chat_id)
+        if entity:
+            result["messages"] = await _enrich_with_context(
+                client=client,
+                entity=entity,
+                messages=result["messages"],
+                context=context,
+                include_reply_threads=include_reply_threads,
+            )
+
+    return result
 
 
 async def _handle_ids_mode(
@@ -164,6 +187,8 @@ async def search_messages_impl(
     thread_scope: ThreadScope = "auto",
     max_concurrent: int | None = _DEFAULT_MAX_CONCURRENT,
     from_user: str | None = None,
+    context: int = 0,
+    include_reply_threads: bool = False,
 ) -> dict[str, Any]:
     """
     Unified message retrieval: search, browse, read by IDs, or list replies.
@@ -192,6 +217,8 @@ async def search_messages_impl(
         include_total_count=include_total_count,
         max_concurrent=max_concurrent,
         from_user=from_user,
+        context=context,
+        include_reply_threads=include_reply_threads,
     )
 
     if thread_scope in ("full", "direct") and reply_to_id is None:
@@ -266,4 +293,6 @@ async def search_messages_impl(
         include_total_count=include_total_count,
         thread_scope=thread_scope,
         from_user=from_user,
+        context=context,
+        include_reply_threads=include_reply_threads,
     )

--- a/src/tools/search/search_mode.py
+++ b/src/tools/search/search_mode.py
@@ -2,9 +2,11 @@
 
 import asyncio
 import logging
+import time
 from datetime import datetime
 from typing import Any
 
+from telethon.errors import FloodWaitError
 from telethon.tl.functions.messages import SearchGlobalRequest
 from telethon.tl.types import InputMessagesFilterEmpty, InputPeerEmpty
 
@@ -19,17 +21,252 @@ from src.utils.entity import (
 from src.utils.error_handling import log_and_build_error, log_connection_error_response
 from src.utils.helpers import _append_dedup_until_limit
 from src.utils.message_format import (
+    message_has_displayable_content,
     response_attachment_warning,
     transcribe_voice_messages,
 )
 
 from . import results
+from .forum_replies import _get_messages_by_ids_batched
+from .replies import _fetch_direct_replies
 from .search_generators import _search_chat_messages_generator
 
 logger = logging.getLogger(__name__)
 
 # Default semaphore limits for global search parallelization
 _DEFAULT_MAX_CONCURRENT: int = 2
+
+# Context enrichment caps
+_CONTEXT_TIMEOUT_BUDGET = 30  # seconds for entire enrichment phase
+_CONTEXT_MAX_IDS = 500  # max neighbor + reply_to IDs per batch
+_CONTEXT_MAX_REPLY_FETCHES = 20  # max _fetch_direct_replies calls
+_CONTEXT_REPLY_LIMIT = 5  # max replies per result
+
+
+def _extract_topic_id_from_message(message) -> int | None:
+    """Extract topic_id from a raw Telethon message for forum scoping."""
+    reply_to = getattr(message, "reply_to", None)
+    reply_to_top_id = getattr(reply_to, "reply_to_top_id", None)
+    if reply_to_top_id:
+        return reply_to_top_id
+    forum_topic = bool(getattr(reply_to, "forum_topic", False))
+    reply_to_msg_id = getattr(reply_to, "reply_to_msg_id", None)
+    if forum_topic and reply_to_msg_id:
+        return reply_to_msg_id
+    return None
+
+
+def _is_valid_context_neighbor(
+    message, is_forum: bool, result_topic_id: int | None
+) -> bool:
+    """Check if a neighbor message is valid for context inclusion."""
+    if not message:
+        return False
+    if not message_has_displayable_content(message):
+        return False
+    if is_forum:
+        neighbor_topic = _extract_topic_id_from_message(message)
+        if result_topic_id is not None:
+            return neighbor_topic == result_topic_id
+        return neighbor_topic is None
+    return True
+
+
+def _lightweight_from_raw(message) -> dict[str, Any]:
+    """Build lightweight context dict from a raw Telethon message."""
+    full_text = (
+        getattr(message, "text", None)
+        or getattr(message, "message", None)
+        or getattr(message, "caption", None)
+    )
+    return {
+        "id": message.id,
+        "date": message.date.isoformat() if getattr(message, "date", None) else None,
+        "text": full_text,
+        "sender_id": getattr(message, "sender_id", None),
+    }
+
+
+def _lightweight_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Build lightweight context dict from a result dict."""
+    sender = result.get("sender")
+    sender_id = sender.get("id") if isinstance(sender, dict) else None
+    return {
+        "id": result.get("id"),
+        "date": result.get("date"),
+        "text": result.get("text"),
+        "sender_id": sender_id,
+    }
+
+
+def _get_reply_count(message) -> int:
+    """Get reply count from a raw Telethon message's replies attribute."""
+    if not message:
+        return 0
+    replies = getattr(message, "replies", None)
+    if not replies:
+        return 0
+    return getattr(replies, "replies", 0) or 0
+
+
+async def _enrich_with_context(
+    client,
+    entity,
+    messages: list[dict[str, Any]],
+    context: int,
+    include_reply_threads: bool = False,
+) -> list[dict[str, Any]]:
+    """Enrich search results with surrounding context and optional reply threads.
+
+    Adds a 'context' envelope to each result with:
+    - before[]: N messages before each result (lightweight format)
+    - after[]: N messages after each result (lightweight format)
+    - reply_to: the message being replied to (lightweight format, or null)
+    - replies[]: direct replies (if include_reply_threads=True, max 5)
+
+    Caps: max 500 IDs, max 20 reply thread fetches, 30s timeout budget.
+    Partial failure: returns results without context on error.
+    """
+    if not messages:
+        return messages
+
+    start_time = time.monotonic()
+    is_forum = bool(getattr(entity, "forum", False))
+
+    # Step 1: Collect all unique IDs needed
+    all_ids: set[int] = set()
+    result_ids: set[int] = set()
+    reply_to_ids: set[int] = set()
+
+    for msg in messages:
+        msg_id = msg.get("id")
+        if not msg_id:
+            continue
+        result_ids.add(msg_id)
+        for offset in range(1, context + 1):
+            all_ids.add(msg_id - offset)
+            all_ids.add(msg_id + offset)
+        rt = msg.get("reply_to_msg_id")
+        if rt:
+            reply_to_ids.add(rt)
+
+    # Include result IDs for reply count checking and reply_to for resolution
+    all_ids.update(reply_to_ids)
+    all_ids.update(result_ids)
+    all_ids.discard(0)
+
+    # Cap total IDs — prioritize reply_to and result IDs over neighbors
+    if len(all_ids) > _CONTEXT_MAX_IDS:
+        neighbor_ids = all_ids - reply_to_ids - result_ids
+        all_ids = reply_to_ids | result_ids
+        remaining = _CONTEXT_MAX_IDS - len(all_ids)
+        if remaining > 0:
+            all_ids.update(list(neighbor_ids)[:remaining])
+        logger.warning(
+            "Context enrichment: capped IDs to %d (was %d)",
+            _CONTEXT_MAX_IDS,
+            len(all_ids) + len(neighbor_ids),
+        )
+
+    # Step 2: Batch-fetch all needed messages
+    try:
+        raw_messages = await _get_messages_by_ids_batched(
+            client, entity, list(all_ids)
+        )
+    except FloodWaitError as e:
+        wait = getattr(e, "seconds", 0) or 0
+        logger.warning("Context enrichment FloodWaitError: wait %ds", wait)
+        return messages
+    except Exception as e:
+        logger.warning("Context enrichment fetch failed: %s", e)
+        return messages
+
+    fetched: dict[int, Any] = {}
+    for m in raw_messages:
+        if m:
+            fetched[m.id] = m
+
+    # Step 3: Build context envelopes
+    reply_fetch_count = 0
+
+    for msg in messages:
+        msg_id = msg.get("id")
+        if not msg_id:
+            continue
+
+        # Check timeout
+        if time.monotonic() - start_time > _CONTEXT_TIMEOUT_BUDGET:
+            logger.warning(
+                "Context enrichment: timeout budget exceeded (%.1fs), stopping",
+                time.monotonic() - start_time,
+            )
+            break
+
+        msg_topic_id = msg.get("topic_id")
+        ctx: dict[str, Any] = {}
+
+        # Before messages (most recent first → oldest last)
+        before = []
+        for offset in range(1, context + 1):
+            neighbor = fetched.get(msg_id - offset)
+            if _is_valid_context_neighbor(neighbor, is_forum, msg_topic_id):
+                before.append(_lightweight_from_raw(neighbor))
+        if before:
+            ctx["before"] = before
+
+        # After messages (oldest first → most recent last)
+        after = []
+        for offset in range(1, context + 1):
+            neighbor = fetched.get(msg_id + offset)
+            if _is_valid_context_neighbor(neighbor, is_forum, msg_topic_id):
+                after.append(_lightweight_from_raw(neighbor))
+        if after:
+            ctx["after"] = after
+
+        # Reply-to message
+        rt = msg.get("reply_to_msg_id")
+        if rt and rt in fetched:
+            ctx["reply_to"] = _lightweight_from_raw(fetched[rt])
+        else:
+            ctx["reply_to"] = None
+
+        # Reply threads
+        if include_reply_threads:
+            raw_result = fetched.get(msg_id)
+            reply_count = _get_reply_count(raw_result)
+            if reply_count > 0 and reply_fetch_count < _CONTEXT_MAX_REPLY_FETCHES:
+                reply_fetch_count += 1
+                try:
+                    replies = await _fetch_direct_replies(
+                        client,
+                        entity,
+                        msg_id,
+                        _CONTEXT_REPLY_LIMIT,
+                        None,
+                        False,
+                    )
+                    ctx["replies"] = [
+                        _lightweight_from_result(r)
+                        for r in replies[:_CONTEXT_REPLY_LIMIT]
+                    ]
+                except FloodWaitError as e:
+                    wait = getattr(e, "seconds", 0) or 0
+                    logger.warning(
+                        "Reply fetch FloodWaitError for msg %d: wait %ds",
+                        msg_id,
+                        wait,
+                    )
+                    ctx["replies"] = []
+                except Exception as e:
+                    logger.warning("Reply fetch failed for msg %d: %s", msg_id, e)
+                    ctx["replies"] = []
+            else:
+                ctx["replies"] = []
+
+        if ctx:
+            msg["context"] = ctx
+
+    return messages
 
 
 async def _execute_parallel_searches_generators(

--- a/src/tools/search/search_mode.py
+++ b/src/tools/search/search_mode.py
@@ -21,6 +21,7 @@ from src.utils.entity import (
 from src.utils.error_handling import log_and_build_error, log_connection_error_response
 from src.utils.helpers import _append_dedup_until_limit
 from src.utils.message_format import (
+    _extract_topic_metadata,
     message_has_displayable_content,
     response_attachment_warning,
     transcribe_voice_messages,
@@ -43,19 +44,6 @@ _CONTEXT_MAX_REPLY_FETCHES = 20  # max _fetch_direct_replies calls
 _CONTEXT_REPLY_LIMIT = 5  # max replies per result
 
 
-def _extract_topic_id_from_message(message) -> int | None:
-    """Extract topic_id from a raw Telethon message for forum scoping."""
-    reply_to = getattr(message, "reply_to", None)
-    reply_to_top_id = getattr(reply_to, "reply_to_top_id", None)
-    if reply_to_top_id:
-        return reply_to_top_id
-    forum_topic = bool(getattr(reply_to, "forum_topic", False))
-    reply_to_msg_id = getattr(reply_to, "reply_to_msg_id", None)
-    if forum_topic and reply_to_msg_id:
-        return reply_to_msg_id
-    return None
-
-
 def _is_valid_context_neighbor(
     message, is_forum: bool, result_topic_id: int | None
 ) -> bool:
@@ -65,7 +53,8 @@ def _is_valid_context_neighbor(
     if not message_has_displayable_content(message):
         return False
     if is_forum:
-        neighbor_topic = _extract_topic_id_from_message(message)
+        neighbor_meta = _extract_topic_metadata(message)
+        neighbor_topic = neighbor_meta.get("topic_id")
         if result_topic_id is not None:
             return neighbor_topic == result_topic_id
         return neighbor_topic is None
@@ -79,6 +68,11 @@ def _lightweight_from_raw(message) -> dict[str, Any]:
         or getattr(message, "message", None)
         or getattr(message, "caption", None)
     )
+    # Include media type hint when text is absent
+    if not full_text:
+        media = getattr(message, "media", None)
+        if media:
+            full_text = f"[{type(media).__name__}]"
     return {
         "id": message.id,
         "date": message.date.isoformat() if getattr(message, "date", None) else None,
@@ -115,7 +109,7 @@ async def _enrich_with_context(
     messages: list[dict[str, Any]],
     context: int,
     include_reply_threads: bool = False,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], str | None]:
     """Enrich search results with surrounding context and optional reply threads.
 
     Adds a 'context' envelope to each result with:
@@ -126,9 +120,10 @@ async def _enrich_with_context(
 
     Caps: max 500 IDs, max 20 reply thread fetches, 30s timeout budget.
     Partial failure: returns results without context on error.
+    Returns: (messages, warning_or_none) — warning set when IDs were capped.
     """
     if not messages:
-        return messages
+        return messages, None
 
     start_time = time.monotonic()
     is_forum = bool(getattr(entity, "forum", False))
@@ -144,29 +139,37 @@ async def _enrich_with_context(
             continue
         result_ids.add(msg_id)
         for offset in range(1, context + 1):
-            all_ids.add(msg_id - offset)
+            neighbor_id = msg_id - offset
+            if neighbor_id > 0:
+                all_ids.add(neighbor_id)
             all_ids.add(msg_id + offset)
         rt = msg.get("reply_to_msg_id")
         if rt:
             reply_to_ids.add(rt)
 
-    # Include result IDs for reply count checking and reply_to for resolution
+    # Include reply_to for resolution
     all_ids.update(reply_to_ids)
-    all_ids.update(result_ids)
+    # Result IDs needed for reply count checking only when reply threads requested
+    if include_reply_threads:
+        all_ids.update(result_ids)
     all_ids.discard(0)
 
+    # Track original count before cap mutation for correct warning
+    original_count = len(all_ids)
+    warning = None
+
     # Cap total IDs — prioritize reply_to and result IDs over neighbors
-    if len(all_ids) > _CONTEXT_MAX_IDS:
+    if original_count > _CONTEXT_MAX_IDS:
         neighbor_ids = all_ids - reply_to_ids - result_ids
         all_ids = reply_to_ids | result_ids
         remaining = _CONTEXT_MAX_IDS - len(all_ids)
         if remaining > 0:
             all_ids.update(list(neighbor_ids)[:remaining])
-        logger.warning(
-            "Context enrichment: capped IDs to %d (was %d)",
-            _CONTEXT_MAX_IDS,
-            len(all_ids) + len(neighbor_ids),
+        warning = (
+            f"Context enrichment: {original_count} unique message IDs exceeded "
+            f"the {_CONTEXT_MAX_IDS} cap; some context may be missing."
         )
+        logger.warning("Context enrichment: capped IDs to %d (was %d)", _CONTEXT_MAX_IDS, original_count)
 
     # Step 2: Batch-fetch all needed messages
     try:
@@ -176,10 +179,10 @@ async def _enrich_with_context(
     except FloodWaitError as e:
         wait = getattr(e, "seconds", 0) or 0
         logger.warning("Context enrichment FloodWaitError: wait %ds", wait)
-        return messages
+        return messages, None
     except Exception as e:
         logger.warning("Context enrichment fetch failed: %s", e)
-        return messages
+        return messages, None
 
     fetched: dict[int, Any] = {}
     for m in raw_messages:
@@ -188,18 +191,20 @@ async def _enrich_with_context(
 
     # Step 3: Build context envelopes
     reply_fetch_count = 0
+    timed_out = False
 
     for msg in messages:
         msg_id = msg.get("id")
         if not msg_id:
             continue
 
-        # Check timeout
+        # Check timeout before processing each result
         if time.monotonic() - start_time > _CONTEXT_TIMEOUT_BUDGET:
             logger.warning(
                 "Context enrichment: timeout budget exceeded (%.1fs), stopping",
                 time.monotonic() - start_time,
             )
+            timed_out = True
             break
 
         msg_topic_id = msg.get("topic_id")
@@ -230,43 +235,50 @@ async def _enrich_with_context(
         else:
             ctx["reply_to"] = None
 
-        # Reply threads
+        # Reply threads — check timeout before each individual fetch
         if include_reply_threads:
-            raw_result = fetched.get(msg_id)
-            reply_count = _get_reply_count(raw_result)
-            if reply_count > 0 and reply_fetch_count < _CONTEXT_MAX_REPLY_FETCHES:
-                reply_fetch_count += 1
-                try:
-                    replies = await _fetch_direct_replies(
-                        client,
-                        entity,
-                        msg_id,
-                        _CONTEXT_REPLY_LIMIT,
-                        None,
-                        False,
-                    )
-                    ctx["replies"] = [
-                        _lightweight_from_result(r)
-                        for r in replies[:_CONTEXT_REPLY_LIMIT]
-                    ]
-                except FloodWaitError as e:
-                    wait = getattr(e, "seconds", 0) or 0
-                    logger.warning(
-                        "Reply fetch FloodWaitError for msg %d: wait %ds",
-                        msg_id,
-                        wait,
-                    )
-                    ctx["replies"] = []
-                except Exception as e:
-                    logger.warning("Reply fetch failed for msg %d: %s", msg_id, e)
-                    ctx["replies"] = []
-            else:
+            if time.monotonic() - start_time > _CONTEXT_TIMEOUT_BUDGET:
+                logger.warning("Context enrichment: timeout before reply fetches, skipping remaining")
                 ctx["replies"] = []
+            else:
+                raw_result = fetched.get(msg_id)
+                reply_count = _get_reply_count(raw_result)
+                if reply_count > 0 and reply_fetch_count < _CONTEXT_MAX_REPLY_FETCHES:
+                    reply_fetch_count += 1
+                    try:
+                        replies = await _fetch_direct_replies(
+                            client,
+                            entity,
+                            msg_id,
+                            _CONTEXT_REPLY_LIMIT,
+                            None,
+                            False,
+                        )
+                        ctx["replies"] = [
+                            _lightweight_from_result(r)
+                            for r in replies[:_CONTEXT_REPLY_LIMIT]
+                        ]
+                    except FloodWaitError as e:
+                        wait = getattr(e, "seconds", 0) or 0
+                        logger.warning(
+                            "Reply fetch FloodWaitError for msg %d: wait %ds",
+                            msg_id,
+                            wait,
+                        )
+                        ctx["replies"] = []
+                    except Exception as e:
+                        logger.warning("Reply fetch failed for msg %d: %s", msg_id, e)
+                        ctx["replies"] = []
+                else:
+                    ctx["replies"] = []
 
         if ctx:
             msg["context"] = ctx
 
-    return messages
+    if timed_out and not warning:
+        warning = "Context enrichment: timed out; some results may lack context."
+
+    return messages, warning
 
 
 async def _execute_parallel_searches_generators(

--- a/src/utils/entity.py
+++ b/src/utils/entity.py
@@ -341,11 +341,15 @@ async def get_entity_by_id(entity_id, *, client: TelegramClient | None = None):
                 "Stripped -100 channel prefix: %r → %d", entity_id, stripped_id
             )
 
-        # Try to convert entity_id to an integer if it's a numeric string
-        try:
-            peer = int(entity_id)
-        except (ValueError, TypeError):
+        # Try to convert entity_id to an integer if it's a numeric string.
+        # Skip for phone numbers — int("+123…") succeeds but produces a wrong user ID.
+        if isinstance(entity_id, str) and entity_id.startswith("+"):
             peer = entity_id
+        else:
+            try:
+                peer = int(entity_id)
+            except (ValueError, TypeError):
+                peer = entity_id
 
         if not peer:
             raise ValueError("Entity ID cannot be null or empty")

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -162,3 +162,24 @@ async def test_get_entity_by_id_no_prefix(mock_get_client):
     calls = mock_client.get_entity.call_args_list
     assert len(calls) == 1  # first call succeeded
     assert calls[0][0][0] == 1234567890
+
+
+@pytest.mark.asyncio
+@patch("src.utils.entity.get_connected_client", new_callable=AsyncMock)
+async def test_get_entity_by_id_phone_not_converted_to_int(mock_get_client):
+    """Phone numbers starting with '+' must NOT be int()-converted — that produces a wrong user ID."""
+    mock_client = MagicMock()
+    mock_user = MagicMock(id=987654321)
+    mock_client.get_entity = AsyncMock(return_value=mock_user)
+    mock_get_client.return_value = mock_client
+
+    from src.utils.entity import get_entity_by_id
+
+    result = await get_entity_by_id("+15551234567")
+    assert result is not None
+    assert result.id == 987654321
+
+    # The phone string should be passed directly to get_entity — NOT int(15551234567)
+    calls = mock_client.get_entity.call_args_list
+    assert len(calls) == 1
+    assert calls[0][0][0] == "+15551234567"  # string, not int

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -1534,35 +1534,39 @@ class TestGetMessagesContextHelpers:
 
     def test_extract_topic_id_from_message_with_reply_to_top_id(self):
         """Should extract topic_id from reply_to.reply_to_top_id."""
-        from src.tools.search.search_mode import _extract_topic_id_from_message
+        from src.utils.message_format import _extract_topic_metadata
 
         msg = MagicMock()
         msg.reply_to = MagicMock(reply_to_top_id=42, forum_topic=True, reply_to_msg_id=10)
-        assert _extract_topic_id_from_message(msg) == 42
+        msg.reply_to_msg_id = None
+        assert _extract_topic_metadata(msg).get("topic_id") == 42
 
     def test_extract_topic_id_from_message_with_forum_topic(self):
         """Should extract topic_id from reply_to_msg_id when forum_topic=True."""
-        from src.tools.search.search_mode import _extract_topic_id_from_message
+        from src.utils.message_format import _extract_topic_metadata
 
         msg = MagicMock()
         msg.reply_to = MagicMock(reply_to_top_id=None, forum_topic=True, reply_to_msg_id=10)
-        assert _extract_topic_id_from_message(msg) == 10
+        msg.reply_to_msg_id = None
+        assert _extract_topic_metadata(msg).get("topic_id") == 10
 
     def test_extract_topic_id_from_message_no_topic(self):
         """Should return None for non-forum messages."""
-        from src.tools.search.search_mode import _extract_topic_id_from_message
+        from src.utils.message_format import _extract_topic_metadata
 
         msg = MagicMock()
         msg.reply_to = MagicMock(reply_to_top_id=None, forum_topic=False, reply_to_msg_id=None)
-        assert _extract_topic_id_from_message(msg) is None
+        msg.reply_to_msg_id = None
+        assert _extract_topic_metadata(msg).get("topic_id") is None
 
     def test_extract_topic_id_from_message_no_reply_to(self):
-        """Should return None when reply_to is None."""
-        from src.tools.search.search_mode import _extract_topic_id_from_message
+        """Should return empty dict when reply_to is None."""
+        from src.utils.message_format import _extract_topic_metadata
 
         msg = MagicMock()
         msg.reply_to = None
-        assert _extract_topic_id_from_message(msg) is None
+        msg.reply_to_msg_id = None
+        assert _extract_topic_metadata(msg) == {}
 
     def test_is_valid_context_neighbor_filters_service_messages(self):
         """Should reject service messages (no displayable content)."""

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -1026,3 +1026,655 @@ class TestGetMessagesDateFiltering:
         assert len(result["messages"]) == 1
         assert result["messages"][0]["id"] == 99
         assert "[Service: PinMessage]" in (result["messages"][0].get("text") or "")
+
+
+class TestGetMessagesContext:
+    """Test context enrichment feature for search results."""
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_disabled_by_default(
+        self,
+        mock_sm_entity,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_enrich_entity,
+        mock_batched,
+    ):
+        """context=0 should not add context envelope."""
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_sm_entity.return_value = mock_entity
+        mock_gen_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+        mock_enrich_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        msg = make_mock_message(
+            id=500, text="result message", date=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+
+        async def mock_iter():
+            yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="result",
+            limit=10,
+            context=0,
+        )
+
+        assert "messages" in result
+        if result["messages"]:
+            assert "context" not in result["messages"][0]
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_adds_before_after(
+        self,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_sm_entity,
+        mock_batched,
+    ):
+        """context=2 should add before[] and after[] with neighbor messages."""
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_gen_entity.return_value = mock_entity
+        mock_sm_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        # Search result: message 500
+        result_msg = make_mock_message(
+            id=500, text="found message", date=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+
+        async def mock_iter():
+            yield result_msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        # Neighbors for context (498, 499, 501, 502)
+        def make_raw_msg(mid, text):
+            m = MagicMock()
+            m.id = mid
+            m.text = text
+            m.message = text
+            m.caption = None
+            m.date = datetime(2024, 6, 15, tzinfo=UTC)
+            m.sender_id = 42
+            m.media = None
+            m.reply_to = None
+            m.reply_to_msg_id = None
+            return m
+
+        neighbors = [
+            make_raw_msg(498, "before 2"),
+            make_raw_msg(499, "before 1"),
+            make_raw_msg(500, "found message"),
+            make_raw_msg(501, "after 1"),
+            make_raw_msg(502, "after 2"),
+        ]
+        mock_batched.return_value = neighbors
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="found",
+            limit=10,
+            context=2,
+        )
+
+        assert "messages" in result
+        assert len(result["messages"]) == 1
+        ctx = result["messages"][0].get("context")
+        assert ctx is not None
+        assert "before" in ctx
+        assert "after" in ctx
+        assert len(ctx["before"]) == 2
+        assert len(ctx["after"]) == 2
+        # Before is ordered most-recent-first (499, 498)
+        assert ctx["before"][0]["id"] == 499
+        assert ctx["before"][1]["id"] == 498
+        # After is ordered oldest-first (501, 502)
+        assert ctx["after"][0]["id"] == 501
+        assert ctx["after"][1]["id"] == 502
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_reply_to(
+        self,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_sm_entity,
+        mock_batched,
+    ):
+        """context should resolve reply_to_msg_id to lightweight message."""
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_gen_entity.return_value = mock_entity
+        mock_sm_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        # Result message replies to msg 400
+        result_msg = make_mock_message(
+            id=500,
+            text="reply message",
+            date=datetime(2024, 6, 15, tzinfo=UTC),
+            reply_to_msg_id=400,
+        )
+
+        async def mock_iter():
+            yield result_msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        def make_raw_msg(mid, text):
+            m = MagicMock()
+            m.id = mid
+            m.text = text
+            m.message = text
+            m.caption = None
+            m.date = datetime(2024, 6, 15, tzinfo=UTC)
+            m.sender_id = 42
+            m.media = None
+            m.reply_to = None
+            m.reply_to_msg_id = None
+            return m
+
+        fetched = [
+            make_raw_msg(400, "original message"),
+            make_raw_msg(499, "neighbor before"),
+            make_raw_msg(500, "reply message"),
+            make_raw_msg(501, "neighbor after"),
+        ]
+        mock_batched.return_value = fetched
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="reply",
+            limit=10,
+            context=1,
+        )
+
+        assert "messages" in result
+        ctx = result["messages"][0].get("context")
+        assert ctx is not None
+        assert ctx["reply_to"] is not None
+        assert ctx["reply_to"]["id"] == 400
+        assert ctx["reply_to"]["text"] == "original message"
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._fetch_direct_replies", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_reply_threads(
+        self,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_sm_entity,
+        mock_batched,
+        mock_fetch_replies,
+    ):
+        """include_reply_threads=True should fetch replies and attach them."""
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_gen_entity.return_value = mock_entity
+        mock_sm_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        result_msg = make_mock_message(
+            id=500, text="popular message", date=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+
+        async def mock_iter():
+            yield result_msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        def make_raw_msg(mid, text, reply_count=0):
+            m = MagicMock()
+            m.id = mid
+            m.text = text
+            m.message = text
+            m.caption = None
+            m.date = datetime(2024, 6, 15, tzinfo=UTC)
+            m.sender_id = 42
+            m.media = None
+            m.reply_to = None
+            m.reply_to_msg_id = None
+            if reply_count > 0:
+                m.replies = MagicMock()
+                m.replies.replies = reply_count
+            else:
+                m.replies = None
+            return m
+
+        fetched = [
+            make_raw_msg(500, "popular message", reply_count=3),
+        ]
+        mock_batched.return_value = fetched
+
+        # Mock _fetch_direct_replies returns result dicts
+        mock_fetch_replies.return_value = [
+            {"id": 501, "text": "reply 1", "date": "2024-06-15T00:00:00", "sender": {"id": 10}},
+            {"id": 502, "text": "reply 2", "date": "2024-06-15T00:01:00", "sender": {"id": 11}},
+        ]
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="popular",
+            limit=10,
+            context=0,
+            include_reply_threads=True,
+        )
+
+        assert "messages" in result
+        ctx = result["messages"][0].get("context")
+        assert ctx is not None
+        assert "replies" in ctx
+        assert len(ctx["replies"]) == 2
+        assert ctx["replies"][0]["id"] == 501
+        assert ctx["replies"][1]["id"] == 502
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_partial_failure_returns_messages(
+        self,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_sm_entity,
+        mock_batched,
+    ):
+        """Enrichment failure should return messages without context (not lose results)."""
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_gen_entity.return_value = mock_entity
+        mock_sm_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        result_msg = make_mock_message(
+            id=500, text="result", date=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+
+        async def mock_iter():
+            yield result_msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        # Make batched fetch fail
+        mock_batched.side_effect = RuntimeError("API error")
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="result",
+            limit=10,
+            context=2,
+        )
+
+        # Should still return the messages, just without context
+        assert "messages" in result
+        assert len(result["messages"]) == 1
+        assert "context" not in result["messages"][0]
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_flood_wait_returns_messages(
+        self,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_sm_entity,
+        mock_batched,
+    ):
+        """FloodWaitError during enrichment should return messages without context."""
+        from telethon.errors import FloodWaitError
+
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_gen_entity.return_value = mock_entity
+        mock_sm_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        result_msg = make_mock_message(
+            id=500, text="result", date=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+
+        async def mock_iter():
+            yield result_msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        # Make batched fetch raise FloodWaitError
+        flood = FloodWaitError(request=None, capture=30)
+        mock_batched.side_effect = flood
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="result",
+            limit=10,
+            context=2,
+        )
+
+        assert "messages" in result
+        assert len(result["messages"]) == 1
+        assert "context" not in result["messages"][0]
+
+    @pytest.mark.asyncio
+    @patch("src.tools.search.search_mode._get_messages_by_ids_batched", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_entity_by_id", new_callable=AsyncMock)
+    @patch("src.tools.search.core.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_mode.get_connected_client", new_callable=AsyncMock)
+    @patch("src.tools.search.search_generators.get_entity_by_id", new_callable=AsyncMock)
+    async def test_context_id_cap(
+        self,
+        mock_gen_entity,
+        mock_sm_client,
+        mock_core_client,
+        mock_core_entity,
+        mock_sm_entity,
+        mock_batched,
+    ):
+        """Should cap total IDs at 500 when too many results with large context."""
+        mock_entity = Mock()
+        mock_entity.id = 123
+        mock_entity.broadcast = False
+        mock_entity.forum = False
+        mock_gen_entity.return_value = mock_entity
+        mock_sm_entity.return_value = mock_entity
+        mock_core_entity.return_value = mock_entity
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=Mock(premium=False))
+        mock_sm_client.return_value = mock_client
+        mock_core_client.return_value = mock_client
+
+        # Create 50 results to trigger ID cap with context=10
+        result_msgs = []
+        for i in range(50):
+            result_msgs.append(
+                make_mock_message(
+                    id=100 + i * 100,
+                    text=f"result {i}",
+                    date=datetime(2024, 6, 15, tzinfo=UTC),
+                )
+            )
+
+        async def mock_iter():
+            for msg in result_msgs:
+                yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=mock_iter())
+
+        def make_raw_msg(mid, text):
+            m = MagicMock()
+            m.id = mid
+            m.text = text
+            m.message = text
+            m.caption = None
+            m.date = datetime(2024, 6, 15, tzinfo=UTC)
+            m.sender_id = 42
+            m.media = None
+            m.reply_to = None
+            m.reply_to_msg_id = None
+            return m
+
+        # Return enough neighbors to fill the cap
+        all_neighbors = []
+        for i in range(50):
+            base = 100 + i * 100
+            for offset in range(-10, 11):
+                if offset != 0:
+                    all_neighbors.append(make_raw_msg(base + offset, f"neighbor {base+offset}"))
+            all_neighbors.append(make_raw_msg(base, f"result {i}"))
+
+        mock_batched.return_value = all_neighbors
+
+        result = await search_messages_impl(
+            chat_id="me",
+            query="result",
+            limit=50,
+            context=10,
+        )
+
+        assert "messages" in result
+        # Verify enrichment was attempted (batched was called)
+        mock_batched.assert_called_once()
+        # The IDs passed should be capped
+        called_ids = mock_batched.call_args[0][2]
+        assert len(called_ids) <= 500
+
+
+class TestGetMessagesContextHelpers:
+    """Unit tests for context enrichment helper functions."""
+
+    def test_extract_topic_id_from_message_with_reply_to_top_id(self):
+        """Should extract topic_id from reply_to.reply_to_top_id."""
+        from src.tools.search.search_mode import _extract_topic_id_from_message
+
+        msg = MagicMock()
+        msg.reply_to = MagicMock(reply_to_top_id=42, forum_topic=True, reply_to_msg_id=10)
+        assert _extract_topic_id_from_message(msg) == 42
+
+    def test_extract_topic_id_from_message_with_forum_topic(self):
+        """Should extract topic_id from reply_to_msg_id when forum_topic=True."""
+        from src.tools.search.search_mode import _extract_topic_id_from_message
+
+        msg = MagicMock()
+        msg.reply_to = MagicMock(reply_to_top_id=None, forum_topic=True, reply_to_msg_id=10)
+        assert _extract_topic_id_from_message(msg) == 10
+
+    def test_extract_topic_id_from_message_no_topic(self):
+        """Should return None for non-forum messages."""
+        from src.tools.search.search_mode import _extract_topic_id_from_message
+
+        msg = MagicMock()
+        msg.reply_to = MagicMock(reply_to_top_id=None, forum_topic=False, reply_to_msg_id=None)
+        assert _extract_topic_id_from_message(msg) is None
+
+    def test_extract_topic_id_from_message_no_reply_to(self):
+        """Should return None when reply_to is None."""
+        from src.tools.search.search_mode import _extract_topic_id_from_message
+
+        msg = MagicMock()
+        msg.reply_to = None
+        assert _extract_topic_id_from_message(msg) is None
+
+    def test_is_valid_context_neighbor_filters_service_messages(self):
+        """Should reject service messages (no displayable content)."""
+        from src.tools.search.search_mode import _is_valid_context_neighbor
+
+        msg = MagicMock()
+        msg.text = None
+        msg.message = None
+        msg.caption = None
+        msg.media = None
+        msg.action = None
+        assert _is_valid_context_neighbor(msg, False, None) is False
+
+    def test_is_valid_context_neighbor_accepts_text_messages(self):
+        """Should accept messages with text content."""
+        from src.tools.search.search_mode import _is_valid_context_neighbor
+
+        msg = MagicMock()
+        msg.text = "hello"
+        msg.reply_to = None
+        assert _is_valid_context_neighbor(msg, False, None) is True
+
+    def test_is_valid_context_neighbor_forum_topic_mismatch(self):
+        """Should reject neighbors from different forum topics."""
+        from src.tools.search.search_mode import _is_valid_context_neighbor
+
+        msg = MagicMock()
+        msg.text = "other topic msg"
+        msg.reply_to = MagicMock(reply_to_top_id=99, forum_topic=True, reply_to_msg_id=None)
+        assert _is_valid_context_neighbor(msg, True, 42) is False
+
+    def test_is_valid_context_neighbor_forum_topic_match(self):
+        """Should accept neighbors from the same forum topic."""
+        from src.tools.search.search_mode import _is_valid_context_neighbor
+
+        msg = MagicMock()
+        msg.text = "same topic msg"
+        msg.reply_to = MagicMock(reply_to_top_id=42, forum_topic=True, reply_to_msg_id=None)
+        assert _is_valid_context_neighbor(msg, True, 42) is True
+
+    def test_lightweight_from_raw(self):
+        """Should extract id, date, text, sender_id from raw message."""
+        from src.tools.search.search_mode import _lightweight_from_raw
+
+        msg = MagicMock()
+        msg.id = 100
+        msg.text = "hello world"
+        msg.message = "hello world"
+        msg.caption = None
+        msg.date = datetime(2024, 6, 15, tzinfo=UTC)
+        msg.sender_id = 42
+
+        result = _lightweight_from_raw(msg)
+        assert result == {
+            "id": 100,
+            "date": "2024-06-15T00:00:00+00:00",
+            "text": "hello world",
+            "sender_id": 42,
+        }
+
+    def test_lightweight_from_result(self):
+        """Should extract id, date, text, sender_id from result dict."""
+        from src.tools.search.search_mode import _lightweight_from_result
+
+        result_dict = {
+            "id": 100,
+            "date": "2024-06-15T00:00:00",
+            "text": "hello world",
+            "sender": {"id": 42, "username": "alice"},
+        }
+
+        result = _lightweight_from_result(result_dict)
+        assert result == {
+            "id": 100,
+            "date": "2024-06-15T00:00:00",
+            "text": "hello world",
+            "sender_id": 42,
+        }
+
+    def test_lightweight_from_result_no_sender(self):
+        """Should handle None sender gracefully."""
+        from src.tools.search.search_mode import _lightweight_from_result
+
+        result_dict = {
+            "id": 100,
+            "date": "2024-06-15T00:00:00",
+            "text": "hello",
+            "sender": None,
+        }
+
+        result = _lightweight_from_result(result_dict)
+        assert result["sender_id"] is None
+
+    def test_get_reply_count_with_replies(self):
+        """Should return reply count from raw message."""
+        from src.tools.search.search_mode import _get_reply_count
+
+        msg = MagicMock()
+        msg.replies = MagicMock()
+        msg.replies.replies = 5
+        assert _get_reply_count(msg) == 5
+
+    def test_get_reply_count_no_replies(self):
+        """Should return 0 when message has no replies."""
+        from src.tools.search.search_mode import _get_reply_count
+
+        msg = MagicMock()
+        msg.replies = None
+        assert _get_reply_count(msg) == 0
+
+    def test_get_reply_count_none_message(self):
+        """Should return 0 for None message."""
+        from src.tools.search.search_mode import _get_reply_count
+
+        assert _get_reply_count(None) == 0


### PR DESCRIPTION
## Summary

Adds `context` and `include_reply_threads` parameters to `get_messages` that enrich search results with surrounding conversation context — neighboring messages, reply chains, and direct replies.

## Changes

- **`context`** (int, 1–10, default 0): include N messages before and after each search result
- **`include_reply_threads`** (bool, default false): fetch up to 5 direct replies per result
- Lightweight context format (id, date, text, sender_id) to save tokens
- Forum topic-aware: neighbors filtered by matching `top_msg_id`
- Cost caps: max 500 IDs, max 20 reply fetches, 30s timeout budget
- Partial failure resilience: returns results without context on error
- `FloodWaitError` propagated with wait duration in warning

## Design

Post-processing step in `_dispatch_search_mode` — enrichment wrapper calls `_enrich_with_context()` after search results are collected. No changes to search generators or result builders.

ADR-0011 approved after 2 review cycles (simplification + edge cases).

## Files

| File | Change |
|------|--------|
| `mcp_tool_types.py` | `ContextWindow` + `IncludeReplyThreads` types |
| `tools_register.py` | New params on `get_messages` |
| `core.py` | Enrichment wrapper in `_dispatch_search_mode` |
| `search_mode.py` | `_enrich_with_context()` + helpers |
| `test_get_messages.py` | 21 new tests (10 integration + 11 unit) |
| `Search-Guidelines.md` | Context enrichment section |
| `Tools-Reference.md` | Updated signature, examples, response format |
| `docs/adr/` | ADR-0011 + review findings |

## Test plan

- [x] 78/78 unit tests pass
- [ ] Subagent review (code quality + safe simplification + ADR/docs adherence)
- [ ] Validation pass