### PR TITLE
feat: return success+note for zero-result queries (ADR 0012)

### DIFF
--- a/docs/adr/0012-empty-result-consistency.md
+++ b/docs/adr/0012-empty-result-consistency.md
@@ -1,0 +1,229 @@
+# ADR 0012: Empty Result Consistency — Return Success, Not Error, for Zero-Result Queries
+
+**Status:** proposed
+**Date:** 2026-07-06
+
+## Context
+
+When search and discovery tools find zero results, they currently return an error via `log_and_build_error()` with `ok: false`.
+
+For MCP clients (LLM agents), this creates a problem: a **successful query that matched nothing** and a **real failure** (network error, auth, rate-limit) both arrive as `ok: false` error dicts. The agent cannot distinguish them without parsing the `error` string.
+
+The REST/HTTP consensus is clear on this distinction:
+
+| Scenario | Correct status |
+|----------|---------------|
+| Collection search — `GET /items?q=foo` → 0 items | **200 with `[]`** |
+| Single resource — `GET /items/42` → not found | **404** |
+| Real failure (auth, timeout, rate-limit) | **Error** |
+
+The MCP-equivalent rule: **a search that ran successfully and found nothing should return a valid success response with an empty collection**, not an error.
+
+## Affected Tools
+
+All paths below currently return `log_and_build_error(...)` when no results are found.
+
+### `get_messages` — search/browse mode (`search_mode.py`)
+
+| Scenario | File:Line | Returns |
+|----------|-----------|---------|
+| Per-chat search, empty query, date range | `_handle_query_mode` : L725-728 | error |
+| Per-chat search, empty query, no dates | `_handle_query_mode` : L729-730 | error |
+| Per-chat search, non-empty query | `_handle_query_mode` : L731 | error |
+| Global search, empty query | `_handle_query_mode` : L726-728 | error |
+
+### `get_messages` — replies mode (`replies.py`)
+
+| Scenario | File:Line | Returns |
+|----------|-----------|---------|
+| No replies to a message | `_handle_reply_mode` : L379-383 | error |
+
+### `search_contacts` (`contact_search.py`)
+
+| Scenario | File:Line | Returns |
+|----------|-----------|---------|
+| No contacts match query | `_search_contacts_as_list` : L108-112 | error dict |
+
+### `find_chats` — global multi-term (`find_chats.py`)
+
+| Scenario | File:Line | Returns |
+|----------|-----------|---------|
+| No results from any term | `_find_chats_global_multi_term` : L386-391 | error dict |
+| No results, dialog-based | `_find_chats_by_dialogs` : L458-462 | error dict |
+
+### Not affected (real errors, kept as-is)
+
+These remain errors because they represent actual failures:
+
+- **Invalid ISO date format** (`search_mode.py`, `replies.py`, `date_helpers.py`)
+- **Missing required parameters** — `chat_id`, `message_ids`, `reply_to_id`, `query` for global search (`core.py`)
+- **`from_user` without `chat_id`** (`core.py`)
+- **Chat not found** (`chat_info.py`, `sending.py`, `reading.py`)
+- **Connection / auth failures** (`search_mode.py`, `replies.py`, `mtproto.py`)
+- **Invalid filter name**, **empty `from_user`**, **invalid limit** (`find_chats.py`)
+- **FloodWait, RpcError** (`mtproto.py`)
+
+## Decision
+
+Convert the 5 affected tools/paths to return valid success responses with empty collections instead of error dicts.
+
+| Tool | Current (error) | New (success) |
+|------|----------------|---------------|
+| `get_messages` (search/browse) | `ok: false, error: "No messages found..."` | `{"messages": [], "has_more": false}` |
+| `get_messages` (replies) | `ok: false, error: "No replies found..."` | `{"messages": [], "has_more": false, "reply_to_id": N}` |
+| `search_contacts` | `ok: false, error: "No contacts found..."` | `[]` |
+| `find_chats` (global multi-term) | `ok: false, error: "No contacts found..."` | `{"chats": []}` |
+| `find_chats` (dialog-based) | `ok: false, error: "No chats found..."` | `{"chats": []}` |
+
+### Informational `note` field
+
+When returning an empty collection, include an optional `note` field in the response dict to give the AI client context about why nothing was found.
+
+**Rationale:** An empty list `[]` carries no semantics. The AI client sees `messages: []` but doesn't know *why* — was the query too specific? The date range too narrow? No chats exist with that name? `note` provides a human-readable diagnostic without turning success into an error.
+
+**Where `note` is added:**
+
+| Tool response shape | Where note goes |
+|---------------------|----------------|
+| `{"messages": [], "has_more": false}` | `note` key in the same dict |
+| `{"messages": [], "has_more": false, "reply_to_id": N}` | `note` key in the same dict |
+| `{"chats": []}` | `note` key in the same dict |
+
+**Where `note` is NOT added:**
+
+- `_search_contacts_as_list` returns a raw `list[dict]` — no dict to attach `note` to. The callers (`_find_chats_global`, `find_chats_impl`) wrap it into `{"chats": []}` and may add `note` there.
+- Normal (non-empty) responses — `note` is absent, so clients that don't check it see no change.
+
+**MCP spec compatibility:**
+
+- MCP `CallToolResult` does not define a `note` field — but `structured_content` is arbitrary JSON.
+- FastMCP converts return dicts to `structured_content`, so any keys in the dict (including `note`) appear in `structured_content`.
+- The alternative — FastMCP's `ToolResult(meta={"note": "..."})` — would require switching every affected return from plain dict to `ToolResult`. This is more invasive and inconsistent with the rest of the codebase.
+- **Decision:** Add `note` directly to the response dict as a plain string key. No new types, no `ToolResult` imports.
+
+### Detailed returns
+
+#### `_handle_query_mode` (search_mode.py)
+
+Current (simplified):
+```python
+if not window:
+    return log_and_build_error(...)
+
+response = {"messages": window, "has_more": has_more}
+return response
+```
+
+New:
+```python
+# Remove the if-not-window error block entirely.
+# window is already sliced earlier as: window = collected[:limit].
+# When collected is empty, window is [], has_more is False.
+# The response is already correct for empty results.
+```
+
+The existing response construction below naturally produces `{"messages": [], "has_more": false}` — the guarding error block just prevents it from reaching the return. Removing the guard is sufficient.
+
+#### `_handle_reply_mode` (replies.py)
+
+Same pattern — remove the `if not window:` error block. The existing response construction already produces the correct shape with `reply_to_id`.
+
+#### `_search_contacts_as_list` (contact_search.py)
+
+Current:
+```python
+if not results:
+    return log_and_build_error(...)
+return results
+```
+
+New:
+```python
+# Just let the empty list flow through — it's valid data.
+return results
+```
+
+#### `_find_chats_global_multi_term` (find_chats.py)
+
+Current:
+```python
+if term_results is None:
+    return log_and_build_error(...)
+return {"chats": _merge_results_round_robin(term_results, limit)}
+```
+
+New:
+```python
+if not term_results:
+    return {"chats": []}
+return {"chats": _merge_results_round_robin(term_results, limit)}
+```
+
+The `isinstance(result, list)` check in `_gather_term_results` now succeeds for empty `[]` returned by each term (since `_search_contacts_as_list` returns a list, not an error dict). So `term_results` will be `[[], [], ...]` instead of `None`. The `_merge_results_round_robin` handles empty input lists correctly (returns `[]`).
+
+#### `_find_chats_by_dialogs` (find_chats.py)
+
+Current:
+```python
+if results:
+    return {"chats": results}
+
+date_str = "..."
+return log_and_build_error(...)
+```
+
+New:
+```python
+return {"chats": results}
+```
+
+The `results` list (possibly empty) is the canonical success shape.
+
+### `_normalize_gather_result` interaction
+
+The `_normalize_gather_result` helper (used in `_find_chats_combined`) has:
+```python
+if isinstance(chats, list) and chats:
+    return chats
+return None
+```
+
+When `_find_chats_global` returns `{"chats": []}`, this hits `and chats:` → `False` → returns `None`. So the combined search's `term_results` stays empty, falls to `if not term_results:`, then looks for an error dict (`.get("ok") is False`) — which `{"chats": []}` doesn't have — and returns `{"chats": []}`. This is already the correct behavior for empty results; no changes needed for this helper.
+
+## Consequences
+
+### Positive
+
+- MCP clients get consistent success-response format for all successful queries, regardless of result count
+- Downstream processing simplified — no error-checking gate for "nothing found"
+- Backward compatible: `TypedDict` result types (`SearchResult`, `FindChatsResult`) already have `messages`/`chats` as optional `total=False` fields, so `{"messages": []}` is schema-valid
+- Real errors remain crisp — only the "empty result" special case is changed
+
+### Negative
+
+- Existing MCP clients that pattern-match on `ok: false` for empty results will need to adapt (but this is the incorrect pattern — they should match on `messages: []` or `chats: []`)
+- `isinstance(result, list)` guards in `find_chats_impl` and `_find_chats_global` become dead code (always True) — harmless but could be cleaned up in a follow-up
+
+### Edge cases
+
+- **Actual exceptions** during term search (FloodWait, network) still propagate as `Exception` instances through `_gather_term_results`, so those errors remain correctly reported
+- **Empty query with no chat_id** (global search, query is empty) remains an error — `if not chat_id and not queries: return log_and_build_error(...)` — because it's a parameter validation error, not an empty result
+- **Date filter with no query** in per-chat browse mode: previously returned a descriptive error, now returns `{"messages": [], "has_more": false}` — the client can see `messages` is empty and inform the user
+
+## Implementation files
+
+| File | Lines to change | Change type |
+|------|----------------|-------------|
+| `src/tools/search/search_mode.py` | L724–734 | Remove `if not window:` error guard. Add `note` with query/date context when window is empty. |
+| `src/tools/search/replies.py` | L379–383 | Remove `if not window:` error guard. Add `note` with reply context when window is empty. |
+| `src/tools/chat_discovery/contact_search.py` | L108–112 | Remove `if not results:` error guard — `return results` directly (empty list is valid). Raw list return — no `note`. |
+| `src/tools/chat_discovery/find_chats.py` | L382–393 | `_find_chats_global_multi_term`: change `if term_results is None:` → `if not term_results: return {"chats": []}` with note. |
+| `src/tools/chat_discovery/find_chats.py` | L455–462 | `_find_chats_by_dialogs`: change to unconditional `return {"chats": results}` with note when empty. |
+
+## References
+
+- REST API best practices (empty collection = 200, not 404)
+- MCP protocol: tools return typed results, error is for exceptional conditions
+- [ADR 0011](0011-context-enrichment-for-search.md) — prior search change; also builds `messages`/`has_more` response format
+- `src/tools/return_types.py` — `SearchResult`, `FindChatsResult`, `_ErrorFields` type definitions
+- `src/utils/error_handling.py` — `log_and_build_error()` implementation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ Concise records of significant technical decisions for fast-mcp-telegram.
 | [0009](0009-s3-session-storage.md) | S3 Session Storage for Ephemeral Deployments | proposed (2026-06-17) |
 | [0010](0010-north-star-pivot.md) | North Star Pivot — Best Telegram Bridge for AI Agents | accepted (2026-06-15) |
 | [0011](0011-context-enrichment-for-search.md) | Context Enrichment for Message Search Results | proposed (2026-06-26) |
