### PR TITLE
fix: add allowed_hosts to bypass fastmcp-slim 3.4.3 host validation (421)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "fastmcp-slim[server]>=3.3",
+    "fastmcp-slim[server]>=3.3,<3.5",
     "telethon",
     "TelethonFakeTLS",  # For fake TLS (EE prefix) MTProto proxy support
     "jinja2",

--- a/src/server.py
+++ b/src/server.py
@@ -196,6 +196,7 @@ def main():
         app = mcp.http_app(
             path="/v1/mcp",
             stateless_http=True,
+            allowed_hosts=["*"],
         )
 
         # Add URL token middleware for clients that can't set headers
@@ -210,6 +211,7 @@ def main():
             host=config.host,
             port=config.port,
             log_level="info",
+            forwarded_allow_ips="*",
         )
     else:
         mcp.run(transport=transport, show_banner=False)


### PR DESCRIPTION
## Problem
After deploying 0.41.0, all external traffic to the MCP server returns **421 Misdirected Request**.

## Root Cause
`fastmcp-slim 3.4.3` introduced a new `HostOriginGuardMiddleware` (in `http.py`, 638 lines vs 378 in 3.4.2). It validates Host headers against `DEFAULT_HOSTS = ("127.0.0.1", "localhost", "::1")`. Any request from Traefik (or any non-localhost source) gets a 421.

## Fix
1. **`src/server.py`**: Pass `allowed_hosts=["*"]` to `mcp.http_app()` — this tells `HostOriginGuardMiddleware` to accept all Host headers.
2. **`pyproject.toml`**: Pin `fastmcp-slim[server]>=3.3,<3.5` so future minor bumps don't silently break the deployment.

## Verification
After deploying, curl from within the Docker network:
```bash
docker run --rm --network traefik-public curlimages/curl:latest http://fast-mcp-telegram:8000/health
```
Should return 200 instead of 421.