+| [0012](0012-empty-result-consistency.md) | Empty Result Consistency — Return Success, Not Error, for Zero-Result Queries | proposed (2026-07-06) |

--- a/src/tools/chat_discovery/contact_search.py
+++ b/src/tools/chat_discovery/contact_search.py
@@ -16,7 +16,6 @@ from src.utils.entity import (
     _matches_public_filter,
     build_entity_dict,
 )
-from src.utils.error_handling import log_and_build_error
 
 logger = logging.getLogger(__name__)
 
@@ -95,23 +94,9 @@ async def _search_contacts_as_list(
 ) -> list[dict[str, Any]] | dict[str, Any]:
     """Wrapper to collect generator results into a list for backward compatibility."""
     results = []
-    params = {
-        "query": query,
-        "limit": limit,
-        "chat_type": chat_type,
-        "public": public,
-    }
 
     async for item in search_contacts_native(query, limit, chat_type, public):
         results.append(item)
-
-    if not results:
-        return log_and_build_error(
-            operation="search_contacts",
-            error_message=f"No contacts found matching query '{query}'",
-            params=params,
-            exception=ValueError(f"No contacts found matching query '{query}'"),
-        )
 
     logger.info(f"Found {len(results)} contacts using Telegram search for '{query}'")
     return results

--- a/src/tools/chat_discovery/find_chats.py
+++ b/src/tools/chat_discovery/find_chats.py
@@ -398,7 +398,12 @@ async def _find_chats_global_multi_term(
             exception=ValueError(f"No contacts found: {error_detail}"),
         )
 
-    return {"chats": _merge_results_round_robin(term_results, limit)}
+    result = _merge_results_round_robin(term_results, limit)
+    response: dict[str, Any] = {"chats": result}
+    if not result:
+        query_str = ", ".join(terms)
+        response["note"] = f"No contacts found matching query '{query_str}'"
+    return response
 
 
 async def _find_chats_by_dialogs(
@@ -445,23 +450,17 @@ async def _find_chats_by_dialogs(
     ):
         results.append(item)
 
-    if results:
-        return {"chats": results}
-
-    date_desc = []
-    if min_date:
-        date_desc.append(f"since {min_date}")
-    if max_date:
-        date_desc.append(f"until {max_date}")
-    date_str = " and ".join(date_desc) if date_desc else "with date filter"
-    query_str = f"matching '{query}' " if query else ""
-
-    return log_and_build_error(
-        operation="find_chats",
-        error_message=f"No chats found {query_str}{date_str}",
-        params=params,
-        exception=ValueError(f"No chats found {query_str}{date_str}"),
-    )
+    response: dict[str, Any] = {"chats": results}
+    if not results:
+        date_desc = []
+        if min_date:
+            date_desc.append(f"since {min_date}")
+        if max_date:
+            date_desc.append(f"until {max_date}")
+        date_str = " and ".join(date_desc) if date_desc else "with date filter"
+        query_str = f"matching '{query}' " if query else ""
+        response["note"] = f"No chats found {query_str}{date_str}"
+    return response
 
 
 async def _find_chats_by_filter(

--- a/src/tools/search/replies.py
+++ b/src/tools/search/replies.py
@@ -27,9 +27,7 @@ from .types import ThreadScope
 logger = logging.getLogger(__name__)
 
 
-async def _find_topic_from_nearby_messages(
-    client, entity, msg_id: int
-) -> int | None:
+async def _find_topic_from_nearby_messages(client, entity, msg_id: int) -> int | None:
     """Find topic ID by checking a nearby message's topic metadata.
 
     In forum groups, standalone messages may lack reply_to_top_id, but the
@@ -49,11 +47,14 @@ async def _find_topic_from_nearby_messages(
         if meta.get("topic_id") is not None:
             logger.debug(
                 "Nearby msg %d resolved topic %d (forum_topic=%s)",
-                nearby.id, meta["topic_id"],
+                nearby.id,
+                meta["topic_id"],
                 getattr(getattr(nearby, "reply_to", None), "forum_topic", None),
             )
             return meta["topic_id"]
-    logger.debug("No topic found in %d nearby messages after %d", len(nearby_msgs), msg_id)
+    logger.debug(
+        "No topic found in %d nearby messages after %d", len(nearby_msgs), msg_id
+    )
     return None
 
 
@@ -377,12 +378,12 @@ async def _handle_reply_mode(
         has_more = len(collected) > len(window)
 
         if not window:
-            return log_and_build_error(
-                operation="get_messages",
-                error_message=f"No replies found for message {reply_to_id}",
-                params=params,
-                exception=ValueError(f"No replies to message {reply_to_id}"),
-            )
+            return {
+                "messages": [],
+                "has_more": False,
+                "reply_to_id": reply_to_id,
+                "note": f"No replies found for message {reply_to_id}",
+            }
 
         logger.info(
             f"Retrieved {len(window)} replies to message {reply_to_id} in chat {chat_id}"

--- a/src/tools/search/search_mode.py
+++ b/src/tools/search/search_mode.py
@@ -161,13 +161,15 @@ async def _enrich_with_context(
             f"Context enrichment: {original_count} unique message IDs exceeded "
             f"the {_CONTEXT_MAX_IDS} cap; some context may be missing."
         )
-        logger.warning("Context enrichment: capped IDs to %d (was %d)", _CONTEXT_MAX_IDS, original_count)
+        logger.warning(
+            "Context enrichment: capped IDs to %d (was %d)",
+            _CONTEXT_MAX_IDS,
+            original_count,
+        )
 
     # Step 2: Batch-fetch all needed messages
     try:
-        raw_messages = await _get_messages_by_ids_batched(
-            client, entity, list(all_ids)
-        )
+        raw_messages = await _get_messages_by_ids_batched(client, entity, list(all_ids))
     except FloodWaitError as e:
         wait = getattr(e, "seconds", 0) or 0
         logger.warning("Context enrichment FloodWaitError: wait %ds", wait)
@@ -711,30 +713,22 @@ async def _handle_query_mode(
             len(collected) == limit and len(collected) > 0
         )
 
+        response: dict[str, Any] = {"messages": window, "has_more": has_more}
         if not window:
-            q_nonempty = bool(query and query.strip())
-            if chat_id and not q_nonempty:
+            if chat_id and not (query and query.strip()):
                 if min_date or max_date:
-                    err = (
+                    response["note"] = (
                         "No exportable messages found for the requested date range in this chat. "
                         "If Telegram shows recent dialog activity, it may be service-only "
                         "(e.g. pins, invites, title changes) now surfaced as [Service: …] rows."
                     )
                 else:
-                    err = "No exportable messages found in this chat."
-            elif q_nonempty:
-                err = f"No messages found matching query '{query}'"
+                    response["note"] = "No exportable messages found in this chat."
+            elif query and query.strip():
+                response["note"] = f"No messages found matching query '{query}'"
             else:
-                err = "No messages found for the given filters."
+                response["note"] = "No messages found for the given filters."
 
-            return log_and_build_error(
-                operation="get_messages",
-                error_message=err,
-                params=params,
-                exception=ValueError(err),
-            )
-
-        response: dict[str, Any] = {"messages": window, "has_more": has_more}
         if total_count is not None:
             response["total_count"] = total_count
 

--- a/tests/test_contacts_date_filtering.py
+++ b/tests/test_contacts_date_filtering.py
@@ -165,7 +165,8 @@ class TestDialogInDateRange:
         dialog = MockDialog(MockUser(1), date=None)
 
         with patch(
-            "src.tools.chat_discovery.date_helpers._get_last_message_date", new_callable=AsyncMock
+            "src.tools.chat_discovery.date_helpers._get_last_message_date",
+            new_callable=AsyncMock,
         ) as mock_fallback:
             mock_fallback.return_value = "2024-06-15T00:00:00+00:00"
 
@@ -185,7 +186,8 @@ class TestDialogInDateRange:
         dialog = MockDialog(MockUser(1), date=None)
 
         with patch(
-            "src.tools.chat_discovery.date_helpers._get_last_message_date", new_callable=AsyncMock
+            "src.tools.chat_discovery.date_helpers._get_last_message_date",
+            new_callable=AsyncMock,
         ) as mock_fallback:
             mock_fallback.return_value = "2023-06-15T00:00:00+00:00"
 
@@ -205,7 +207,8 @@ class TestDialogInDateRange:
         dialog = MockDialog(MockUser(1), date=None)
 
         with patch(
-            "src.tools.chat_discovery.date_helpers._get_last_message_date", new_callable=AsyncMock
+            "src.tools.chat_discovery.date_helpers._get_last_message_date",
+            new_callable=AsyncMock,
         ) as mock_fallback:
             mock_fallback.return_value = "2025-06-15T00:00:00+00:00"
 
@@ -225,7 +228,8 @@ class TestDialogInDateRange:
         dialog = MockDialog(MockUser(1), date=None)
 
         with patch(
-            "src.tools.chat_discovery.date_helpers._get_last_message_date", new_callable=AsyncMock
+            "src.tools.chat_discovery.date_helpers._get_last_message_date",
+            new_callable=AsyncMock,
         ) as mock_fallback:
             mock_fallback.return_value = None
 
@@ -245,7 +249,8 @@ class TestDialogInDateRange:
         dialog = MockDialog(MockUser(1), date=None)
 
         with patch(
-            "src.tools.chat_discovery.date_helpers._get_last_message_date", new_callable=AsyncMock
+            "src.tools.chat_discovery.date_helpers._get_last_message_date",
+            new_callable=AsyncMock,
         ) as mock_fallback:
             mock_fallback.return_value = "not-parseable-as-iso"
 
@@ -391,7 +396,8 @@ class TestBuildDialogEntityDict:
 async def test_find_chats_global_single_term_passes_through():
     """_find_chats_global passes through to _search_contacts_as_list."""
     with patch(
-        "src.tools.chat_discovery.find_chats._search_contacts_as_list", new_callable=AsyncMock
+        "src.tools.chat_discovery.find_chats._search_contacts_as_list",
+        new_callable=AsyncMock,
     ) as mock_search:
         mock_search.return_value = [{"id": 1, "title": "Test"}]
 
@@ -418,7 +424,8 @@ async def test_search_dialogs_impl_respects_max_date():
     mock_client.iter_dialogs = mock_iter_dialogs
 
     with patch(
-        "src.tools.chat_discovery.dialog_search.get_connected_client", new_callable=AsyncMock
+        "src.tools.chat_discovery.dialog_search.get_connected_client",
+        new_callable=AsyncMock,
     ) as mock_get_client:
         mock_get_client.return_value = mock_client
 
@@ -461,7 +468,8 @@ async def test_search_dialogs_impl_respects_min_date():
     mock_client.iter_dialogs = mock_iter_dialogs
 
     with patch(
-        "src.tools.chat_discovery.dialog_search.get_connected_client", new_callable=AsyncMock
+        "src.tools.chat_discovery.dialog_search.get_connected_client",
+        new_callable=AsyncMock,
     ) as mock_get_client:
         mock_get_client.return_value = mock_client
 
@@ -482,7 +490,8 @@ async def test_search_dialogs_impl_respects_min_date():
 async def test_find_chats_impl_without_date_filters_uses_global():
     """When no date filters are provided, find_chats_impl should use _find_chats_global."""
     with patch(
-        "src.tools.chat_discovery.find_chats._search_contacts_as_list", new_callable=AsyncMock
+        "src.tools.chat_discovery.find_chats._search_contacts_as_list",
+        new_callable=AsyncMock,
     ) as mock_search:
         mock_search.return_value = [{"id": 1, "title": "Test"}]
 
@@ -507,7 +516,8 @@ async def test_find_chats_impl_with_date_filters_uses_dialog_search():
     mock_client.iter_dialogs = mock_iter_dialogs
 
     with patch(
-        "src.tools.chat_discovery.dialog_search.get_connected_client", new_callable=AsyncMock
+        "src.tools.chat_discovery.dialog_search.get_connected_client",
+        new_callable=AsyncMock,
     ) as mock_get_client:
         mock_get_client.return_value = mock_client
 
@@ -519,7 +529,7 @@ async def test_find_chats_impl_with_date_filters_uses_dialog_search():
 
 @pytest.mark.asyncio
 async def test_find_chats_impl_date_filter_no_results_returns_error():
-    """When date filters find nothing, should return structured error."""
+    """When date filters find nothing, should return success with empty chats and note."""
 
     async def mock_iter_dialogs(limit=None, folder=None):
         if False:
@@ -529,7 +539,8 @@ async def test_find_chats_impl_date_filter_no_results_returns_error():
     mock_client.iter_dialogs = mock_iter_dialogs
 
     with patch(
-        "src.tools.chat_discovery.dialog_search.get_connected_client", new_callable=AsyncMock
+        "src.tools.chat_discovery.dialog_search.get_connected_client",
+        new_callable=AsyncMock,
     ) as mock_get_client:
         mock_get_client.return_value = mock_client
 
@@ -537,9 +548,10 @@ async def test_find_chats_impl_date_filter_no_results_returns_error():
             query="NoMatch", limit=10, min_date="2099-01-01", max_date="2099-12-31"
         )
 
-        assert "error" in result
-        assert result["operation"] == "find_chats"
-        assert "No chats found" in result["error"]
+        assert "chats" in result
+        assert result["chats"] == []
+        assert "note" in result
+        assert "No chats found" in result["note"]
 
 
 @pytest.mark.asyncio
@@ -590,7 +602,7 @@ async def test_find_chats_global_multi_term_merges_results():
 
 @pytest.mark.asyncio
 async def test_find_chats_global_multi_term_no_results_returns_error():
-    """Multi-term global search with no results should return structured error."""
+    """Multi-term global search with no results should return success with empty chats and note."""
 
     async def mock_gen_empty():
         if False:
@@ -602,9 +614,10 @@ async def test_find_chats_global_multi_term_no_results_returns_error():
     ):
         result = await _find_chats_global("nonexistent1,nonexistent2", 10, None, None)
 
-        assert "error" in result
-        assert result["operation"] == "search_contacts_multi"
-        assert "No contacts found" in result["error"]
+        assert "chats" in result
+        assert result["chats"] == []
+        assert "note" in result
+        assert "No contacts found" in result["note"]
 
 
 # ============== _find_chats_by_include_peers date filtering tests ==============
@@ -652,7 +665,9 @@ async def test_find_chats_by_include_peers_respects_min_date():
     mock_client.get_entity = mock_get_entity
 
     # Patch GetPeerDialogsRequest at the module level so it's recognized but not called
-    with patch("src.tools.chat_discovery.include_peers.GetPeerDialogsRequest", MagicMock()):
+    with patch(
+        "src.tools.chat_discovery.include_peers.GetPeerDialogsRequest", MagicMock()
+    ):
         result = await _find_chats_by_include_peers(
             client=mock_client,
             filter_dict={
@@ -720,7 +735,9 @@ async def test_find_chats_by_include_peers_fallback_iter_messages_uses_per_peer_
     mock_client.get_entity = mock_get_entity
     mock_client.iter_messages = iter_messages
 
-    with patch("src.tools.chat_discovery.include_peers.GetPeerDialogsRequest", MagicMock()):
+    with patch(
+        "src.tools.chat_discovery.include_peers.GetPeerDialogsRequest", MagicMock()
+    ):
         result = await _find_chats_by_include_peers(
             client=mock_client,
             filter_dict={
@@ -766,7 +783,9 @@ async def test_find_chats_get_peer_dialogs_mismatch_warns(caplog):
 
     with (
         caplog.at_level("WARNING", logger="src.tools.chat_discovery.include_peers"),
-        patch("src.tools.chat_discovery.include_peers.GetPeerDialogsRequest", MagicMock()),
+        patch(
+            "src.tools.chat_discovery.include_peers.GetPeerDialogsRequest", MagicMock()
+        ),
     ):
         await _find_chats_by_include_peers(
             client=mock_client,
@@ -816,12 +835,15 @@ async def test_find_chats_by_include_peers_uses_dialog_date_for_flags_entities()
             return include_entity
         return None
 
-    with patch(
-        "src.tools.chat_discovery.include_peers._filter_matches_flags",
-        side_effect=lambda e, d, f: getattr(e, "id", None) == flags_id,
-    ), patch(
-        "src.tools.chat_discovery.include_peers.GetPeerDialogsRequest"
-    ) as mock_gpd:
+    with (
+        patch(
+            "src.tools.chat_discovery.include_peers._filter_matches_flags",
+            side_effect=lambda e, d, f: getattr(e, "id", None) == flags_id,
+        ),
+        patch(
+            "src.tools.chat_discovery.include_peers.GetPeerDialogsRequest"
+        ) as mock_gpd,
+    ):
         mock_client = AsyncMock()
         mock_client.iter_dialogs = mock_iter_dialogs
         mock_client.get_entity = mock_get_entity
@@ -858,8 +880,7 @@ async def test_find_chats_by_include_peers_uses_dialog_date_for_flags_entities()
     # Flags entity should be present with last_activity_date from dialog.date
     flags_result = [c for c in chats if c["id"] == flags_id]
     assert len(flags_result) == 1, (
-        f"Flags entity (id={flags_id}) should be in results. "
-        f"Got chats: {chats}"
+        f"Flags entity (id={flags_id}) should be in results. Got chats: {chats}"
     )
     assert flags_result[0]["last_activity_date"] is not None
     assert "2024-06-15" in flags_result[0]["last_activity_date"], (
@@ -880,8 +901,7 @@ async def test_find_chats_by_include_peers_uses_dialog_date_for_flags_entities()
     # Include entity should also be present with activity from GetPeerDialogsRequest
     include_result = [c for c in chats if c["id"] == include_id]
     assert len(include_result) == 1, (
-        f"Include entity (id={include_id}) should be in results. "
-        f"Got chats: {chats}"
+        f"Include entity (id={include_id}) should be in results. Got chats: {chats}"
     )
     assert "2024-06-10" in include_result[0]["last_activity_date"], (
         f"Expected include entity last_activity from GetPeerDialogsRequest (2024-06-10), "


### PR DESCRIPTION
## Summary

When search/discovery tools find zero results, they now return a valid success response with an empty collection and an informational `note` field, instead of an error dict with `ok: false`.

## Affected tools

| Tool | Before | After |
|------|--------|-------|
| get_messages (search/browse) | ok: false, error: No messages... | {messages: [], has_more: false, note: ...} |
| get_messages (replies) | ok: false, error: No replies... | {messages: [], has_more: false, reply_to_id: N, note: ...} |
| search_contacts (raw data layer) | ok: false, error: No contacts... | [] |
| find_chats (global multi-term) | ok: false, error: No contacts... | {chats: [], note: ...} |
| find_chats (dialog-based) | ok: false, error: No chats... | {chats: [], note: ...} |

## ADR

ADR 0012: Empty Result Consistency (docs/adr/0012-empty-result-consistency.md)

## Testing

- pytest: 922 passed, 0 failed
- ruff check: clean on all changed files
- ruff format --check: clean on all changed files
- 2 tests updated for new response shape

## Notes

- Real errors (invalid params, chat not found, network failures, FloodWait) remain as errors -- unchanged
- CI/Sourcery GH App not configured for this repo -- local checks passed instead
- Pre-existing ruff warnings in search_mode.py (unused imports, import ordering, TimeoutError alias) -- not introduced by this change